### PR TITLE
Auto-generate master configuration

### DIFF
--- a/.github/workflows/bbm_check_conf.yml
+++ b/.github/workflows/bbm_check_conf.yml
@@ -40,12 +40,14 @@ jobs:
       - name: Check master.cfg files
         run: |
           ln -s master-private.cfg-sample master-private.cfg
+          ln -s master-config.yaml-sample master-config.yaml
+          python define_masters.py
           echo "Checking master.cfg"
           docker run -i -v $(pwd):/srv/buildbot/master -w /srv/buildbot/master quay.io/mariadb-foundation/bb-master:master buildbot checkconfig master.cfg
           echo -e "done\n"
           # not checking libvirt config file (//TEMP we need to find a solution
           # to not check ssh connection)
-          for dir in master-docker-nonstandard master-galera master-nonlatent master-web master-protected-branches; do
+          for dir in master-docker-nonstandard master-galera master-nonlatent master-web master-protected-branches autogen/*; do
             echo "Checking $dir/master.cfg"
             docker run -i -v $(pwd):/srv/buildbot/master -w /srv/buildbot/master quay.io/mariadb-foundation/bb-master:master bash -c "cd $dir && buildbot checkconfig master.cfg"
             echo -e "done\n"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ master-private.cfg
 prof*
 venv
 workers
+autogen

--- a/buildbot.tac
+++ b/buildbot.tac
@@ -23,7 +23,7 @@ if basedir == '.':
 application = service.Application('buildmaster')
 from twisted.python.logfile import LogFile
 from twisted.python.log import ILogObserver, FileLogObserver
-logfile = LogFile.fromFullPath(os.path.join(log_basedir, "master-docker.log"), rotateLength=rotateLength,
+logfile = LogFile.fromFullPath(os.path.join(log_basedir, "%s"), rotateLength=rotateLength,
                                 maxRotatedFiles=maxRotatedFiles)
 application.setComponent(ILogObserver, FileLogObserver(logfile).emit)
 

--- a/define_masters.py
+++ b/define_masters.py
@@ -1,0 +1,54 @@
+import yaml
+import os
+import shutil
+
+base_path = "autogen/"
+config = { "private": { } }
+exec(open("master-private.cfg").read(), config, { })
+
+with open('os_info.yaml', 'r') as f:
+    os_info = yaml.safe_load(f)
+
+platforms = {}
+
+for os_name in os_info:
+    for arch in os_info[os_name]['arch']:
+        builder_name = arch + '-' + os_name
+        if arch not in platforms:
+            platforms[arch] = []
+        platforms[arch].append(builder_name)
+
+# Clear old configurations
+if os.path.exists(base_path):
+    shutil.rmtree(base_path)
+
+idx = 0
+for arch in platforms:
+    # Create the directory for the architecture that is handled by each master
+    # If for a given architecture there are more than "max_builds" builds,
+    # create multiple masters
+    # "max_builds" is defined is master-private.py
+    num_masters = int(len(platforms[arch]) / config['private']['master-variables']['max_builds']) + 1
+
+    for master_id in range(num_masters):
+        dir_path = base_path + arch + "-master-" + str(master_id)
+        os.makedirs(dir_path)
+
+        master_config = {}
+        master_config['builders'] = platforms[arch]
+        master_config['workers'] = config['private']['master-variables']['workers'][arch]
+        master_config['port'] = config['private']['master-variables']['starting_port'] + idx
+        master_config['log_name'] = "master-docker-" + arch + "-" + str(master_id) + '.log'
+
+        with open(dir_path + '/master-config.yaml', 'w') as f:
+            yaml.dump(master_config, f)
+
+        shutil.copyfile('master.cfg', dir_path + '/master.cfg')
+        shutil.copyfile('master-private.cfg', dir_path + '/master-private.cfg')
+
+        buildbot_tac = open("buildbot.tac", "r").read() % master_config['log_name']
+        with open(dir_path + '/buildbot.tac', 'w') as f:
+            f.write(buildbot_tac)
+        idx += 1
+    print(arch, len(platforms[arch]))
+ 

--- a/master-config.yaml-sample
+++ b/master-config.yaml-sample
@@ -1,0 +1,20 @@
+builders:
+- aarch64-centos-stream8
+- aarch64-centos-stream9
+- aarch64-debian-10
+- aarch64-debian-11
+- aarch64-debian-sid
+- aarch64-fedora-35
+- aarch64-fedora-36
+- aarch64-rhel-8
+- aarch64-rhel-9
+- aarch64-ubuntu-1804
+- aarch64-ubuntu-2004
+- aarch64-ubuntu-2204
+log_name: master-docker-aarch64-0.log
+port: 9998
+workers:
+- aarch64-bbw1
+- aarch64-bbw2
+- aarch64-bbw3
+- aarch64-bbw4

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -194,7 +194,7 @@ c['workers'].append(worker.DockerLatentWorker("bm-bbw1-docker-ubuntu-1804", None
 
 
 ## Add Power workers
-for w_name in ['p9-rhel7-bbw']:
+for w_name in ['ppc64le-rhel7-bbw']:
     jobs = 7
     addWorker(w_name, 1, '-ubuntu-1804', 'quay.io/mariadb-foundation/bb-worker:ubuntu18.04', jobs=jobs, save_packages=True, shm_size='20G')
     addWorker(w_name, 1, '-clang-ubuntu-2004', 'vladbogo/bb:ppc64le-ubuntu-2004-clang1x',jobs=jobs, save_packages=True, shm_size='20G')
@@ -479,7 +479,7 @@ c['builders'].append(
 
 c['builders'].append(
     util.BuilderConfig(name="ppc64le-ubuntu-1804-without-server",
-      workernames=workers["p9-bbw-docker-ubuntu-1804"],
+      workernames=workers["ppc64le-bbw-docker-ubuntu-1804"],
       tags=["Ubuntu", "without-server", "gcc", "pc9"],
       collapseRequests=True,
       nextBuild=nextBuild,
@@ -489,7 +489,7 @@ c['builders'].append(
 
 c['builders'].append(
     util.BuilderConfig(name="ppc64le-ubuntu-2004-clang1x",
-      workernames=workers["p9-bbw-docker-clang-ubuntu-2004"],
+      workernames=workers["ppc64le-bbw-docker-clang-ubuntu-2004"],
       tags=["Ubuntu", "quick", "clang-10", "pc9"],
       collapseRequests=True,
       nextBuild=nextBuild,

--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -125,13 +125,17 @@ for platform in all_platforms:
         worker_ids = range(1, 6)
         jobs = 4
     elif platform == 'ppc64le':
-        machines = ['p9-rhel8-bbw', 'p9-rhel7-bbw']
+        machines = ['ppc64le-rhel8-bbw', 'ppc64le-rhel7-bbw']
         worker_ids = [1]
         jobs = 12
     elif platform == 's390x':
         machines = ['s390x-bbw']
         worker_ids = range(1,3)
         jobs = 8
+    elif platform == 'x86':
+        machines = ['hz-bbw']
+        worker_ids = [2]
+        jobs = 7
 
     assert jobs is not None
 
@@ -140,7 +144,11 @@ for platform in all_platforms:
             for os in os_info:
                 if platform in os_info[os]['arch']:
                     quay_name = 'quay.io/mariadb-foundation/bb-worker:' + ''.join(os.split('-'))
-                    addWorker(w_name, i, '-' + os, 'quay.io/mariadb-foundation/bb-worker:centos7', jobs=jobs, save_packages=True)
+                    os_name = os
+                    if platform == 'x86':
+                        quay_name += '-i386'
+                        os_name += '-i386'
+                    addWorker(w_name, i, '-' + os_name, 'quay.io/mariadb-foundation/bb-worker:centos7', jobs=jobs, save_packages=True)
 
 def dpkgDeb():
     return ShellCommand(
@@ -212,8 +220,8 @@ for os in os_info:
         worker_name = arch + '-bbw-docker-' + os
         if arch == 'amd64':
             worker_name = 'x64-bbw-docker-' + os
-        elif arch == 'ppc64le':
-            worker_name = 'p9-bbw-docker-' + os
+        if arch == 'x86':
+            worker_name = 'x64-bbw-docker-' + os + '-i386'
 
         if os_info[os]['type'] == 'rpm':
             factory = f_rpm_build

--- a/master-private.cfg-sample
+++ b/master-private.cfg-sample
@@ -9,6 +9,36 @@ private["zabbix_token"] = "zabbix_token"
 private["user_pass"]= {
     "admin":"user_pass",
 }
+private["master-variables"] = {
+    "max_builds": 15,
+    "starting_port": 9996,
+    "workers": {
+        "amd64": [
+                'amd-bbw1',
+                'amd-bbw2',
+                'intel-bbw1',
+            ],
+        "aarch64": [
+                'aarch64-bbw1',
+                'aarch64-bbw2',
+                'aarch64-bbw3',
+                'aarch64-bbw4',
+            ],
+        "ppc64le": [
+                'ppc64le-rhel8-bbw1',
+                'ppc64le-rhel7-bbw1',
+                'ppc64le-db-bbw1',
+            ],
+        "s390x": [
+                's390x-bbw1',
+                's390x-bbw2',
+                's390x-bbw3',
+            ],
+        "x86": [
+                'hz-bbw2',
+            ],
+    },
+}
 private["worker_pass"]= {
     "hz-bbw2-ubuntu1804":"1234",
     "hz-bbw2-libvirt-debian-10":"1234",
@@ -29,9 +59,9 @@ private["docker_workers"]= {
     "hz-bbw5-docker":"tcp://IP_address:port",
     "gsk-bbw1-docker":"tcp://IP_address:port",
     "bm-bbw1-docker":"tcp://IP_address:port",
-    "p9-rhel8-bbw1-docker":"tcp://IP_address:port",
-    "p9-rhel7-bbw1-docker":"tcp://IP_address:port",
-    "p9-db-bbw1-docker":"tcp://IP_address:port",
+    "ppc64le-rhel8-bbw1-docker":"tcp://IP_address:port",
+    "ppc64le-rhel7-bbw1-docker":"tcp://IP_address:port",
+    "ppc64le-db-bbw1-docker":"tcp://IP_address:port",
     "aarch64-bbw1-docker":"tcp://IP_address:port",
     "aarch64-bbw2-docker":"tcp://IP_address:port",
     "aarch64-bbw3-docker":"tcp://IP_address:port",

--- a/master.cfg
+++ b/master.cfg
@@ -14,11 +14,16 @@ from datetime import timedelta
 
 sys.setrecursionlimit(10000)
 
+sys.path.insert(0, '/srv/buildbot/master')
+
 from common_factories import *
 from constants import *
 from locks import *
 from schedulers_definition import *
 from utils import *
+
+with open('master-config.yaml', 'r') as f:
+    master_config = yaml.safe_load(f)
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
@@ -68,7 +73,7 @@ c['buildbotURL'] = "https://buildbot.mariadb.org/"
 # could connect to your master with this protocol.
 # 'port' must match the value configured into the workers (with their
 # --master option)
-c['protocols'] = {'pb': {'port': 9992}}
+c['protocols'] = {'pb': {'port': master_config['port']}}
 
 ####### DB URL
 
@@ -98,179 +103,36 @@ c['workers'] = []
 
 workers={}
 def addWorker(worker_name_prefix, worker_id, worker_type, dockerfile, jobs=5, save_packages=False, shm_size='15G'):
-    worker_name = worker_name_prefix + str(worker_id) + '-docker'
-    name = worker_name + worker_type
+    name, instance = createWorker(
+            worker_name_prefix,
+            worker_id,
+            worker_type,
+            dockerfile,
+            jobs,
+            save_packages,
+            shm_size,
+            )
 
-    i = worker_id
-    tls = None
-    #if worker_name_prefix.startswith('aarch64'):
-    #    tls = docker.tls.TLSConfig(verify=True, ca_cert='/srv/buildbot/tlscerts/ca-arm-bbw' + str(i)+ '.pem', client_cert=('/srv/buildbot/tlscerts/cert-arm-bbw' + str(i) + '.pem', '/srv/buildbot/tlscerts/key-arm-bbw' + str(i) + '.pem'))
-    #else:
-    #    tls = None
-
-    if worker_name_prefix.startswith('hz'):
-        b_name = 'x64-bbw'
-    elif worker_name_prefix.startswith('intel'):
-        b_name = 'x64-bbw'
-    elif worker_name_prefix.startswith('p9'):
-        b_name = 'p9-bbw'
-    elif worker_name_prefix.startswith('amd'):
-        b_name = 'x64-bbw'
+    if name[0] not in workers:
+        workers[name[0]] = [name[1]]
     else:
-        b_name = worker_name_prefix
-    base_name = b_name + '-docker' + worker_type
+        workers[name[0]].append(name[1])
+ 
+    c['workers'].append(instance)
 
-    if base_name not in workers:
-        workers[base_name] = [name]
-    else:
-        workers[base_name].append(name)
+for w_name in master_config['workers']:
+    jobs = 7
 
-    volumes=['/srv/buildbot/ccache:/mnt/ccache', '/srv/buildbot/packages:/mnt/packages', '/mnt/autofs/master_packages/:/packages']
-    # Set master FQDN - for VPN machines it should be 100.64.100.1
-    fqdn = 'buildbot.mariadb.org'
-    if worker_name_prefix.startswith('intel') or worker_name_prefix.startswith('bg') or worker_name_prefix.startswith('amd'):
-        fqdn = '100.64.100.1'
-    if worker_name_prefix.startswith('p9-rhel'):
-        fqdn = '10.103.203.6'
-    if 'vladbogo' in dockerfile or 'quay' in dockerfile:
-        dockerfile_str = None
-        image_str = dockerfile
-        need_pull = True
-    else:
-        dockerfile_str = open("dockerfiles/" + dockerfile).read()
-        image_str = None
-        need_pull = False
-    if 'rhel' in worker_type and dockerfile_str is not None and not 'download' in dockerfile:
-        dockerfile_str = dockerfile_str % (config["private"]["rhel_sub"]["user"], config["private"]["rhel_sub"]["password"])
-    c['workers'].append(worker.DockerLatentWorker(name, None,
-                        docker_host=config["private"]["docker_workers"][worker_name],
-                        image=image_str,
-                        dockerfile=dockerfile_str,
-                        tls=tls,
-                        autopull=True,
-                        alwaysPull=need_pull,
-                        followStartupLogs=False,
-                        masterFQDN=fqdn,
-                        build_wait_timeout=0,
-                        missing_timeout=600,
-                        max_builds=1,
-                        hostconfig={ 'shm_size':shm_size},
-                        volumes=volumes,
-                        properties={ 'jobs':jobs, 'save_packages':save_packages }))
+    for builder in master_config['builders']:
+        worker_name = w_name[:-1]
+        worker_id = w_name[-1]
 
-
-for w_name in ['hz-bbw', 'intel-bbw', 'amd-bbw']:
-    if w_name.startswith('hz'):
-        jobs = 7
-    else:
-        jobs = 15
-    if w_name == 'hz-bbw':
-        for i in [2, 5]:
-            addWorker(w_name, i, '-debian-sid', 'quay.io/mariadb-foundation/bb-worker:debiansid', jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-debian-sid-i386', 'quay.io/mariadb-foundation/bb-worker:debiansid-386', jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-ubuntu-1804', 'quay.io/mariadb-foundation/bb-worker:ubuntu18.04', jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-sles-12', 'sles-12-download.dockerfile', jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-sles-15', 'sles-15-download.dockerfile', jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-valgrind-ubuntu-1804', "valgrind-ubuntu-1804.dockerfile", jobs=jobs, save_packages=False)
-            addWorker(w_name, i, '-icc-ubuntu-1804', "vladbogo/bb:icc-ubuntu-1804", jobs=jobs, save_packages=False)
-            addWorker(w_name, i, '-rhel-7', 'quay.io/mariadb-foundation/bb-worker:rhel7', jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-ubuntu-2204', "quay.io/mariadb-foundation/bb-worker:ubuntu22.04",jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-opensuse-15', 'opensuse-15.dockerfile', jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-clang-ubuntu-1804', "clang-ubuntu-1804.dockerfile", jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-ubuntu-2004', 'quay.io/mariadb-foundation/bb-worker:ubuntu20.04', jobs=jobs, save_packages=True)
-        for i in [1, 4]:
-            addWorker(w_name, i, '-debian-11', 'quay.io/mariadb-foundation/bb-worker:debian11', jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-fedora-36', 'quay.io/mariadb-foundation/bb-worker:fedora36', jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-rhel-8', 'quay.io/mariadb-foundation/bb-worker:rhel8', jobs=jobs, save_packages=True)
-            addWorker(w_name, i, '-rhel-9', 'quay.io/mariadb-foundation/bb-worker:rhel9', jobs=jobs, save_packages=True)
-
-    if w_name == 'intel-bbw' or w_name == 'amd-bbw':
-        i=1
-        addWorker(w_name, i, '-ubuntu-2004', 'quay.io/mariadb-foundation/bb-worker:ubuntu20.04', jobs=jobs, save_packages=True)
-        addWorker(w_name, i, '-debian-sid', 'quay.io/mariadb-foundation/bb-worker:debiansid', jobs=jobs, save_packages=True)
-        addWorker(w_name, i, '-debian-sid-i386', 'quay.io/mariadb-foundation/bb-worker:debiansid-386', jobs=jobs, save_packages=True)
-        addWorker(w_name, i, '-ubuntu-1804', 'quay.io/mariadb-foundation/bb-worker:ubuntu18.04', jobs=jobs, save_packages=True)
-        addWorker(w_name, i, '-sles-12', 'sles-12-download.dockerfile', jobs=jobs, save_packages=True)
-        addWorker(w_name, i, '-sles-15', 'sles-15-download.dockerfile', jobs=jobs, save_packages=True)
-        addWorker(w_name, i, '-valgrind-ubuntu-1804', "valgrind-ubuntu-1804.dockerfile", jobs=jobs, save_packages=False)
-        addWorker(w_name, i, '-icc-ubuntu-1804', "vladbogo/bb:icc-ubuntu-1804", jobs=jobs, save_packages=False)
-        addWorker(w_name, i, '-rhel-7', 'quay.io/mariadb-foundation/bb-worker:rhel7', jobs=jobs, save_packages=True)
-        addWorker(w_name, i, '-ubuntu-2204', "quay.io/mariadb-foundation/bb-worker:ubuntu22.04", jobs=jobs, save_packages=True)
-        addWorker(w_name, i, '-opensuse-15', 'opensuse-15.dockerfile', jobs=jobs, save_packages=True)
-        addWorker(w_name, i, '-clang-ubuntu-1804', "clang-ubuntu-1804.dockerfile", jobs=jobs, save_packages=True)
-
-## Add Power workers
-for w_name in ['p9-rhel8-bbw', 'p9-rhel7-bbw', 'p9-db-bbw']:
-    jobs = 12
-    addWorker(w_name, 1, '-ubuntu-1804', 'quay.io/mariadb-foundation/bb-worker:ubuntu18.04', jobs=jobs, save_packages=True, shm_size='20G')
-    addWorker(w_name, 1, '-ubuntu-2004', 'quay.io/mariadb-foundation/bb-worker:ubuntu20.04', jobs=jobs, save_packages=True, shm_size='20G')
-    # Disable other workers for Ubuntu 22.04 ppc until MDBF-357 is fixed
-    if w_name == 'p9-rhel8-bbw':
-        addWorker(w_name, 1, '-ubuntu-2204', 'quay.io/mariadb-foundation/bb-worker:ubuntu22.04', jobs=jobs, save_packages=True, shm_size='20G')
-        addWorker(w_name, 1, '-debian-sid', 'quay.io/mariadb-foundation/bb-worker:debiansid', jobs=jobs, save_packages=True, shm_size='20G')
-    addWorker(w_name, 1, '-debian-10', 'quay.io/mariadb-foundation/bb-worker:debian10', jobs=jobs, save_packages=True, shm_size='20G')
-    addWorker(w_name, 1, '-debian-11', 'quay.io/mariadb-foundation/bb-worker:debian11', jobs=jobs, save_packages=True, shm_size='20G')
-    addWorker(w_name, 1, '-clang-ubuntu-2004', 'vladbogo/bb:ppc64le-ubuntu-2004-clang1x',jobs=jobs, save_packages=True, shm_size='20G')
-    addWorker(w_name, 1, '-rhel-8', 'quay.io/mariadb-foundation/bb-worker:rhel8', jobs=jobs, save_packages=True, shm_size='20G')
-    addWorker(w_name, 1, '-rhel-9', 'quay.io/mariadb-foundation/bb-worker:rhel9', jobs=jobs, save_packages=True, shm_size='20G')
-
-## bg-bbw-docker
-for i in range(1,5):
-    if i == 1:
-        jobs = 5
-    else:
-        jobs = 3
-
-    addWorker('bg-bbw', i, '-clang-ubuntu-1804', "clang-ubuntu-1804.dockerfile", jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-msan-clang-ubuntu-2004', "vladbogo/bb:msan-ubuntu-2004-clang-12", jobs=jobs, save_packages=False)
-    addWorker('bg-bbw', i, '-valgrind-ubuntu-1804', "valgrind-ubuntu-1804.dockerfile", jobs=jobs, save_packages=False)
-    addWorker('bg-bbw', i, '-fedora-35', "quay.io/mariadb-foundation/bb-worker:fedora35", jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-fedora-36', "quay.io/mariadb-foundation/bb-worker:fedora36", jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-opensuse-15', "opensuse-15.dockerfile", jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-centos-stream8', "quay.io/mariadb-foundation/bb-worker:centos-stream8", jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-x86-ubuntu-1804', "quay.io/mariadb-foundation/bb-worker:ubuntu18.04-386", jobs=jobs, save_packages=False)
-    addWorker('bg-bbw', i, '-ubuntu-2004', 'quay.io/mariadb-foundation/bb-worker:ubuntu20.04', jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-debian-10', 'quay.io/mariadb-foundation/bb-worker:debian10', jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-rhel-8', 'quay.io/mariadb-foundation/bb-worker:rhel8', jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-rhel-9', 'quay.io/mariadb-foundation/bb-worker:rhel9', jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-centos-7', 'quay.io/mariadb-foundation/bb-worker:centos7', jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-sles-12', 'sles-12-download.dockerfile', jobs=jobs, save_packages=True)
-    addWorker('bg-bbw', i, '-sles-15', 'sles-15-download.dockerfile', jobs=jobs, save_packages=True)
-
-# aarch64-bbw-docker
-for i in range(1, 6):
-    jobs = 4
-    if i == 5:
-        jobs = 25
-    if i == 4:
-        jobs = 8
-
-    if i == 5:
-        addWorker('aarch64-bbw', i, '-debian-11', "quay.io/mariadb-foundation/bb-worker:debian11", jobs=jobs, save_packages=True)
-        addWorker('aarch64-bbw', i, '-debian-sid', "quay.io/mariadb-foundation/bb-worker:debiansid", jobs=jobs, save_packages=True)
-        addWorker('aarch64-bbw', i, '-rhel-8', "quay.io/mariadb-foundation/bb-worker:rhel8", jobs=jobs, save_packages=True)
-        addWorker('aarch64-bbw', i, '-rhel-9', "quay.io/mariadb-foundation/bb-worker:rhel9", jobs=jobs, save_packages=True)
-        addWorker('aarch64-bbw', i, '-fedora-35', "quay.io/mariadb-foundation/bb-worker:fedora35", jobs=jobs, save_packages=True)
-        addWorker('aarch64-bbw', i, '-fedora-36', "quay.io/mariadb-foundation/bb-worker:fedora36", jobs=jobs, save_packages=True)
-        addWorker('aarch64-bbw', i, '-ubuntu-2004', "quay.io/mariadb-foundation/bb-worker:ubuntu20.04", jobs=jobs, save_packages=True)
-        addWorker('aarch64-bbw', i, '-ubuntu-2204', "quay.io/mariadb-foundation/bb-worker:ubuntu22.04", jobs=jobs, save_packages=True)
-
-    if i == 4 or i == 5:
-        addWorker('aarch64-bbw', i, '-debian-10', "quay.io/mariadb-foundation/bb-worker:debian10", jobs=jobs, save_packages=True)
-    else:
-        addWorker('aarch64-bbw', i, '-debian-10', "quay.io/mariadb-foundation/bb-worker:debian10", jobs=jobs, save_packages=True)
-        addWorker('aarch64-bbw', i, '-ubuntu-1804', "quay.io/mariadb-foundation/bb-worker:ubuntu18.04", jobs=jobs, save_packages=True)
-
-    if i == 2 or i == 5:
-        addWorker('aarch64-bbw', i, '-centos-stream8', "quay.io/mariadb-foundation/bb-worker:centos-stream8", jobs=8, save_packages=True)
-
-# add s390x workers
-for i in [1,2,3]:
-    addWorker('s390x-bbw', i, '-ubuntu-2004', "quay.io/mariadb-foundation/bb-worker:ubuntu20.04", jobs=8, save_packages=True)
-    addWorker('s390x-bbw', i, '-ubuntu-2204', "quay.io/mariadb-foundation/bb-worker:ubuntu22.04", jobs=8, save_packages=True)
-    addWorker('s390x-bbw', i, '-rhel-8', "vladbogo/bb:s390x-rhel-8", jobs=8, save_packages=True)
-    addWorker('s390x-bbw', i, '-rhel-9', "quay.io/mariadb-foundation/bb-worker:rhel9", jobs=jobs, save_packages=True)
-    addWorker('s390x-bbw', i, '-sles-15', "vladbogo/bb:s390x-sles-15", jobs=8, save_packages=True)
+        os_name = '-'.join(builder.split('-')[1:])
+        quay_name = 'quay.io/mariadb-foundation/bb-worker:' + ''.join(os_name.split('-'))
+        if builder.startswith('x86'):
+            os_name += '-i386'
+            quay_name += '-i386'
+        addWorker(worker_name, worker_id, '-' + os_name, quay_name, jobs=jobs, save_packages=True)
 
 ####### FACTORY CODE
 
@@ -327,833 +189,53 @@ f_deb_autobake.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2>
 
 c['builders'] = []
 
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804",
-      workernames=workers["x64-bbw-docker-ubuntu-1804"],
-      tags=["Ubuntu", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804-deb-autobake",
-      workernames=workers["x64-bbw-docker-ubuntu-1804"],
-      tags=["Ubuntu", "deb", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-2004",
-      workernames=workers["x64-bbw-docker-ubuntu-2004"],
-      tags=["Ubuntu", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-1804-icc",
-      workernames=workers["x64-bbw-docker-icc-ubuntu-1804"],
-      tags=["Ubuntu", "quick", "icc", "icpc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'c_compiler': 'icc', 'cxx_compiler': 'icpc'},
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-2004-deb-autobake",
-      workernames=workers["bg-bbw-docker-ubuntu-2004"],
-      tags=["Ubuntu", "deb", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="s390x-ubuntu-2004",
-      workernames=workers["s390x-bbw-docker-ubuntu-2004"],
-      tags=["Ubuntu", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="s390x-ubuntu-2004-deb-autobake",
-      workernames=workers["s390x-bbw-docker-ubuntu-2004"],
-      tags=["Ubuntu", "deb", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="s390x-ubuntu-2204",
-      workernames=workers["s390x-bbw-docker-ubuntu-2204"],
-      tags=["Ubuntu", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="s390x-ubuntu-2204-deb-autobake",
-      workernames=workers["s390x-bbw-docker-ubuntu-2204"],
-      tags=["Ubuntu", "deb", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="s390x-rhel-8",
-      workernames=workers["s390x-bbw-docker-rhel-8"],
-      tags=["RHEL", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="s390x-rhel-8-rpm-autobake",
-      workernames=workers["s390x-bbw-docker-rhel-8"],
-      tags=["RHEL", "rpm", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'rhel8'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="s390x-rhel-9",
-      workernames=workers["s390x-bbw-docker-rhel-9"],
-      tags=["RHEL", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="s390x-rhel-9-rpm-autobake",
-      workernames=workers["s390x-bbw-docker-rhel-9"],
-      tags=["RHEL", "rpm", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'rhel9'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="s390x-sles-15",
-      workernames=workers["s390x-bbw-docker-sles-15"],
-      tags=["SLES", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="s390x-sles-15-rpm-autobake",
-      workernames=workers["s390x-bbw-docker-sles-15"],
-      tags=["SLES", "rpm", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'sles15'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-2204",
-      workernames=workers["x64-bbw-docker-ubuntu-2204"],
-      tags=["Ubuntu", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-ubuntu-2204-deb-autobake",
-      workernames=workers["x64-bbw-docker-ubuntu-2204"],
-      tags=["Ubuntu", "deb", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-debian-10-deb-autobake",
-      workernames=workers["bg-bbw-docker-debian-10"],
-      tags=["Debian", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-debian-11",
-      workernames=workers["x64-bbw-docker-debian-11"],
-      tags=["Debian", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-debian-11-deb-autobake",
-      workernames=workers["x64-bbw-docker-debian-11"],
-      tags=["Debian", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-debian-sid",
-      workernames=workers["x64-bbw-docker-debian-sid"],
-      tags=["Debian", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-debian-sid-deb-autobake",
-      workernames=workers["x64-bbw-docker-debian-sid"],
-      tags=["Debian", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="x86-debian-sid",
-      workernames=workers["x64-bbw-docker-debian-sid-i386"],
-      tags=["Debian", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="x86-debian-sid-deb-autobake",
-      workernames=workers["x64-bbw-docker-debian-sid-i386"],
-      tags=["Debian", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-rhel-7",
-      workernames=workers["x64-bbw-docker-rhel-7"],
-      tags=["RHEL", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-rhel-7-rpm-autobake",
-      workernames=workers["x64-bbw-docker-rhel-7"],
-      tags=["RHEL", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'rhel7'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-rhel-8",
-      workernames=workers["x64-bbw-docker-rhel-8"],
-      tags=["RHEL", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-rhel-8-rpm-autobake",
-      workernames=workers["bg-bbw-docker-rhel-8"],
-      tags=["RHEL", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'rhel8'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-rhel-9",
-      workernames=workers["x64-bbw-docker-rhel-9"],
-      tags=["RHEL", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-rhel-9-rpm-autobake",
-      workernames=workers["x64-bbw-docker-rhel-9"],
-      tags=["RHEL", "rpm", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'rhel9'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-fedora-35-rpm-autobake",
-      workernames=workers["bg-bbw-docker-fedora-35"],
-      tags=["Fedora", "rpm", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'fedora35'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-fedora-36",
-      workernames=workers["x64-bbw-docker-fedora-36"],
-      tags=["Fedora", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-fedora-36-rpm-autobake",
-      workernames=workers["bg-bbw-docker-fedora-36"],
-      tags=["Fedora", "rpm", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'fedora36'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-sles-12",
-      workernames=workers["x64-bbw-docker-sles-12"],
-      tags=["Fedora", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-sles-12-rpm-autobake",
-      workernames=workers["x64-bbw-docker-sles-12"],
-      tags=["Fedora", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'sles12'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-sles-15",
-      workernames=workers["x64-bbw-docker-sles-15"],
-      tags=["Fedora", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-sles-15-rpm-autobake",
-      workernames=workers["x64-bbw-docker-sles-15"],
-      tags=["Fedora", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'sles15'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-centos-7-rpm-autobake",
-      workernames=workers["bg-bbw-docker-centos-7"],
-      tags=["Centos", "rpm", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'centos7'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-centos-stream8",
-      workernames=workers["bg-bbw-docker-centos-stream8"],
-      tags=["Centos", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-centos-stream8-rpm-autobake",
-      workernames=workers["bg-bbw-docker-centos-stream8"],
-      tags=["Centos", "rpm", "bake", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'centos8'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-opensuse-15",
-      workernames=workers["x64-bbw-docker-opensuse-15"],
-      tags=["OpenSUSE", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="amd64-opensuse-15-rpm-autobake",
-      workernames=workers["bg-bbw-docker-opensuse-15"],
-      tags=["OpenSUSE", "quick", "gcc"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'opensuse15'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-ubuntu-1804",
-      workernames=workers["p9-bbw-docker-ubuntu-1804"],
-      tags=["Ubuntu", "quick", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-ubuntu-1804-deb-autobake",
-      workernames=workers["p9-bbw-docker-ubuntu-1804"],
-      tags=["Ubuntu", "deb", "bake", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-ubuntu-2004",
-      workernames=workers["p9-bbw-docker-ubuntu-2004"],
-      tags=["Ubuntu", "quick", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-ubuntu-2004-deb-autobake",
-      workernames=workers["p9-bbw-docker-ubuntu-2004"],
-      tags=["Ubuntu", "deb", "bake", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-ubuntu-2204",
-      workernames=workers["p9-bbw-docker-ubuntu-2204"],
-      tags=["Ubuntu", "quick", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-ubuntu-2204-deb-autobake",
-      workernames=workers["p9-bbw-docker-ubuntu-2204"],
-      tags=["Ubuntu", "deb", "bake", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-debian-11",
-      workernames=workers["p9-bbw-docker-debian-11"],
-      tags=["Ubuntu", "quick", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-debian-11-deb-autobake",
-      workernames=workers["p9-bbw-docker-debian-11"],
-      tags=["Ubuntu", "deb", "bake", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-debian-sid",
-      workernames=workers["p9-bbw-docker-debian-sid"],
-      tags=["Ubuntu", "quick", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-debian-sid-deb-autobake",
-      workernames=workers["p9-bbw-docker-debian-sid"],
-      tags=["Ubuntu", "deb", "bake", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-ubuntu-2004-clang1x",
-      workernames=workers["p9-bbw-docker-clang-ubuntu-2004"],
-      tags=["Ubuntu", "quick", "clang-10", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'c_compiler': 'clang-10', 'cxx_compiler': 'clang++-10', 'additional_args': '-DWITHOUT_ROCKSDB=True -DWITHOUT_CONNECT=True -DCMAKE_C_FLAGS=-Wno-inconsistent-missing-override -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override'},
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-rhel-8",
-      workernames=workers["p9-bbw-docker-rhel-8"],
-      tags=["RHEL", "quick", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-rhel-8-rpm-autobake",
-      workernames=workers["p9-bbw-docker-rhel-8"],
-      tags=["RHEL", "quick", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'rhel8'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-rhel-9",
-      workernames=workers["p9-bbw-docker-rhel-9"],
-      tags=["RHEL", "quick", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="ppc64le-rhel-9-rpm-autobake",
-      workernames=workers["p9-bbw-docker-rhel-9"],
-      tags=["RHEL", "quick", "gcc", "pc9"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'rhel8'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="x86-ubuntu-1804",
-      workernames=workers["bg-bbw-docker-x86-ubuntu-1804"],
-      tags=["Ubuntu", "quick", "gcc", "32bit"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-ubuntu-1804",
-      workernames=workers["aarch64-bbw-docker-ubuntu-1804"],
-      tags=["Ubuntu", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-ubuntu-1804-deb-autobake",
-      workernames=workers["aarch64-bbw-docker-ubuntu-1804"],
-      tags=["Ubuntu", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-ubuntu-2004",
-      workernames=workers["aarch64-bbw-docker-ubuntu-2004"],
-      tags=["Ubuntu", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-ubuntu-2004-deb-autobake",
-      workernames=workers["aarch64-bbw-docker-ubuntu-2004"],
-      tags=["Ubuntu", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-ubuntu-2204",
-      workernames=workers["aarch64-bbw-docker-ubuntu-2204"],
-      tags=["Ubuntu", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-ubuntu-2204-deb-autobake",
-      workernames=workers["aarch64-bbw-docker-ubuntu-2204"],
-      tags=["Ubuntu", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-fedora-35",
-      workernames=workers["aarch64-bbw-docker-fedora-35"],
-      tags=["Fedora", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-fedora-35-rpm-autobake",
-      workernames=workers["aarch64-bbw-docker-fedora-35"],
-      tags=["Fedora", "rpm", "bake", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'fedora35'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-fedora-36",
-      workernames=workers["aarch64-bbw-docker-fedora-36"],
-      tags=["Fedora", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-fedora-36-rpm-autobake",
-      workernames=workers["aarch64-bbw-docker-fedora-36"],
-      tags=["Fedora", "rpm", "bake", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'fedora36'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-centos-stream8",
-      workernames=workers["aarch64-bbw-docker-centos-stream8"],
-      tags=["Centos", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-centos-stream8-rpm-autobake",
-      workernames=workers["aarch64-bbw-docker-centos-stream8"],
-      tags=["Centos", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'centos8'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-debian-10",
-      workernames=workers["aarch64-bbw-docker-debian-10"],
-      tags=["Debian", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-debian-10-deb-autobake",
-      workernames=workers["aarch64-bbw-docker-debian-10"],
-      tags=["Debian", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-debian-11",
-      workernames=workers["aarch64-bbw-docker-debian-11"],
-      tags=["Debian", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-debian-11-deb-autobake",
-      workernames=workers["aarch64-bbw-docker-debian-11"],
-      tags=["Debian", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-debian-sid",
-      workernames=workers["aarch64-bbw-docker-debian-sid"],
-      tags=["Debian", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-debian-sid-deb-autobake",
-      workernames=workers["aarch64-bbw-docker-debian-sid"],
-      tags=["Debian", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_deb_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-rhel-8",
-      workernames=workers["aarch64-bbw-docker-rhel-8"],
-      tags=["RHEL", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-rhel-8-rpm-autobake",
-      workernames=workers["aarch64-bbw-docker-rhel-8"],
-      tags=["RHEL", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'rhel8', 'mtr_additional_args': '-DPLUGIN_COLUMNSTORE=NO'},
-      factory=f_rpm_autobake))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-rhel-9",
-      workernames=workers["aarch64-bbw-docker-rhel-9"],
-      tags=["RHEL", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      factory=f_quick_build))
-
-c['builders'].append(
-    util.BuilderConfig(name="aarch64-rhel-9-rpm-autobake",
-      workernames=workers["aarch64-bbw-docker-rhel-9"],
-      tags=["RHEL", "quick", "gcc", "aarch64"],
-      collapseRequests=True,
-      nextBuild=nextBuild,
-      canStartBuild=canStartBuild,
-      locks=getLocks,
-      properties={'rpm_type': 'rhel9', 'mtr_additional_args': '-DPLUGIN_COLUMNSTORE=NO'},
-      factory=f_rpm_autobake))
-
-# Add a Janitor configurator that removes old logs
-c['configurators'] = [util.JanitorConfigurator(
-    logHorizon=timedelta(weeks=6),
-    hour=23
-)]
+for builder in master_config['builders']:
+    splits = builder.split('-')
+    arch = splits[0]
+    os_name = '-'.join(splits[1:])
+
+    mtr_additional_args = None
+    if 'mtr_additional_args' in os_info[os_name]:
+        if arch in os_info[os_name]['mtr_additional_args']:
+            mtr_additional_args = os_info[os_name]['mtr_additional_args'][arch]
+
+    if arch == 'amd64':
+        arch = 'x64'
+    worker_name = arch + '-bbw-docker-' + os_name
+
+    if arch == 'x86':
+        worker_name = 'x64-bbw-docker-' + os_name + '-i386'
+
+    build_type = os_info[os_name]['type']
+
+    c['builders'].append(
+        util.BuilderConfig(name=builder,
+          workernames=workers[worker_name],
+          tags=[os_name],
+          collapseRequests=True,
+          nextBuild=nextBuild,
+          canStartBuild=canStartBuild,
+          locks=getLocks,
+          factory=f_quick_build))
+
+    factory_instance = f_deb_autobake
+    properties = {}
+
+    if mtr_additional_args is not None:
+        properties['mtr_additional_args'] = mtr_additional_args
+    if build_type == 'rpm':
+        properties['rpm_type'] = ''.join(os_name.split('-'))
+        factory_instance = f_rpm_autobake
+    c['builders'].append(
+        util.BuilderConfig(name=builder + "-" + build_type + "-autobake",
+          workernames=workers[worker_name],
+          tags=[os_name, build_type, "autobake"],
+          collapseRequests=True,
+          nextBuild=nextBuild,
+          canStartBuild=canStartBuild,
+          locks=getLocks,
+          properties=properties,
+          factory=factory_instance))
 
 c['logEncoding'] = 'utf-8'
 
@@ -1167,5 +249,3 @@ c['mq'] = {  # Need to enable multimaster aware mq. Wamp is the only option for 
     'wamp_debug_level' : 'info'
 }
 
-#### prometheus exporter //TEMP added Faustin
-c['services'].append(reporters.Prometheus(port=9101))

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -38,6 +38,7 @@ debian-sid:
     - amd64
     - aarch64
     - ppc64le
+    - x86
   type: deb
 fedora-35:
   version_name: 35
@@ -69,6 +70,8 @@ rhel-8:
     - ppc64le
     - s390x
   type: rpm
+  mtr_additional_args:
+    aarch64: -DPLUGIN_COLUMNSTORE=NO
 rhel-9:
   version_name: 9
   arch:
@@ -77,6 +80,8 @@ rhel-9:
     - ppc64le
     - s390x
   type: rpm
+  mtr_additional_args:
+    aarch64: -DPLUGIN_COLUMNSTORE=NO
 sles-12:
   version_name: 12
   arch:
@@ -94,6 +99,7 @@ ubuntu-1804:
     - amd64
     - aarch64
     - ppc64le
+    - x86
   type: deb
 ubuntu-2004:
   version_name: focal

--- a/utils.py
+++ b/utils.py
@@ -49,8 +49,8 @@ def createWorker(worker_name_prefix, worker_id, worker_type, dockerfile, jobs=5,
         b_name = 'x64-bbw'
     elif worker_name_prefix.startswith('intel'):
         b_name = 'x64-bbw'
-    elif worker_name_prefix.startswith('p9'):
-        b_name = 'p9-bbw'
+    elif worker_name_prefix.startswith('ppc64le'):
+        b_name = 'ppc64le-bbw'
     elif worker_name_prefix.startswith('amd'):
         b_name = 'x64-bbw'
     else:


### PR DESCRIPTION
Auto-generate the master configuration based on the os_info.yaml data
and split the builders along multiple master processes.

Steps to generate the config:
1. python define_masters.py

This step creates a series of folders in ./autogen/* each corresponding
to a different master process.