### PR TITLE
Move non standard builders to a separate master

### DIFF
--- a/.github/workflows/bbm_check_conf.yml
+++ b/.github/workflows/bbm_check_conf.yml
@@ -8,6 +8,7 @@ on:
       - "common_factories.py"
       - "constants.py"
       - "locks.py"
+      - "master-docker-nonstandard/master.cfg",
       - "master-galera/master.cfg"
       - "master-nonlatent/master.cfg"
       - "master-protected-branches/master.cfg"
@@ -44,7 +45,7 @@ jobs:
           echo -e "done\n"
           # not checking libvirt config file (//TEMP we need to find a solution
           # to not check ssh connection)
-          for dir in master-galera master-nonlatent master-web master-protected-branches; do
+          for dir in master-docker-nonstandard master-galera master-nonlatent master-web master-protected-branches; do
             echo "Checking $dir/master.cfg"
             docker run -i -v $(pwd):/srv/buildbot/master -w /srv/buildbot/master quay.io/mariadb-foundation/bb-master:master bash -c "cd $dir && buildbot checkconfig master.cfg"
             echo -e "done\n"

--- a/master-docker-nonstandard/buildbot.tac
+++ b/master-docker-nonstandard/buildbot.tac
@@ -1,0 +1,33 @@
+import os
+
+from twisted.application import service
+from buildbot.master import BuildMaster
+
+basedir = '.'
+log_basedir = '/var/log/buildbot/'
+
+rotateLength = 20000000
+maxRotatedFiles = 30
+configfile = 'master.cfg'
+
+# Default umask for server
+umask = None
+
+# if this is a relocatable tac file, get the directory containing the TAC
+if basedir == '.':
+    import os
+    basedir = os.path.abspath(os.path.dirname(__file__))
+
+# note: this line is matched against to check that this is a buildmaster
+# directory; do not edit it.
+application = service.Application('buildmaster')
+from twisted.python.logfile import LogFile
+from twisted.python.log import ILogObserver, FileLogObserver
+logfile = LogFile.fromFullPath(os.path.join(log_basedir, "master-docker-non-standard.log"), rotateLength=rotateLength,
+                                maxRotatedFiles=maxRotatedFiles)
+application.setComponent(ILogObserver, FileLogObserver(logfile).emit)
+
+m = BuildMaster(basedir, configfile, umask)
+m.setServiceParent(application)
+m.log_rotation.rotateLength = rotateLength
+m.log_rotation.maxRotatedFiles = maxRotatedFiles

