### PR TITLE
Part Revert "docker-library: MDEV-28628 - fully merged" for 10.10 pre…

### DIFF
--- a/scripts/docker-library-build-and-test.sh
+++ b/scripts/docker-library-build-and-test.sh
@@ -58,6 +58,16 @@ case "${buildername#*ubuntu-}" in
     ;;
 esac
 
+# gradually exclude for other major version as
+# https://github.com/MariaDB/server/commit/c168e16782fc449f61412e5afc1c01d59b77c675
+# is merged up.
+case "$branch" in
+  preview-10.10*)
+    pkgver=$base
+    ;;
+  *) ;;
+esac
+
 buildernamebase=${buildername#*-}
 builderarch=${buildername%%-*}
 


### PR DESCRIPTION
…view

This reverts commit 6bf1067502175950353473710af4bb0938d467c0 and adjusts
the logic for 10.10 preview that hasn't included the change of package
name commit.

This is needed so I can trigger some preview container builds that still use the old versioning (e.g: https://buildbot.mariadb.org/#/builders/311/builds/9925)