### PR TITLE
RHEL9 bb worker generation

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -96,7 +96,7 @@ jobs:
             image: ubi8
             tag: rhel8
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-          - dockerfile: rhel8.Dockerfile
+          - dockerfile: rhel8.Dockerfile pip.Dockerfile
             image: ubi9
             tag: rhel9
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x

--- a/ci_build_images/pip.Dockerfile
+++ b/ci_build_images/pip.Dockerfile
@@ -11,21 +11,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs >/tmp/rustup-init.
         *) bash /tmp/rustup-init.sh -y --profile=minimal ;; \
     esac \
     && rm -f /tmp/rustup-init.sh \
-    # for Centos7/ppcle64, specific pip packages versions \
-    # and python3-devel are needed \
-    && if grep -q "CentOS Linux release 7" /etc/centos-release || \
-      grep -q "Red Hat Enterprise Linux Server release 7" /etc/redhat-release && \
-      [ "$(arch)" = "ppc64le" ]; then \
-        yum -y install python3-devel; \
-        yum clean all; \
-        pip3 install --no-cache-dir cffi==1.14.3 cryptography==3.1.1 pyOpenSSL==19.1.0 twisted[tls]==20.3.0 buildbot-worker==2.8.4; \
-    else \
-        pip3 install --no-cache-dir -U pip; \
-        curl -so /root/requirements.txt \
-        https://raw.githubusercontent.com/MariaDB/buildbot/main/ci_build_images/requirements.txt; \
-        # https://jira.mariadb.org/browse/MDBF-329 \
-        if grep -q "stretch" /etc/apt/sources.list; then \
-           pip3 install --no-cache-dir --no-warn-script-location incremental; \
-        fi; \
-        pip3 install --no-cache-dir --no-warn-script-location -r /root/requirements.txt; \
-    fi
+    && source "$HOME/.cargo/env" \
+    && pip3 install --no-cache-dir -U pip \
+    && curl -so /root/requirements.txt \
+       https://raw.githubusercontent.com/MariaDB/buildbot/main/ci_build_images/requirements.txt \
+    && pip3 install --no-cache-dir --no-warn-script-location -r /root/requirements.txt


### PR DESCRIPTION
Now passing build per https://github.com/MariaDB/buildbot/actions/runs/2667561514

Changes to account for rhel9 including using pip again as buildbot-worker.

Removed centos7 ppc64le code, and stretch code (EOL).

Without '&& source "$HOME/.cargo/env"" the s390x hasn't finding the rustc compiler.

Add fmt as its of sufficient verison in rhel9 to support the 10.7 dependency.