--- a/master-docker-nonstandard/dockerfiles
+++ b/master-docker-nonstandard/dockerfiles
@@ -1,0 +1,1 @@
+../dockerfiles

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -1,0 +1,564 @@
+# -*- python -*-
+# ex: set filetype=python:
+
+from buildbot.plugins import *
+from buildbot.process.properties import Property, Properties
+from buildbot.steps.shell import ShellCommand, Compile, Test, SetPropertyFromCommand
+from buildbot.steps.mtrlogobserver import MTR, MtrLogObserver
+from buildbot.steps.source.github import GitHub
+from buildbot.process.remotecommand import RemoteCommand
+from twisted.internet import defer
+import sys
+import docker
+from datetime import timedelta
+
+sys.path.insert(0, '/srv/buildbot/master')
+sys.setrecursionlimit(10000)
+
+from common_factories import *
+from constants import *
+from locks import *
+from schedulers_definition import *
+from utils import *
+
+# This is the dictionary that the buildmaster pays attention to. We also use
+# a shorter alias to save typing.
+c = BuildmasterConfig = {}
+
+# Load the slave, database passwords and 3rd-party tokens from an external private file, so
+# that the rest of the configuration can be public.
+config = { "private": { } }
+exec(open("../master-private.cfg").read(), config, { })
+
+####### BUILDBOT SERVICES
+
+# 'services' is a list of BuildbotService items like reporter targets. The
+# status of each build will be pushed to these targets. buildbot/reporters/*.py
+# has a variety to choose from, like IRC bots.
+
+
+c['services'] = []
+context = util.Interpolate("buildbot/%(prop:buildername)s")
+gs = reporters.GitHubStatusPush(token=config["private"]["gh_mdbci"]["access_token"],
+                                context=context,
+                                startDescription='Build started.',
+                                endDescription='Build done.',
+                                verbose=True,
+                                builders=github_status_builders)
+c['services'].append(gs)
+
+####### PROJECT IDENTITY
+
+# the 'title' string will appear at the top of this buildbot installation's
+# home pages (linked to the 'titleURL').
+c['title'] = "MariaDB CI"
+c['titleURL'] = "https://github.com/MariaDB/server"
+
+# the 'buildbotURL' string should point to the location where the buildbot's
+# internal web server is visible. This typically uses the port number set in
+# the 'www' entry below, but with an externally-visible host name which the
+# buildbot cannot figure out without some help.
+
+c['buildbotURL'] = "https://buildbot.mariadb.org/"
+
+# 'protocols' contains information about protocols which master will use for
+# communicating with workers. You must define at least 'port' option that workers
+# could connect to your master with this protocol.
+# 'port' must match the value configured into the workers (with their
+# --master option)
+c['protocols'] = {'pb': {'port': 9995}}
+
+####### DB URL
+
+c['db'] = {
+    # This specifies what database buildbot uses to store its state.
+    'db_url' : config["private"]["db_url"]
+}
+
+mtrDbPool = util.EqConnectionPool("MySQLdb", config["private"]["db_host"], config["private"]["db_user"], config["private"]["db_password"], config["private"]["db_mtr_db"])
+
+####### Disable net usage reports from being sent to buildbot.net
+c['buildbotNetUsageData'] = None
+
+####### SCHEDULERS
+
+# Configure the Schedulers, which decide how to react to incoming changes.
+c['schedulers'] = getSchedulers()
+
+####### WORKERS
+
+# The 'workers' list defines the set of recognized workers. Each element is
+# a Worker object, specifying a unique worker name and password.  The same
+# worker name and password must be configured on the worker.
+c['workers'] = []
+
+workers = {}
+def addWorker(worker_name_prefix, worker_id, worker_type, dockerfile, jobs=5, save_packages=False, shm_size='15G'):
+    name, instance = createWorker(
+            worker_name_prefix,
+            worker_id,
+            worker_type,
+            dockerfile,
+            jobs,
+            save_packages,
+            shm_size,
+            )
+
+    if name[0] not in workers:
+        workers[name[0]] = [name[1]]
+    else:
+        workers[name[0]].append(name[1])
+ 
+    c['workers'].append(instance)
+
+# Docker workers
+
+## hz-bbw2-docker
+c['workers'].append(worker.DockerLatentWorker("hz-bbw2-docker-eco-php-ubuntu-2004", None,
+                    docker_host=config["private"]["docker_workers"]["hz-bbw2-docker"],
+                    dockerfile=open("dockerfiles/eco-php-ubuntu-2004.dockerfile").read(),
+                    followStartupLogs=False,
+                    masterFQDN='buildbot.mariadb.org',
+                    hostconfig={ 'shm_size':'6G' },
+                    build_wait_timeout=0,
+                    max_builds=1,
+                    volumes=['/srv/buildbot/eco/code:/code', '/srv/buildbot/eco/build:/build'],
+                    properties={ 'jobs':7, 'save_packages':False }))
+
+c['workers'].append(worker.DockerLatentWorker("hz-bbw2-docker-eco-dbdeployer-ubuntu-2004", None,
+                    docker_host=config["private"]["docker_workers"]["hz-bbw2-docker"],
+                    dockerfile=open("dockerfiles/eco-dbdeployer-ubuntu-2004.dockerfile").read(),
+                    followStartupLogs=False,
+                    masterFQDN='buildbot.mariadb.org',
+                    hostconfig={ 'shm_size':'6G' },
+                    build_wait_timeout=0,
+                    max_builds=1,
+                    volumes=['/srv/buildbot/eco/dbdeployer:/dbdeployer'],
+                    properties={ 'jobs':7, 'save_packages':False }))
+
+c['workers'].append(worker.DockerLatentWorker("hz-bbw2-docker-eco-pymysql-python-3-9-slim-buster", None,
+                    docker_host=config["private"]["docker_workers"]["hz-bbw2-docker"],
+                    dockerfile=open("dockerfiles/eco-pymysql-python-3-9-slim-buster.dockerfile").read(),
+                    followStartupLogs=False,
+                    masterFQDN='buildbot.mariadb.org',
+                    hostconfig={ 'shm_size':'6G' },
+                    build_wait_timeout=0,
+                    max_builds=1,
+                    volumes=['/srv/buildbot/eco/pymysqlcode:/code'],
+                    properties={ 'jobs':7, 'save_packages':False }))
+
+c['workers'].append(worker.DockerLatentWorker("hz-bbw2-docker-eco-mysqljs-nodejs15-buster", None,
+                    docker_host=config["private"]["docker_workers"]["hz-bbw2-docker"],
+                    dockerfile=open("dockerfiles/eco-mysqljs-nodejs15-buster.dockerfile").read(),
+                    followStartupLogs=False,
+                    masterFQDN='buildbot.mariadb.org',
+                    hostconfig={ 'shm_size':'6G' },
+                    build_wait_timeout=0,
+                    max_builds=1,
+                    volumes=['/srv/buildbot/eco/mysqljscode:/code'],
+                    properties={ 'jobs':7, 'save_packages':False }))
+
+## apexis-bbw1-docker
+c['workers'].append(worker.DockerLatentWorker("fjord1-docker-ubuntu-1804", None,
+                    docker_host=config["private"]["docker_workers"]["apexis-bbw1-docker"],
+                    dockerfile=open("dockerfiles/clang-ubuntu-1804.dockerfile").read(),
+                    followStartupLogs=False,
+                    masterFQDN='buildbot.mariadb.org',
+                    hostconfig={ 'shm_size':'6G' },
+                    max_builds=1,
+                    volumes=['/opt/mariadb-buildbot/ccache:/mnt/ccache', '/opt/mariadb-buildbot/packages:/mnt/packages'],
+                    properties={ 'jobs':7, 'save_packages':False }))
+
+c['workers'].append(worker.DockerLatentWorker("fjord2-docker-ubuntu-1804", None,
+                    docker_host=config["private"]["docker_workers"]["apexis-bbw2-docker"],
+                    dockerfile=open("dockerfiles/clang-ubuntu-1804.dockerfile").read(),
+                    followStartupLogs=False,
+                    masterFQDN='buildbot.mariadb.org',
+                    hostconfig={ 'shm_size':'6G' },
+                    max_builds=1,
+                    volumes=['/opt/mariadb-buildbot/ccache:/mnt/ccache', '/opt/mariadb-buildbot/packages:/mnt/packages'],
+                    properties={ 'jobs':7, 'save_packages':False }))
+
+## bm-bbw1-docker
+c['workers'].append(worker.DockerLatentWorker("bm-bbw1-docker-ubuntu-1804", None,
+                    docker_host=config["private"]["docker_workers"]["bm-bbw1-docker"],
+                    image="quay.io/mariadb-foundation/bb-worker:ubuntu18.04",
+                    followStartupLogs=False,
+                    autopull=True,
+                    alwaysPull=True,
+                    masterFQDN='buildbot.mariadb.org',
+                    hostconfig={ 'shm_size':'20G' },
+                    max_builds=1,
+                    volumes=['/srv/buildbot/ccache:/mnt/ccache', '/mnt/autofs/master_packages:/packages'],
+                    properties={ 'jobs': 2, 'save_packages':False }))
+
+
+## Add Power workers
+for w_name in ['p9-rhel7-bbw']:
+    jobs = 7
+    addWorker(w_name, 1, '-ubuntu-1804', 'quay.io/mariadb-foundation/bb-worker:ubuntu18.04', jobs=jobs, save_packages=True, shm_size='20G')
+    addWorker(w_name, 1, '-clang-ubuntu-2004', 'vladbogo/bb:ppc64le-ubuntu-2004-clang1x',jobs=jobs, save_packages=True, shm_size='20G')
+
+## bg-bbw-docker
+for i in range(1,5):
+    jobs = 7
+    addWorker('bg-bbw', i, '-clang-ubuntu-1804', "clang-ubuntu-1804.dockerfile", jobs=jobs, save_packages=False)
+    addWorker('bg-bbw', i, '-icc-ubuntu-1804', "vladbogo/bb:icc-ubuntu-1804", jobs=jobs, save_packages=False)
+    addWorker('bg-bbw', i, '-msan-clang-ubuntu-2004', "vladbogo/bb:msan-ubuntu-2004-clang-12", jobs=jobs, save_packages=False)
+    addWorker('bg-bbw', i, '-ubuntu-2004', 'quay.io/mariadb-foundation/bb-worker:ubuntu20.04', jobs=jobs, save_packages=True)
+    addWorker('bg-bbw', i, '-valgrind-ubuntu-1804', "valgrind-ubuntu-1804.dockerfile", jobs=jobs, save_packages=False)
+
+####### FACTORY CODE
+
+f_quick_build = getQuickBuildFactory(mtrDbPool)
+f_rpm_autobake = getRpmAutobakeFactory(mtrDbPool)
+
+## f_asan_build
+f_asan_build = util.BuildFactory()
+f_asan_build.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
+f_asan_build.addStep(downloadSourceTarball())
+f_asan_build.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
+f_asan_build.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
+# build steps
+f_asan_build.addStep(steps.ShellCommand(command='echo "leak:libtasn1\nleak:libgnutls\nleak:libgmp" > mysql-test/lsan.supp', doStepIf=filterBranch))
+f_asan_build.addStep(steps.ShellCommand(command='cat mysql-test/lsan.supp', doStepIf=filterBranch))
+f_asan_build.addStep(steps.Compile(command=
+    ["sh", "-c", util.Interpolate('cmake . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-O2 -msse4.2 -Wno-unused-command-line-argument -fdebug-macro -Wno-inconsistent-missing-override" -DCMAKE_CXX_FLAGS="-O2 -msse4.2 -Wno-unused-command-line-argument -fdebug-macro -Wno-inconsistent-missing-override" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DWITH_ASAN=YES -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF -DWITH_ZLIB=bundled -DWITH_SSL=bundled -DWITH_PCRE=system && make -j%(kw:jobs)s package', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], haltOnFailure="true"))
+f_asan_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
+    ["sh", "-c", util.Interpolate('cd mysql-test && MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=`pwd`/lsan.supp" perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
+f_asan_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
+f_asan_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
+f_asan_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
+
+## f_msan_build
+f_msan_build = util.BuildFactory()
+f_msan_build.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
+f_msan_build.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
+f_msan_build.addStep(downloadSourceTarball())
+f_msan_build.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
+# build steps
+f_msan_build.addStep(steps.ShellCommand(command='ls /msan-libs'))
+f_msan_build.addStep(steps.Compile(command=
+    ["bash", "-xc", util.Interpolate('cmake . -DCMAKE_{C_COMPILER=clang,CXX_COMPILER=clang++}-12 -DCMAKE_C_FLAGS="-O2 -Wno-unused-command-line-argument -fdebug-macro" -DCMAKE_CXX_FLAGS="-stdlib=libc++ -O2 -Wno-unused-command-line-argument -fdebug-macro" -DWITH_EMBEDDED_SERVER=OFF -DWITH_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DWITH_INNODB_{BZIP2,LZ4,LZMA,LZO,SNAPPY}=OFF -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER}=NO -DWITH_SAFEMALLOC=OFF -DWITH_{ZLIB,SSL,PCRE}=bundled -DHAVE_LIBAIO_H=0 -DCMAKE_DISABLE_FIND_PACKAGE_{URING,LIBAIO}=1 -DWITH_MSAN=ON && make -j%(kw:jobs)s package', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], haltOnFailure="true"))
+f_msan_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
+    ["bash", "-xc", util.Interpolate('cd mysql-test && LD_LIBRARY_PATH=/msan-libs MSAN_OPTIONS=abort_on_error=1 ./mtr --mem --big-test --force --retry=0 --skip-test=.*compression.* --max-test-fail=100 --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
+f_msan_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
+f_msan_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
+f_msan_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
+
+## f_valgrind_build
+f_valgrind_build = util.BuildFactory()
+f_valgrind_build.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
+f_valgrind_build.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
+f_valgrind_build.addStep(downloadSourceTarball())
+f_valgrind_build.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
+# build steps
+f_valgrind_build.addStep(steps.Compile(command=
+    ["sh", "-c", util.Interpolate('cmake . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DENABLE_ASSEMBLER=1 -DWITH_EXTRA_CHARSETS=complex -DENABLE_THREAD_SAFE_CLIENT=1 -DWITH_BIG_TABLES=1 -DWITH_PLUGIN_ARIA=1 -DWITH_ARIA_TMP_TABLES=1 -DWITH_JEMALLOC=NO -DCMAKE_BUILD_TYPE=Debug -DSECURITY_HARDENED=OFF -DWITH_VALGRIND=1 -DWITH_SSL=bundled -DWITH_MAX=AUTO -DWITH_EMBEDDED_SERVER=1 -DWITH_LIBEVENT=bundled -DPLUGIN_PLUGIN_FILE_KEY_MANAGEMENT=NO -DPLUGIN_ROCKSDB=DYNAMIC -DPLUGIN_TEST_SQL_DISCOVERY=DYNAMIC -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DENABLE_LOCAL_INFILE=1 && make -j%(kw:jobs)s package', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], haltOnFailure="true"))
+f_valgrind_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
+    ["sh", "-c", util.Interpolate('cd mysql-test && perl mysql-test-run.pl --valgrind="--leak-check=summary --gen-suppressions=yes --num-callers=10" --skip-test=encryption*  --force --retry=0 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
+f_valgrind_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
+f_valgrind_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
+f_valgrind_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
+
+## f_big_test
+f_big_test = util.BuildFactory()
+f_big_test.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
+f_big_test.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
+# get the source tarball and extract it
+f_big_test.addStep(steps.FileDownload(mastersrc=util.Interpolate("/srv/buildbot/packages/" + "%(prop:tarbuildnum)s" + "/" + "%(prop:mariadb_version)s" + ".tar.gz"),
+    workerdest=util.Interpolate("%(prop:mariadb_version)s" + ".tar.gz")))
+f_big_test.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf " + "%(prop:mariadb_version)s" + ".tar.gz --strip-components=1")))
+# build steps
+f_big_test.addStep(steps.Compile(command=
+    ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPLUGIN_ROCKSDB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_SPHINX=NO && make -j%(kw:jobs)s VERBOSE=1 package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], env={'CCACHE_DIR':'/mnt/ccache'}))
+f_big_test.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
+    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --big --big --mem --parallel=$(expr %(kw:jobs)s \* 2) --skip-test=archive.archive-big", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
+f_big_test.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
+f_big_test.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
+# create package and upload to master
+f_big_test.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary"))
+#f_big_test.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
+f_big_test.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
+
+## f_full_test
+f_full_test = util.BuildFactory()
+f_full_test.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
+# get the source tarball and extract it
+f_full_test.addStep(steps.FileDownload(mastersrc=util.Interpolate("/srv/buildbot/packages/" + "%(prop:tarbuildnum)s" + "/" + "%(prop:mariadb_version)s" + ".tar.gz"),
+    workerdest=util.Interpolate("%(prop:mariadb_version)s" + ".tar.gz")))
+f_full_test.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf " + "%(prop:mariadb_version)s" + ".tar.gz --strip-components=1")))
+# build steps
+f_full_test.addStep(steps.Compile(command=
+    ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DBUILD_CONFIG=mysql_release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DWITH_SSL=system -DWITH_JEMALLOC=auto -DWITH_EMBEDDED_SERVER=1 -DHAVE_EMBEDDED_PRIVILEGE_CONTROL=1 -DWITH_LIBARCHIVE=ON -Wno-dev && make -j%(kw:jobs)s VERBOSE=1 package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], env={'CCACHE_DIR':'/mnt/ccache'}))
+f_full_test.addStep(steps.MTR(addLogs=True, name="test emb", command=
+    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --embedded-server --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
+f_full_test.addStep(steps.MTR(addLogs=True, name="test n", command=
+    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
+f_full_test.addStep(steps.MTR(addLogs=True, name="test p", command=
+    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --ps-protocol --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
+f_full_test.addStep(steps.MTR(addLogs=True, name="test ps-embedded", command=
+    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --ps --embedded --mem --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
+f_full_test.addStep(steps.MTR(addLogs=True, name="test xtra", command=
+    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --suite=funcs_1,funcs_2,stress,jp --big --testcase-timeout=8 --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
+f_full_test.addStep(steps.MTR(addLogs=True, name="test engines", command=
+    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --suite=spider,spider/bg,engines/funcs,engines/iuds --big --testcase-timeout=8 --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
+f_full_test.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
+
+## f_without_server
+f_without_server = util.BuildFactory()
+f_without_server.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
+f_without_server.addStep(steps.ShellCommand(command="ls -la"))
+f_without_server.addStep(downloadSourceTarball())
+f_without_server.addStep(steps.ShellCommand(command="ls -la"))
+f_without_server.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
+f_without_server.addStep(steps.ShellCommand(command="ls -la"))
+# build steps
+f_without_server.addStep(steps.Compile(command=
+    ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DWITHOUT_SERVER=1 && make -j%(kw:jobs)s package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'), c_compiler=util.Property('c_compiler', default='gcc'), cxx_compiler=util.Property('cxx_compiler', default='g++'))], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
+#    ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && mkdir -p ../builddir && cd ../builddir && cmake ${OLDPWD} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DWITHOUT_SERVER=ON && cmake --build . --parallel %(kw:jobs)s --target package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'), c_compiler=util.Property('c_compiler', default='gcc'), cxx_compiler=util.Property('cxx_compiler', default='g++'))], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
+# create package and upload to master
+f_without_server.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary"))
+#f_without_server.addStep(steps.FileUpload(workersrc=util.Interpolate("%(prop:mariadb_binary)s"), masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + "/" + '%(prop:buildername)s' + "/" + "%(prop:mariadb_binary)s"), mode=0o755, url=util.Interpolate('https://ci.mariadb.org/' + "%(prop:tarbuildnum)s" + "/" + '%(prop:buildername)s' + "/"), urlText="Download", doStepIf=savePackage))
+f_without_server.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
+f_without_server.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
+
+## f_eco_php
+f_eco_php = util.BuildFactory()
+f_eco_php.addStep(steps.ShellCommand(
+    name="fetch_install_script",
+    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/installdb.sh -o /buildbot/installdb.sh && chmod a+x /buildbot/installdb.sh"]))
+f_eco_php.addStep(steps.ShellCommand(
+    name="fetch_test_script",
+    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-php.sh -o /buildbot/test-php.sh && chmod a+x /buildbot/test-php.sh"]))
+f_eco_php.addStep(steps.ShellCommand(
+    name="fetching and installing database",
+    command=["sh", "-xc", util.Interpolate("/buildbot/installdb.sh \"https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s\" --plugin-load-add=auth_pam --pam_use_cleartext_plugin")]))
+f_eco_php.addStep(steps.ShellCommand(
+    name="test PHP-7.1",
+    command=["sh", "-xc", "/buildbot/test-php.sh PHP-7.1"]))
+f_eco_php.addStep(steps.ShellCommand(
+    name="test PHP-8.0",
+    command=["sh", "-xc", "/buildbot/test-php.sh PHP-8.0"]))
+f_eco_php.addStep(steps.ShellCommand(
+    name="test PHP-8.1",
+    command=["sh", "-xc", "/buildbot/test-php.sh PHP-8.1"]))
+f_eco_php.addStep(steps.ShellCommand(
+    name="test master",
+    command=["sh", "-xc", "/buildbot/test-php.sh"]))
+
+## f_eco_dbdeployer
+f_eco_dbdeployer = util.BuildFactory()
+f_eco_dbdeployer.addStep(steps.ShellCommand(
+    name="fetch_test_script",
+    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-dbdeployer.sh -o /buildbot/test-dbdeployer.sh && chmod a+x /buildbot/test-dbdeployer.sh"]))
+f_eco_dbdeployer.addStep(steps.ShellCommand(
+    name="download if needed latest dbdeployer",
+    command=["sh", "-xc", "/buildbot/test-dbdeployer.sh dbdeployerfetch"]))
+f_eco_dbdeployer.addStep(steps.ShellCommand(
+    name="fetching mariadb tarball",
+    command=["sh", "-xc", util.Interpolate("/buildbot/test-dbdeployer.sh init \"https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s\"")]))
+f_eco_dbdeployer.addStep(steps.ShellCommand(
+    name="deploy single ma",
+    command=["sh", "-xc", util.Interpolate("/buildbot/test-dbdeployer.sh deploy single ma%(prop:mariadb_version)s")]))
+f_eco_dbdeployer.addStep(steps.ShellCommand(
+    name="deploy replication ma",
+    command=["sh", "-xc", util.Interpolate("/buildbot/test-dbdeployer.sh deploy replication ma%(prop:mariadb_version)s")]))
+f_eco_dbdeployer.addStep(steps.ShellCommand(
+    name="global test",
+    command=["sh", "-xc", "/buildbot/test-dbdeployer.sh global test"]))
+f_eco_dbdeployer.addStep(steps.ShellCommand(
+    name="global replication",
+    command=["sh", "-xc", "/buildbot/test-dbdeployer.sh global test-replication"]))
+
+## f_eco_pymysql
+f_eco_pymysql = util.BuildFactory()
+f_eco_pymysql.addStep(steps.ShellCommand(
+    name="fetch_install_script",
+    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/installdb.sh -o /buildbot/installdb.sh && chmod a+x /buildbot/installdb.sh"]))
+f_eco_pymysql.addStep(steps.ShellCommand(
+    name="fetch_test_script",
+    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-pymysql.sh -o /buildbot/test-pymysql.sh && chmod a+x /buildbot/test-pymysql.sh"]))
+f_eco_pymysql.addStep(steps.ShellCommand(
+    name="fetching and installing database",
+    command=["sh", "-xc", util.Interpolate("/buildbot/installdb.sh \"https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s\"")]))
+f_eco_pymysql.addStep(steps.ShellCommand(
+    name="test pymysql-main",
+    command=["sh", "-xc", "/buildbot/test-pymysql.sh"]))
+f_eco_pymysql.addStep(steps.ShellCommand(
+    name="test pymysql-v0.7.11",
+    command=["sh", "-xc", "/buildbot/test-pymysql.sh v0.7.11"]))
+
+## f_eco_mysqljs
+f_eco_mysqljs = util.BuildFactory()
+f_eco_mysqljs.addStep(steps.ShellCommand(
+    name="fetch_install_script",
+    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/installdb.sh -o /buildbot/installdb.sh && chmod a+x /buildbot/installdb.sh"]))
+f_eco_mysqljs.addStep(steps.ShellCommand(
+    name="fetch_test_script",
+    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-mysqljs.sh -o /buildbot/test-mysqljs.sh && chmod a+x /buildbot/test-mysqljs.sh"]))
+f_eco_mysqljs.addStep(steps.ShellCommand(
+    name="fetching and installing database",
+    command=["sh", "-xc", util.Interpolate("/buildbot/installdb.sh \"https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s\"")]))
+f_eco_mysqljs.addStep(steps.ShellCommand(
+    name="test mysqljs-master",
+    command=["sh", "-xc", "/buildbot/test-mysqljs.sh"]))
+f_eco_mysqljs.addStep(steps.ShellCommand(
+    name="test mysqljs-v2.18.1",
+    command=["sh", "-xc", "/buildbot/test-mysqljs.sh v2.18.1"]))
+
+####### BUILDERS LIST
+
+c['builders'] = []
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-ubuntu-1804-icc",
+      workernames=workers["bg-bbw-docker-icc-ubuntu-1804"],
+      tags=["Ubuntu", "quick", "icc", "icpc"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      locks=getLocks,
+      properties={'c_compiler': 'icc', 'cxx_compiler': 'icpc'},
+      factory=f_quick_build))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-ubuntu-2004-eco-php",
+      workernames=["hz-bbw2-docker-eco-php-ubuntu-2004"],
+      tags=["Ubuntu", "ecosystem", "PHP"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      factory=f_eco_php))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-ubuntu-2004-eco-dbdeployer",
+      workernames=["hz-bbw2-docker-eco-dbdeployer-ubuntu-2004"],
+      tags=["Ubuntu", "ecosystem", "dbdeployer"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      factory=f_eco_dbdeployer))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-debian-10-eco-pymysql",
+      workernames=["hz-bbw2-docker-eco-pymysql-python-3-9-slim-buster"],
+      tags=["Debian", "ecosystem", "pymysql"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      factory=f_eco_pymysql))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-debian-10-eco-mysqljs",
+      workernames=["hz-bbw2-docker-eco-mysqljs-nodejs15-buster"],
+      tags=["Debian", "ecosystem", "mysqljs"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      factory=f_eco_mysqljs))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-ubuntu-1804-bigtest",
+      workernames=["bm-bbw1-docker-ubuntu-1804"],
+      tags=["Ubuntu", "big", "gcc"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      factory=f_big_test))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-ubuntu-2004-fulltest",
+      workernames=workers["bg-bbw-docker-ubuntu-2004"],
+      tags=["Ubuntu", "full", "gcc"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      locks=getLocks,
+      factory=f_full_test))
+
+c['builders'].append(
+    util.BuilderConfig(name="ppc64le-ubuntu-1804-without-server",
+      workernames=workers["p9-bbw-docker-ubuntu-1804"],
+      tags=["Ubuntu", "without-server", "gcc", "pc9"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      locks=getLocks,
+      factory=f_without_server))
+
+c['builders'].append(
+    util.BuilderConfig(name="ppc64le-ubuntu-2004-clang1x",
+      workernames=workers["p9-bbw-docker-clang-ubuntu-2004"],
+      tags=["Ubuntu", "quick", "clang-10", "pc9"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      locks=getLocks,
+      properties={'c_compiler': 'clang-10', 'cxx_compiler': 'clang++-10', 'additional_args': '-DWITHOUT_ROCKSDB=True -DWITHOUT_CONNECT=True -DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override'},
+      factory=f_quick_build))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-ubuntu-1804-clang6",
+      workernames=["fjord1-docker-ubuntu-1804"] + workers["bg-bbw-docker-clang-ubuntu-1804"],
+      tags=["Ubuntu", "quick", "clang-6"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      locks=getLocks,
+      properties={'c_compiler': 'clang-6.0', 'cxx_compiler': 'clang++-6.0', 'additional_args': '-DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override'},
+      factory=f_quick_build))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-ubuntu-1804-clang10",
+      workernames=["fjord2-docker-ubuntu-1804"] + workers["bg-bbw-docker-clang-ubuntu-1804"],
+      tags=["Ubuntu", "quick", "clang-10"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      locks=getLocks,
+      properties={'c_compiler': 'clang-10', 'cxx_compiler': 'clang++', 'additional_args': '-DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override'},
+      factory=f_quick_build))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-ubuntu-1804-clang10-asan",
+      workernames=["fjord2-docker-ubuntu-1804"] + workers["bg-bbw-docker-clang-ubuntu-1804"],
+      tags=["Ubuntu", "quick", "clang-10", "asan"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      locks=getLocks,
+      factory=f_asan_build))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-ubuntu-2004-msan",
+      workernames=workers["bg-bbw-docker-msan-clang-ubuntu-2004"],
+      tags=["Ubuntu", "quick", "clang-10", "msan"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      locks=getLocks,
+      factory=f_msan_build))
+
+c['builders'].append(
+    util.BuilderConfig(name="amd64-ubuntu-1804-valgrind",
+      workernames=workers["bg-bbw-docker-valgrind-ubuntu-1804"],
+      tags=["Ubuntu", "quick", "gcc", "valgrind"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      locks=getLocks,
+      factory=f_valgrind_build))
+
+
+c['logEncoding'] = 'utf-8'
+
+c['multiMaster'] = True
+
+c['mq'] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
+    'type' : 'wamp',
+    'router_url': 'ws://buildbot.mariadb.org:8085/ws',
+    'realm': 'realm1',
+    # valid are: none, critical, error, warn, info, debug, trace
+    'wamp_debug_level' : 'info'
+}

--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -106,7 +106,12 @@ def addWorker(worker_name_prefix, worker_id, worker_type, dockerfile, jobs=5, sa
             shm_size,
             worker_name_suffix='-galera',
             )
-    workers[name[0]] = name[1]
+
+    if name[0] not in workers:
+        workers[name[0]] = [name[1]]
+    else:
+        workers[name[0]].append(name[1])
+ 
     c['workers'].append(instance)
 
 for platform in all_platforms:

--- a/master.cfg
+++ b/master.cfg
@@ -14,10 +14,11 @@ from datetime import timedelta
 
 sys.setrecursionlimit(10000)
 
-from constants import *
-from utils import *
-from locks import *
 from common_factories import *
+from constants import *
+from locks import *
+from schedulers_definition import *
+from utils import *
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
@@ -84,38 +85,7 @@ c['buildbotNetUsageData'] = None
 ####### SCHEDULERS
 
 # Configure the Schedulers, which decide how to react to incoming changes.
-c['schedulers'] = []
-
-c['schedulers'].append(schedulers.Triggerable(name="s_upstream_all",
-        builderNames=getBranchBuilderNames))
-
-schedulerProtectedBranches = schedulers.Triggerable(name="s_protected_branches",
-        builderNames=github_status_builders)
-c['schedulers'].append(schedulerProtectedBranches)
-
-schedulerPackages = schedulers.Triggerable(name="s_packages",
-        builderNames=getAutobakeBuilderNames)
-c['schedulers'].append(schedulerPackages)
-
-schedulerBigtests = schedulers.Triggerable(name="s_bigtest",
-        builderNames=getBigtestBuilderNames)
-c['schedulers'].append(schedulerBigtests)
-
-schedulerInstall = schedulers.Triggerable(name="s_install",
-        builderNames=getInstallBuilderNames)
-c['schedulers'].append(schedulerInstall)
-
-schedulerUpgrade = schedulers.Triggerable(name="s_upgrade",
-        builderNames=getUpgradeBuilderNames)
-c['schedulers'].append(schedulerUpgrade)
-
-schedulerEco = schedulers.Triggerable(name="s_eco",
-        builderNames=getEcoBuilderNames)
-c['schedulers'].append(schedulerEco)
-
-schedulerDockerlibrary = schedulers.Triggerable(name="s_dockerlibrary",
-        builderNames=getDockerLibraryNames)
-c['schedulers'].append(schedulerDockerlibrary)
+c['schedulers'] = getSchedulers()
 
 ####### WORKERS
 
@@ -125,51 +95,6 @@ c['schedulers'].append(schedulerDockerlibrary)
 c['workers'] = []
 
 # Docker workers
-
-## hz-bbw2-docker
-c['workers'].append(worker.DockerLatentWorker("hz-bbw2-docker-eco-php-ubuntu-2004", None,
-                    docker_host=config["private"]["docker_workers"]["hz-bbw2-docker"],
-                    dockerfile=open("dockerfiles/eco-php-ubuntu-2004.dockerfile").read(),
-                    followStartupLogs=False,
-                    masterFQDN='buildbot.mariadb.org',
-                    hostconfig={ 'shm_size':'6G' },
-                    build_wait_timeout=0,
-                    max_builds=1,
-                    volumes=['/srv/buildbot/eco/code:/code', '/srv/buildbot/eco/build:/build'],
-                    properties={ 'jobs':7, 'save_packages':False }))
-
-c['workers'].append(worker.DockerLatentWorker("hz-bbw2-docker-eco-dbdeployer-ubuntu-2004", None,
-                    docker_host=config["private"]["docker_workers"]["hz-bbw2-docker"],
-                    dockerfile=open("dockerfiles/eco-dbdeployer-ubuntu-2004.dockerfile").read(),
-                    followStartupLogs=False,
-                    masterFQDN='buildbot.mariadb.org',
-                    hostconfig={ 'shm_size':'6G' },
-                    build_wait_timeout=0,
-                    max_builds=1,
-                    volumes=['/srv/buildbot/eco/dbdeployer:/dbdeployer'],
-                    properties={ 'jobs':7, 'save_packages':False }))
-
-c['workers'].append(worker.DockerLatentWorker("hz-bbw2-docker-eco-pymysql-python-3-9-slim-buster", None,
-                    docker_host=config["private"]["docker_workers"]["hz-bbw2-docker"],
-                    dockerfile=open("dockerfiles/eco-pymysql-python-3-9-slim-buster.dockerfile").read(),
-                    followStartupLogs=False,
-                    masterFQDN='buildbot.mariadb.org',
-                    hostconfig={ 'shm_size':'6G' },
-                    build_wait_timeout=0,
-                    max_builds=1,
-                    volumes=['/srv/buildbot/eco/pymysqlcode:/code'],
-                    properties={ 'jobs':7, 'save_packages':False }))
-
-c['workers'].append(worker.DockerLatentWorker("hz-bbw2-docker-eco-mysqljs-nodejs15-buster", None,
-                    docker_host=config["private"]["docker_workers"]["hz-bbw2-docker"],
-                    dockerfile=open("dockerfiles/eco-mysqljs-nodejs15-buster.dockerfile").read(),
-                    followStartupLogs=False,
-                    masterFQDN='buildbot.mariadb.org',
-                    hostconfig={ 'shm_size':'6G' },
-                    build_wait_timeout=0,
-                    max_builds=1,
-                    volumes=['/srv/buildbot/eco/mysqljscode:/code'],
-                    properties={ 'jobs':7, 'save_packages':False }))
 
 workers={}
 def addWorker(worker_name_prefix, worker_id, worker_type, dockerfile, jobs=5, save_packages=False, shm_size='15G'):
@@ -274,27 +199,6 @@ for w_name in ['hz-bbw', 'intel-bbw', 'amd-bbw']:
         addWorker(w_name, i, '-opensuse-15', 'opensuse-15.dockerfile', jobs=jobs, save_packages=True)
         addWorker(w_name, i, '-clang-ubuntu-1804', "clang-ubuntu-1804.dockerfile", jobs=jobs, save_packages=True)
 
-## apexis-bbw1-docker
-c['workers'].append(worker.DockerLatentWorker("fjord1-docker-ubuntu-1804", None,
-                    docker_host=config["private"]["docker_workers"]["apexis-bbw1-docker"],
-                    dockerfile=open("dockerfiles/clang-ubuntu-1804.dockerfile").read(),
-                    followStartupLogs=False,
-                    masterFQDN='buildbot.mariadb.org',
-                    hostconfig={ 'shm_size':'6G' },
-                    max_builds=1,
-                    volumes=['/opt/mariadb-buildbot/ccache:/mnt/ccache', '/opt/mariadb-buildbot/packages:/mnt/packages'],
-                    properties={ 'jobs':7, 'save_packages':False }))
-
-c['workers'].append(worker.DockerLatentWorker("fjord2-docker-ubuntu-1804", None,
-                    docker_host=config["private"]["docker_workers"]["apexis-bbw2-docker"],
-                    dockerfile=open("dockerfiles/clang-ubuntu-1804.dockerfile").read(),
-                    followStartupLogs=False,
-                    masterFQDN='buildbot.mariadb.org',
-                    hostconfig={ 'shm_size':'6G' },
-                    max_builds=1,
-                    volumes=['/opt/mariadb-buildbot/ccache:/mnt/ccache', '/opt/mariadb-buildbot/packages:/mnt/packages'],
-                    properties={ 'jobs':7, 'save_packages':False }))
-
 ## Add Power workers
 for w_name in ['p9-rhel8-bbw', 'p9-rhel7-bbw', 'p9-db-bbw']:
     jobs = 12
@@ -368,43 +272,7 @@ for i in [1,2,3]:
     addWorker('s390x-bbw', i, '-rhel-9', "quay.io/mariadb-foundation/bb-worker:rhel9", jobs=jobs, save_packages=True)
     addWorker('s390x-bbw', i, '-sles-15', "vladbogo/bb:s390x-sles-15", jobs=8, save_packages=True)
 
-## bm-bbw1-docker
-c['workers'].append(worker.DockerLatentWorker("bm-bbw1-docker-ubuntu-1804", None,
-                    docker_host=config["private"]["docker_workers"]["bm-bbw1-docker"],
-                    image="quay.io/mariadb-foundation/bb-worker:ubuntu18.04",
-                    followStartupLogs=False,
-                    autopull=True,
-                    alwaysPull=True,
-                    masterFQDN='buildbot.mariadb.org',
-                    hostconfig={ 'shm_size':'20G' },
-                    max_builds=1,
-                    volumes=['/srv/buildbot/ccache:/mnt/ccache', '/mnt/autofs/master_packages:/packages'],
-                    properties={ 'jobs': 2, 'save_packages':False }))
-
-# The 'builders' list defines the Builders, which tell Buildbot how to perform a build:
-# what steps, and which workers can execute them.  Note that any particular build will
-# only take place on one worker.
-
-def downloadSourceTarball():
-    return ShellCommand(
-             name="fetch_tarball",
-             description="fetching source tarball",
-             descriptionDone="fetching source tarball...done",
-             haltOnFailure=True,
-             command=["bash", "-xc", util.Interpolate("""
-  d=/mnt/packages/
-  f="%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz"
-  find $d -type f -mtime +2 -delete -ls
-  for i in `seq 1 10`;
-  do
-    if flock "$d$f" wget -cO "$d$f" "https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:mariadb_version)s.tar.gz"; then
-        break
-    else
-        sleep $i
-    fi
-  done
-""")])
-
+####### FACTORY CODE
 
 def dpkgDeb():
     return ShellCommand(
@@ -420,160 +288,9 @@ def dpkgDeb():
     find debs -type f -exec sha256sum {} \; | sort > sha256sums.txt
 """)], doStepIf=lambda step: hasFiles(step) and savePackage(step))
 
-####### FACTORY CODE
 
 f_quick_build = getQuickBuildFactory(mtrDbPool)
 f_rpm_autobake = getRpmAutobakeFactory(mtrDbPool)
-
-## f_tarball - create source tarball
-f_tarball = util.BuildFactory()
-f_tarball.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
-f_tarball.addStep(steps.ShellCommand(command=["echo", " revision: ", util.Property('revision')]))
-f_tarball.addStep(steps.GitHub(
-  repourl=util.Property('repository'),
-  mode='full',
-  method='clobber',
-  workdir='build/server',
-  shallow=True,
-  submodules=True
-))
-f_tarball.addStep(steps.Compile(command=["cmake","../server"], workdir='build/mkdist', description="cmake"))
-f_tarball.addStep(steps.Compile(command=["make", "dist"], workdir='build/mkdist', description="make dist"))
-f_tarball.addStep(steps.SetPropertyFromCommand(property="mariadb_version", command="basename mariadb-*.tar.gz .tar.gz", workdir="build/mkdist"))
-f_tarball.addStep(steps.SetPropertyFromCommand(property="master_branch", command=util.Interpolate("echo " + "%(prop:mariadb_version)s" + " | cut -d'-' -f 2 | cut -d'.' -f 1,2")))
-f_tarball.addStep(steps.ShellCommand(command=util.Interpolate("mkdir -p %(prop:buildnumber)s/logs"), workdir="build/mkdist"))
-f_tarball.addStep(steps.ShellCommand(command=util.Interpolate("sha256sum %(prop:mariadb_version)s" + ".tar.gz >> " + " %(prop:buildnumber)s" + "/sha256sums.txt" + " && mv %(prop:mariadb_version)s" +".tar.gz" + " %(prop:buildnumber)s"), workdir="build/mkdist"))
-f_tarball.addStep(steps.SetPropertyFromCommand(command="ls -1 *.tar.gz", extract_fn=ls2list, workdir=util.Interpolate("build/mkdist/" + "%(prop:buildnumber)s")))
-#f_tarball.addStep(steps.DirectoryUpload(workersrc=util.Interpolate('%(prop:builddir)s' + '/build/mkdist/' + '%(prop:buildnumber)s'),
-#    masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:buildnumber)s'), url=util.Interpolate('https://ci.mariadb.org/' + "%(prop:buildnumber)s"), urlText="Download", doStepIf=hasFiles))
-f_tarball.addStep(steps.ShellCommand(name='save_packages', haltOnFailure=True, command=util.Interpolate('cp -r ' + '%(prop:builddir)s' + '/build/mkdist/' + '%(prop:buildnumber)s' + ' /packages && sync /packages/' + '%(prop:buildnumber)s')))
-f_tarball.addStep(steps.Trigger(schedulerNames=['s_protected_branches'], waitForFinish=False, updateSourceStamp=False, doStepIf=waitIfStaging,
-    set_properties={"tarbuildnum" : Property("buildnumber"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch")}))
-f_tarball.addStep(steps.Trigger(schedulerNames=['s_upstream_all'], waitForFinish=False, updateSourceStamp=False,
-    set_properties={"tarbuildnum" : Property("buildnumber"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch")}))
-f_tarball.addStep(steps.SetPropertyFromCommand(command=util.Interpolate("echo " + "prot-" + "%(prop:master_branch)s"), property="master_staging_branch"))
-f_tarball.addStep(steps.ShellSequence( commands=[
-    util.ShellArg(command="git config --global user.email '" + config["private"]["gh_mdbci"]["email"] + "'"),
-    util.ShellArg(command="git config --global user.name '" + config["private"]["gh_mdbci"]["name"] + "'"),
-    util.ShellArg(command="git remote set-url origin https://" + config["private"]["gh_mdbci"]["push_access_token"] + ":x-oauth-basic@github.com/cvicentiu/server"),
-    util.ShellArg(command=util.Interpolate("git fetch origin %(prop:master_staging_branch)s && git branch %(prop:master_staging_branch)s FETCH_HEAD && git checkout %(prop:master_staging_branch)s && git checkout %(prop:branch)s && git pull --unshallow"), logfile="rebase"),
-    util.ShellArg(command=["bash", "-xc", util.Interpolate("if git checkout %(prop:master_staging_branch)s && git merge --ff-only %(prop:branch)s; then git push --set-upstream origin %(prop:master_staging_branch)s; else  if git checkout %(prop:branch)s && [[ $(git --no-pager log --merges %(prop:master_staging_branch)s..%(prop:branch)s | wc -l) -ne 0 ]]; then exit 1; else git rebase %(prop:master_staging_branch)s && git push --force; fi fi")], logfile="rebase")],
-    workdir="build/server", haltOnFailure="true", doStepIf=lambda step: isStagingBranch(step)))
-#f_tarball.addStep(steps.ShellSequence( commands=[
-#    util.ShellArg(command=util.Interpolate("git checkout " + "%(prop:staging_branch)s"), logfile="rebase"),
-#    util.ShellArg(command=util.Interpolate("git merge %(prop:branch)s"), logfile="rebase")], workdir="build/server", haltOnFailure="true", doStepIf=ifStagingSucceeding))
-f_tarball.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
-
-## f_32b_quick_build
-f_32b_quick_build = util.BuildFactory()
-f_32b_quick_build.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
-f_32b_quick_build.addStep(downloadSourceTarball())
-f_32b_quick_build.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
-f_32b_quick_build.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-# build steps
-f_32b_quick_build.addStep(steps.Compile(command=
-    ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DCMAKE_SYSTEM_LIBRARY_PATH=/usr/lib/i386-linux-gnu/ -DCMAKE_LIBRARY_PATH=/usr/lib/i386-linux-gnu/ -DCMAKE_FIND_ROOT_PATH=/usr/lib/i386-linux-gnu -DCMAKE_LIBRARY_ARCHITECTURE=i386 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=g++ -DWITH_EMBEDDED_SERVER=OFF -DWITH_SAFEMALLOC=OFF -DWITH_WSREP=OFF -DPLUGIN_ARCHIVE=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_CONNECT=NO -DPLUGIN_SPHINX=NO -DWITH_SSL=bundled -DWITH_ZLIB=system -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 && make -j%(kw:jobs)s package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)') )], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
-
-f_32b_quick_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
-f_32b_quick_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-f_32b_quick_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
-# create package and upload to master
-f_32b_quick_build.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary"))
-#f_32b_quick_build.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
-f_32b_quick_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
-
-## f_asan_build
-f_asan_build = util.BuildFactory()
-f_asan_build.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
-f_asan_build.addStep(downloadSourceTarball())
-f_asan_build.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
-f_asan_build.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-# build steps
-f_asan_build.addStep(steps.ShellCommand(command='echo "leak:libtasn1\nleak:libgnutls\nleak:libgmp" > mysql-test/lsan.supp', doStepIf=filterBranch))
-f_asan_build.addStep(steps.ShellCommand(command='cat mysql-test/lsan.supp', doStepIf=filterBranch))
-f_asan_build.addStep(steps.Compile(command=
-    ["sh", "-c", util.Interpolate('cmake . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-O2 -msse4.2 -Wno-unused-command-line-argument -fdebug-macro -Wno-inconsistent-missing-override" -DCMAKE_CXX_FLAGS="-O2 -msse4.2 -Wno-unused-command-line-argument -fdebug-macro -Wno-inconsistent-missing-override" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DWITH_ASAN=YES -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF -DWITH_ZLIB=bundled -DWITH_SSL=bundled -DWITH_PCRE=system && make -j%(kw:jobs)s package', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], haltOnFailure="true"))
-f_asan_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate('cd mysql-test && MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=`pwd`/lsan.supp" perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
-f_asan_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-f_asan_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
-f_asan_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
-
-## f_msan_build
-f_msan_build = util.BuildFactory()
-f_msan_build.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
-f_msan_build.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-f_msan_build.addStep(downloadSourceTarball())
-f_msan_build.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
-# build steps
-f_msan_build.addStep(steps.ShellCommand(command='ls /msan-libs'))
-f_msan_build.addStep(steps.Compile(command=
-    ["bash", "-xc", util.Interpolate('cmake . -DCMAKE_{C_COMPILER=clang,CXX_COMPILER=clang++}-12 -DCMAKE_C_FLAGS="-O2 -Wno-unused-command-line-argument -fdebug-macro" -DCMAKE_CXX_FLAGS="-stdlib=libc++ -O2 -Wno-unused-command-line-argument -fdebug-macro" -DWITH_EMBEDDED_SERVER=OFF -DWITH_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DWITH_INNODB_{BZIP2,LZ4,LZMA,LZO,SNAPPY}=OFF -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER}=NO -DWITH_SAFEMALLOC=OFF -DWITH_{ZLIB,SSL,PCRE}=bundled -DHAVE_LIBAIO_H=0 -DCMAKE_DISABLE_FIND_PACKAGE_{URING,LIBAIO}=1 -DWITH_MSAN=ON && make -j%(kw:jobs)s package', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], haltOnFailure="true"))
-f_msan_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["bash", "-xc", util.Interpolate('cd mysql-test && LD_LIBRARY_PATH=/msan-libs MSAN_OPTIONS=abort_on_error=1 ./mtr --mem --big-test --force --retry=0 --skip-test=.*compression.* --max-test-fail=100 --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
-f_msan_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-f_msan_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
-f_msan_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
-
-## f_valgrind_build
-f_valgrind_build = util.BuildFactory()
-f_valgrind_build.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
-f_valgrind_build.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-f_valgrind_build.addStep(downloadSourceTarball())
-f_valgrind_build.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
-# build steps
-f_valgrind_build.addStep(steps.Compile(command=
-    ["sh", "-c", util.Interpolate('cmake . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DENABLE_ASSEMBLER=1 -DWITH_EXTRA_CHARSETS=complex -DENABLE_THREAD_SAFE_CLIENT=1 -DWITH_BIG_TABLES=1 -DWITH_PLUGIN_ARIA=1 -DWITH_ARIA_TMP_TABLES=1 -DWITH_JEMALLOC=NO -DCMAKE_BUILD_TYPE=Debug -DSECURITY_HARDENED=OFF -DWITH_VALGRIND=1 -DWITH_SSL=bundled -DWITH_MAX=AUTO -DWITH_EMBEDDED_SERVER=1 -DWITH_LIBEVENT=bundled -DPLUGIN_PLUGIN_FILE_KEY_MANAGEMENT=NO -DPLUGIN_ROCKSDB=DYNAMIC -DPLUGIN_TEST_SQL_DISCOVERY=DYNAMIC -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DENABLE_LOCAL_INFILE=1 && make -j%(kw:jobs)s package', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], haltOnFailure="true"))
-f_valgrind_build.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate('cd mysql-test && perl mysql-test-run.pl --valgrind="--leak-check=summary --gen-suppressions=yes --num-callers=10" --skip-test=encryption*  --force --retry=0 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)', jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
-f_valgrind_build.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-f_valgrind_build.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
-f_valgrind_build.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
-
-## f_big_test
-f_big_test = util.BuildFactory()
-f_big_test.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
-f_big_test.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-# get the source tarball and extract it
-f_big_test.addStep(steps.FileDownload(mastersrc=util.Interpolate("/srv/buildbot/packages/" + "%(prop:tarbuildnum)s" + "/" + "%(prop:mariadb_version)s" + ".tar.gz"),
-    workerdest=util.Interpolate("%(prop:mariadb_version)s" + ".tar.gz")))
-f_big_test.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf " + "%(prop:mariadb_version)s" + ".tar.gz --strip-components=1")))
-# build steps
-f_big_test.addStep(steps.Compile(command=
-    ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPLUGIN_ROCKSDB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_SPHINX=NO && make -j%(kw:jobs)s VERBOSE=1 package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], env={'CCACHE_DIR':'/mnt/ccache'}))
-f_big_test.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --big --big --mem --parallel=$(expr %(kw:jobs)s \* 2) --skip-test=archive.archive-big", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
-f_big_test.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-f_big_test.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
-# create package and upload to master
-f_big_test.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary"))
-#f_big_test.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
-f_big_test.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
-
-## f_full_test
-f_full_test = util.BuildFactory()
-f_full_test.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
-# get the source tarball and extract it
-f_full_test.addStep(steps.FileDownload(mastersrc=util.Interpolate("/srv/buildbot/packages/" + "%(prop:tarbuildnum)s" + "/" + "%(prop:mariadb_version)s" + ".tar.gz"),
-    workerdest=util.Interpolate("%(prop:mariadb_version)s" + ".tar.gz")))
-f_full_test.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf " + "%(prop:mariadb_version)s" + ".tar.gz --strip-components=1")))
-# build steps
-f_full_test.addStep(steps.Compile(command=
-    ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DBUILD_CONFIG=mysql_release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DWITH_SSL=system -DWITH_JEMALLOC=auto -DWITH_EMBEDDED_SERVER=1 -DHAVE_EMBEDDED_PRIVILEGE_CONTROL=1 -DWITH_LIBARCHIVE=ON -Wno-dev && make -j%(kw:jobs)s VERBOSE=1 package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], env={'CCACHE_DIR':'/mnt/ccache'}))
-f_full_test.addStep(steps.MTR(addLogs=True, name="test emb", command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --embedded-server --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
-f_full_test.addStep(steps.MTR(addLogs=True, name="test n", command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
-f_full_test.addStep(steps.MTR(addLogs=True, name="test p", command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --ps-protocol --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
-f_full_test.addStep(steps.MTR(addLogs=True, name="test ps-embedded", command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --ps --embedded --mem --testcase-timeout=8 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
-f_full_test.addStep(steps.MTR(addLogs=True, name="test xtra", command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --suite=funcs_1,funcs_2,stress,jp --big --testcase-timeout=8 --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
-f_full_test.addStep(steps.MTR(addLogs=True, name="test engines", command=
-    ["sh", "-c", util.Interpolate("cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=1 --mem --suite=spider,spider/bg,engines/funcs,engines/iuds --big --testcase-timeout=8 --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1 --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=10800, dbpool=mtrDbPool, parallel=mtrJobsMultiplier))
-f_full_test.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ## f_deb_autobake
 f_deb_autobake = util.BuildFactory()
@@ -606,128 +323,7 @@ f_deb_autobake.addStep(steps.Trigger(name='major-minor-upgrade', schedulerNames=
     set_properties={"tarbuildnum" : Property("tarbuildnum"), "mariadb_version" : Property("mariadb_version"), "master_branch" : Property("master_branch"), "parentbuildername": Property("buildername")}, doStepIf=lambda step: hasUpgrade(step) and savePackage(step) and hasFiles(step)))
 f_deb_autobake.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
-## f_bintar
-f_bintar = util.BuildFactory()
-f_bintar.addStep(downloadSourceTarball())
-f_bintar.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
-f_bintar.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-# build steps
-f_bintar.addStep(steps.Compile(command=
-    ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DBUILD_CONFIG=mysql_release -DWITH_READLINE=1 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache %(kw:additional_args)s  && make -j%(kw:jobs)s package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'), additional_args=util.Property('additional_args', default=''))], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
-
-#f_bintar.addStep(steps.MTR(logfiles={"mysqld*": "/buildbot/mysql_logs.html"}, command=
-#    ["sh", "-c", util.Interpolate("cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=1 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))], timeout=7200, haltOnFailure="true", parallel=mtrJobsMultiplier, dbpool=mtrDbPool, autoCreateTables=True))
-#f_bintar.addStep(steps.ShellCommand(name="move mysqld log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
-#f_bintar.addStep(steps.DirectoryUpload(name="save mysqld log files", compress="bz2", alwaysRun=True,  workersrc='/buildbot/logs/', masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + '/logs/' + '%(prop:buildername)s' )))
-# create package and upload to master
-f_bintar.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary", doStepIf=savePackage))
-f_bintar.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
-f_bintar.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
-
-## f_without_server
-f_without_server = util.BuildFactory()
-f_without_server.addStep(steps.SetProperty(property="dockerfile", value=util.Interpolate("%(kw:url)s", url=dockerfile), description="dockerfile"))
-f_without_server.addStep(steps.ShellCommand(command="ls -la"))
-f_without_server.addStep(downloadSourceTarball())
-f_without_server.addStep(steps.ShellCommand(command="ls -la"))
-f_without_server.addStep(steps.ShellCommand(command=util.Interpolate("tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1")))
-f_without_server.addStep(steps.ShellCommand(command="ls -la"))
-# build steps
-f_without_server.addStep(steps.Compile(command=
-    ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DWITHOUT_SERVER=1 && make -j%(kw:jobs)s package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'), c_compiler=util.Property('c_compiler', default='gcc'), cxx_compiler=util.Property('cxx_compiler', default='g++'))], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
-#    ["sh", "-c", util.Interpolate("export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && mkdir -p ../builddir && cd ../builddir && cmake ${OLDPWD} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DWITHOUT_SERVER=ON && cmake --build . --parallel %(kw:jobs)s --target package", jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'), c_compiler=util.Property('c_compiler', default='gcc'), cxx_compiler=util.Property('cxx_compiler', default='g++'))], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
-# create package and upload to master
-f_without_server.addStep(steps.SetPropertyFromCommand(command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary"))
-#f_without_server.addStep(steps.FileUpload(workersrc=util.Interpolate("%(prop:mariadb_binary)s"), masterdest=util.Interpolate('/srv/buildbot/packages/' + '%(prop:tarbuildnum)s' + "/" + '%(prop:buildername)s' + "/" + "%(prop:mariadb_binary)s"), mode=0o755, url=util.Interpolate('https://ci.mariadb.org/' + "%(prop:tarbuildnum)s" + "/" + '%(prop:buildername)s' + "/"), urlText="Download", doStepIf=savePackage))
-f_without_server.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
-f_without_server.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
-
-## f_eco_php
-f_eco_php = util.BuildFactory()
-f_eco_php.addStep(steps.ShellCommand(
-    name="fetch_install_script",
-    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/installdb.sh -o /buildbot/installdb.sh && chmod a+x /buildbot/installdb.sh"]))
-f_eco_php.addStep(steps.ShellCommand(
-    name="fetch_test_script",
-    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-php.sh -o /buildbot/test-php.sh && chmod a+x /buildbot/test-php.sh"]))
-f_eco_php.addStep(steps.ShellCommand(
-    name="fetching and installing database",
-    command=["sh", "-xc", util.Interpolate("/buildbot/installdb.sh \"https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s\" --plugin-load-add=auth_pam --pam_use_cleartext_plugin")]))
-f_eco_php.addStep(steps.ShellCommand(
-    name="test PHP-7.1",
-    command=["sh", "-xc", "/buildbot/test-php.sh PHP-7.1"]))
-f_eco_php.addStep(steps.ShellCommand(
-    name="test PHP-8.0",
-    command=["sh", "-xc", "/buildbot/test-php.sh PHP-8.0"]))
-f_eco_php.addStep(steps.ShellCommand(
-    name="test PHP-8.1",
-    command=["sh", "-xc", "/buildbot/test-php.sh PHP-8.1"]))
-f_eco_php.addStep(steps.ShellCommand(
-    name="test master",
-    command=["sh", "-xc", "/buildbot/test-php.sh"]))
-
-## f_eco_dbdeployer
-f_eco_dbdeployer = util.BuildFactory()
-f_eco_dbdeployer.addStep(steps.ShellCommand(
-    name="fetch_test_script",
-    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-dbdeployer.sh -o /buildbot/test-dbdeployer.sh && chmod a+x /buildbot/test-dbdeployer.sh"]))
-f_eco_dbdeployer.addStep(steps.ShellCommand(
-    name="download if needed latest dbdeployer",
-    command=["sh", "-xc", "/buildbot/test-dbdeployer.sh dbdeployerfetch"]))
-f_eco_dbdeployer.addStep(steps.ShellCommand(
-    name="fetching mariadb tarball",
-    command=["sh", "-xc", util.Interpolate("/buildbot/test-dbdeployer.sh init \"https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s\"")]))
-f_eco_dbdeployer.addStep(steps.ShellCommand(
-    name="deploy single ma",
-    command=["sh", "-xc", util.Interpolate("/buildbot/test-dbdeployer.sh deploy single ma%(prop:mariadb_version)s")]))
-f_eco_dbdeployer.addStep(steps.ShellCommand(
-    name="deploy replication ma",
-    command=["sh", "-xc", util.Interpolate("/buildbot/test-dbdeployer.sh deploy replication ma%(prop:mariadb_version)s")]))
-f_eco_dbdeployer.addStep(steps.ShellCommand(
-    name="global test",
-    command=["sh", "-xc", "/buildbot/test-dbdeployer.sh global test"]))
-f_eco_dbdeployer.addStep(steps.ShellCommand(
-    name="global replication",
-    command=["sh", "-xc", "/buildbot/test-dbdeployer.sh global test-replication"]))
-
-## f_eco_pymysql
-f_eco_pymysql = util.BuildFactory()
-f_eco_pymysql.addStep(steps.ShellCommand(
-    name="fetch_install_script",
-    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/installdb.sh -o /buildbot/installdb.sh && chmod a+x /buildbot/installdb.sh"]))
-f_eco_pymysql.addStep(steps.ShellCommand(
-    name="fetch_test_script",
-    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-pymysql.sh -o /buildbot/test-pymysql.sh && chmod a+x /buildbot/test-pymysql.sh"]))
-f_eco_pymysql.addStep(steps.ShellCommand(
-    name="fetching and installing database",
-    command=["sh", "-xc", util.Interpolate("/buildbot/installdb.sh \"https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s\"")]))
-f_eco_pymysql.addStep(steps.ShellCommand(
-    name="test pymysql-main",
-    command=["sh", "-xc", "/buildbot/test-pymysql.sh"]))
-f_eco_pymysql.addStep(steps.ShellCommand(
-    name="test pymysql-v0.7.11",
-    command=["sh", "-xc", "/buildbot/test-pymysql.sh v0.7.11"]))
-
-## f_eco_mysqljs
-f_eco_mysqljs = util.BuildFactory()
-f_eco_mysqljs.addStep(steps.ShellCommand(
-    name="fetch_install_script",
-    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/installdb.sh -o /buildbot/installdb.sh && chmod a+x /buildbot/installdb.sh"]))
-f_eco_mysqljs.addStep(steps.ShellCommand(
-    name="fetch_test_script",
-    command=["sh", "-xc", "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-mysqljs.sh -o /buildbot/test-mysqljs.sh && chmod a+x /buildbot/test-mysqljs.sh"]))
-f_eco_mysqljs.addStep(steps.ShellCommand(
-    name="fetching and installing database",
-    command=["sh", "-xc", util.Interpolate("/buildbot/installdb.sh \"https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s\"")]))
-f_eco_mysqljs.addStep(steps.ShellCommand(
-    name="test mysqljs-master",
-    command=["sh", "-xc", "/buildbot/test-mysqljs.sh"]))
-f_eco_mysqljs.addStep(steps.ShellCommand(
-    name="test mysqljs-v2.18.1",
-    command=["sh", "-xc", "/buildbot/test-mysqljs.sh v2.18.1"]))
-
 ####### BUILDERS LIST
-protected_branches_mtr_additional_args = '--suite=main --skip-test="^stack_crash$|^float$|^derived_split_innodb$|^mysql_client_test$|^kill$|^processlist_not_embedded$|^sp-big$"'
 
 c['builders'] = []
 
@@ -906,51 +502,6 @@ c['builders'].append(
       factory=f_deb_autobake))
 
 c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-2004-eco-php",
-      workernames=["hz-bbw2-docker-eco-php-ubuntu-2004"],
-      tags=["Ubuntu", "ecosystem", "PHP"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      factory=f_eco_php))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-2004-eco-dbdeployer",
-      workernames=["hz-bbw2-docker-eco-dbdeployer-ubuntu-2004"],
-      tags=["Ubuntu", "ecosystem", "dbdeployer"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      factory=f_eco_dbdeployer))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-debian-10-eco-pymysql",
-      workernames=["hz-bbw2-docker-eco-pymysql-python-3-9-slim-buster"],
-      tags=["Debian", "ecosystem", "pymysql"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      factory=f_eco_pymysql))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-debian-10-eco-mysqljs",
-      workernames=["hz-bbw2-docker-eco-mysqljs-nodejs15-buster"],
-      tags=["Debian", "ecosystem", "mysqljs"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      factory=f_eco_mysqljs))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804-bigtest",
-      workernames=["bm-bbw1-docker-ubuntu-1804"],
-      tags=["Ubuntu", "big", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      factory=f_big_test))
-
-c['builders'].append(
     util.BuilderConfig(name="amd64-debian-10-deb-autobake",
       workernames=workers["bg-bbw-docker-debian-10"],
       tags=["Debian", "quick", "gcc"],
@@ -968,7 +519,6 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -1103,7 +653,6 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -1213,16 +762,6 @@ c['builders'].append(
       factory=f_rpm_autobake))
 
 c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-2004-fulltest",
-      workernames=workers["bg-bbw-docker-ubuntu-2004"],
-      tags=["Ubuntu", "full", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_full_test))
-
-c['builders'].append(
     util.BuilderConfig(name="ppc64le-ubuntu-1804",
       workernames=workers["p9-bbw-docker-ubuntu-1804"],
       tags=["Ubuntu", "quick", "gcc", "pc9"],
@@ -1323,16 +862,6 @@ c['builders'].append(
       factory=f_deb_autobake))
 
 c['builders'].append(
-    util.BuilderConfig(name="ppc64le-ubuntu-1804-without-server",
-      workernames=workers["p9-bbw-docker-ubuntu-1804"],
-      tags=["Ubuntu", "without-server", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_without_server))
-
-c['builders'].append(
     util.BuilderConfig(name="ppc64le-ubuntu-2004-clang1x",
       workernames=workers["p9-bbw-docker-clang-ubuntu-2004"],
       tags=["Ubuntu", "quick", "clang-10", "pc9"],
@@ -1351,7 +880,6 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -1373,7 +901,6 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -1388,48 +915,6 @@ c['builders'].append(
       factory=f_rpm_autobake))
 
 c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804-clang6",
-      workernames=["fjord1-docker-ubuntu-1804"] + workers["x64-bbw-docker-clang-ubuntu-1804"],
-      tags=["Ubuntu", "quick", "clang-6"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'c_compiler': 'clang-6.0', 'cxx_compiler': 'clang++-6.0', 'additional_args': '-DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override'},
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804-clang10",
-      workernames=["fjord2-docker-ubuntu-1804"] + workers["x64-bbw-docker-clang-ubuntu-1804"],
-      tags=["Ubuntu", "quick", "clang-10"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'c_compiler': 'clang-10', 'cxx_compiler': 'clang++', 'additional_args': '-DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override'},
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804-clang10-asan",
-      workernames=["fjord2-docker-ubuntu-1804"] + workers["x64-bbw-docker-clang-ubuntu-1804"],
-      tags=["Ubuntu", "quick", "clang-10", "asan"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_asan_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-2004-msan",
-      workernames=workers["bg-bbw-docker-msan-clang-ubuntu-2004"],
-      tags=["Ubuntu", "quick", "clang-10", "msan"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_msan_build))
-
-c['builders'].append(
     util.BuilderConfig(name="x86-ubuntu-1804",
       workernames=workers["bg-bbw-docker-x86-ubuntu-1804"],
       tags=["Ubuntu", "quick", "gcc", "32bit"],
@@ -1437,17 +922,7 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      factory=f_32b_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804-valgrind",
-      workernames=workers["bg-bbw-docker-valgrind-ubuntu-1804"] + workers['x64-bbw-docker-valgrind-ubuntu-1804'],
-      tags=["Ubuntu", "quick", "gcc", "valgrind"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_valgrind_build))
+      factory=f_quick_build))
 
 c['builders'].append(
     util.BuilderConfig(name="aarch64-ubuntu-1804",
@@ -1580,7 +1055,6 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
       factory=f_quick_build))
 
 c['builders'].append(
@@ -1601,7 +1075,6 @@ c['builders'].append(
       nextBuild=nextBuild,
       canStartBuild=canStartBuild,
       locks=getLocks,
-      properties={'mtr_additional_args': protected_branches_mtr_additional_args},
       factory=f_quick_build))
 
 c['builders'].append(

--- a/schedulers_definition.py
+++ b/schedulers_definition.py
@@ -1,0 +1,40 @@
+from buildbot.plugins import *
+
+from utils import *
+
+def getSchedulers():
+    l = []
+
+    l.append(schedulers.Triggerable(name="s_upstream_all",
+        builderNames=getBranchBuilderNames))
+
+    schedulerProtectedBranches = schedulers.Triggerable(name="s_protected_branches",
+        builderNames=github_status_builders)
+    l.append(schedulerProtectedBranches)
+
+
+    schedulerPackages = schedulers.Triggerable(name="s_packages",
+            builderNames=getAutobakeBuilderNames)
+    l.append(schedulerPackages)
+
+    schedulerBigtests = schedulers.Triggerable(name="s_bigtest",
+            builderNames=getBigtestBuilderNames)
+    l.append(schedulerBigtests)
+
+    schedulerInstall = schedulers.Triggerable(name="s_install",
+            builderNames=getInstallBuilderNames)
+    l.append(schedulerInstall)
+
+    schedulerUpgrade = schedulers.Triggerable(name="s_upgrade",
+            builderNames=getUpgradeBuilderNames)
+    l.append(schedulerUpgrade)
+
+    schedulerEco = schedulers.Triggerable(name="s_eco",
+            builderNames=getEcoBuilderNames)
+    l.append(schedulerEco)
+
+    schedulerDockerlibrary = schedulers.Triggerable(name="s_dockerlibrary",
+            builderNames=getDockerLibraryNames)
+    l.append(schedulerDockerlibrary)
+
+    return l

--- a/utils.py
+++ b/utils.py
@@ -91,6 +91,26 @@ def createWorker(worker_name_prefix, worker_id, worker_type, dockerfile, jobs=5,
                         properties={ 'jobs':jobs, 'save_packages':save_packages })
     return ((base_name, name + worker_name_suffix), worker_instance)
 
+def downloadSourceTarball():
+    return ShellCommand(
+             name="fetch_tarball",
+             description="fetching source tarball",
+             descriptionDone="fetching source tarball...done",
+             haltOnFailure=True,
+             command=["bash", "-xc", util.Interpolate("""
+  d=/mnt/packages/
+  f="%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz"
+  find $d -type f -mtime +2 -delete -ls
+  for i in `seq 1 10`;
+  do
+    if flock "$d$f" wget -cO "$d$f" "https://ci.mariadb.org/%(prop:tarbuildnum)s/%(prop:mariadb_version)s.tar.gz"; then
+        break
+    else
+        sleep $i
+    fi
+  done
+""")])
+
 # git branch filter using fnmatch
 import fnmatch
 def staging_branch_fn(branch):


### PR DESCRIPTION
The non standard builders (e.g. MSAN, valgrind, eco, etc) need to be manually
defined. Move them to a separate master so that the rest of the builders
can be defined automatically based on the os_info.yaml file content.