### PR TITLE
docker-library: MDEV-28628 fully merged

### DIFF
--- a/scripts/docker-library-build-and-test.sh
+++ b/scripts/docker-library-build-and-test.sh
@@ -58,17 +58,6 @@ case "${buildername#*ubuntu-}" in
     ;;
 esac
 
-# gradually exclude for other major version as
-# https://github.com/MariaDB/server/commit/c168e16782fc449f61412e5afc1c01d59b77c675
-# is merged up.
-case "$container_tag" in
-  10.[3456])
-    ;;
-  *)
-    pkgver=$base
-    ;;
-esac
-
 buildernamebase=${buildername#*-}
 builderarch=${buildername%%-*}
 


### PR DESCRIPTION
https://github.com/MariaDB/server/commit/c168e16782fc449f61412e5afc1c01d59b77c675 up to 10.10 now as evident on GH