### PR TITLE
Build both master and master-web images

### DIFF
--- a/.github/workflows/bbm_build_container.yml
+++ b/.github/workflows/bbm_build_container.yml
@@ -30,16 +30,27 @@ jobs:
         run: |
           # //TEMP there is probably a better way to not include context
           mkdir empty
-      - name: Build image
+      - name: Build master image
         uses: docker/build-push-action@v2
         with:
           context: /home/runner/work/buildbot/buildbot/empty
           file: /home/runner/work/buildbot/buildbot/Dockerfile
           push: true
-          tags: localhost:5000/test/bb-master:latest
-      - name: Check container
+          tags: localhost:5000/test/bb-master:master
+      - name: Build master-web image
+        uses: docker/build-push-action@v2
+        with:
+          context: /home/runner/work/buildbot/buildbot/empty
+          build-args: |
+            master_type=master-web
+          file: /home/runner/work/buildbot/buildbot/Dockerfile
+          push: true
+          tags: localhost:5000/test/bb-master:master-web
+      - name: Check images
         run: |
-          docker run -i localhost:5000/test/bb-master:latest buildbot --version
+          docker run -i localhost:5000/test/bb-master:master buildbot --version
+          #//TEMP there is probably a better way for master-web here
+          docker run -i localhost:5000/test/bb-master:master-web buildbot --version
       - name: Check for registry credentials
         if: >
           github.ref == 'refs/heads/main' &&
@@ -66,9 +77,11 @@ jobs:
       - name: Push images to registry
         if: ${{ env.DEPLOY_IMAGES == 'true' }}
         run: |
-          msg="Push docker image to registry"
+          msg="Push docker images to registry"
           line="${msg//?/=}"
           printf "\n${line}\n${msg}\n${line}\n"
-          skopeo copy --all --src-tls-verify=0 \
-          docker://localhost:5000/test/bb-master:latest \
-          docker://quay.io/mariadb-foundation/bb-master:latest
+          for image in master master-web
+            skopeo copy --all --src-tls-verify=0 \
+            docker://localhost:5000/test/bb-master:${image} \
+            docker://quay.io/mariadb-foundation/bb-master:${image}
+          done

--- a/.github/workflows/bbm_check_conf.yml
+++ b/.github/workflows/bbm_check_conf.yml
@@ -40,12 +40,12 @@ jobs:
         run: |
           ln -s master-private.cfg-sample master-private.cfg
           echo "Checking master.cfg"
-          docker run -i -v $(pwd):/srv/buildbot/master -w /srv/buildbot/master quay.io/mariadb-foundation/bb-master:latest buildbot checkconfig master.cfg
+          docker run -i -v $(pwd):/srv/buildbot/master -w /srv/buildbot/master quay.io/mariadb-foundation/bb-master:master buildbot checkconfig master.cfg
           echo -e "done\n"
           # not checking libvirt config file (//TEMP we need to find a solution
           # to not check ssh connection)
           for dir in master-galera master-nonlatent master-web master-protected-branches; do
             echo "Checking $dir/master.cfg"
-            docker run -i -v $(pwd):/srv/buildbot/master -w /srv/buildbot/master quay.io/mariadb-foundation/bb-master:latest bash -c "cd $dir && buildbot checkconfig master.cfg"
+            docker run -i -v $(pwd):/srv/buildbot/master -w /srv/buildbot/master quay.io/mariadb-foundation/bb-master:master bash -c "cd $dir && buildbot checkconfig master.cfg"
             echo -e "done\n"
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # Buildbot master container
-# todo:
-#   - use multiple containers to build (save space)
-#   - create bbm and bbm-web containers on quay.io
+# FROM debian:11 AS builder
 
-FROM debian:11 AS builder
+# TODO, use dive to do some cleaning!
+FROM debian:11-slim
 LABEL maintainer="MariaDB Buildbot maintainers"
 ARG DEBIAN_FRONTEND=noninteractive
+ARG master_type="master"
 
 # Install required packages
-WORKDIR /root
+WORKDIR /opt/buildbot
+# hadolint ignore=DL3003
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get -y install --no-install-recommends \
@@ -16,24 +17,29 @@ RUN apt-get update \
       git \
       libmariadb-dev \
       libvirt-dev \
-      nodejs \
-      npm \
+      pkg-config \
+      python3 \
       python3-dev \
+      python3-distutils \
       python3-pip \
       python3-venv \
-      pkg-config \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm install --location=global yarn \
-    && export PATH="$HOME/node_modules/.bin:$PATH" \
-    && yarn global add gulp yo generator-buildbot-dashboard
-
-# Install buildbot fork (master-web)
-WORKDIR /opt
-RUN git clone --branch grid https://github.com/vladbogo/buildbot buildbot \
-    && python3 -m venv buildbot/.venv \
-    && . buildbot/.venv/bin/activate \
+    && if [ "$master_type" = "master-web" ]; then \
+      apt-get -y install --no-install-recommends \
+        libcairo2 \
+        yarnpkg; \
+    fi \
+    && if [ "$master_type" = "master-web" ]; then \
+      export PATH="/usr/share/nodejs/yarn/bin:$PATH"; \
+      yarn global add gulp yo generator-buildbot-dashboard; \
+    fi \
+    && git clone --branch grid https://github.com/vladbogo/buildbot . \
+    && python3 -m venv .venv \
+    && . .venv/bin/activate \
+    && if [ "$master_type" = "master-web" ]; then \
+      make frontend; \
+    fi \
     && pip install --no-cache-dir pip -U \
+    && pip install --no-cache-dir wheel \
     && pip install --no-cache-dir \
       buildbot-prometheus \
       buildbot-worker \
@@ -43,26 +49,26 @@ RUN git clone --branch grid https://github.com/vladbogo/buildbot buildbot \
       mock \
       mysqlclient \
       pyzabbix \
+      sqlalchemy==1.3.23 \
       treq \
-      wheel \
-    && pip install --no-cache-dir sqlalchemy==1.3.23
-
-WORKDIR /opt/buildbot/master
-RUN . /opt/buildbot/.venv/bin/activate \
-    && python setup.py bdist_wheel \
-    && pip install --no-cache-dir dist/*.whl
-
-# actual image, see https://docs.docker.com/develop/develop-images/multistage-build/
-FROM debian:11-slim
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get -y install --no-install-recommends \
-      libmariadb-dev \
-      python3 \
-      python3-distutils \
+    && cd master && python setup.py bdist_wheel \
+    && pip install --no-cache-dir dist/*.whl \
+    && if [ "$master_type" = "master-web" ]; then \
+      pip install --no-cache-dir pyjade; \
+    fi \
+    && ln -s /opt/buildbot/.venv/bin/buildbot /usr/local/bin/buildbot \
+    # cleaning \
+    && apt-get purge -y \
+      build-essential \
+      git \
+      pkg-config \
+      python3-dev \
+      python3-pip \
+      python3-venv \
+    && if [ "$master_type" = "master-web" ]; then \
+      apt-get purge -y yarnpkg; \
+      rm -rf "$(find /opt/buildbot -maxdepth 3 -name node_modules)"; \
+    fi \
+    && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder /opt/buildbot/.venv/ /opt/buildbot/.venv/
-RUN ln -s /opt/buildbot/.venv/bin/buildbot /usr/local/bin/buildbot


### PR DESCRIPTION
Rollback the multi-stage container build:
Copying the python virtual environment from the builder container to the final container is not a good approach since it's not guaranteed to work. That's why we prefer to install everything needed in the final container.