### PR TITLE
Rhel7 needs systemd-devel to produce rpm for systemd devices

### DIFF
--- a/ci_build_images/rhel7.Dockerfile
+++ b/ci_build_images/rhel7.Dockerfile
@@ -32,6 +32,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     python3-pip \
     scons \
     snappy-devel \
+    systemd-devel \
     wget \
     && if [ "$(arch)" = "ppc64le" ]; then \
         subscription-manager repos --enable rhel-7-for-power-le-optional-rpms; \


### PR DESCRIPTION
https://buildbot.mariadb.org/#/builders/438/builds/2