### PR TITLE
WIP: Add FlawFinder Job

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -196,6 +196,16 @@ c['workers'].append(worker.DockerLatentWorker("bm-bbw1-docker-ubuntu-1804", None
                     volumes=['/srv/buildbot/ccache:/mnt/ccache', '/mnt/autofs/master_packages:/packages'],
                     properties={ 'jobs': 2, 'save_packages':False }))
 
+## flawfinder
+c['workers'].append(worker.DockerLatentWorker("flawfinder-worker", None,
+                    docker_host=config["private"]["docker_workers"]["flawfinder"],
+                    dockerfile=open("fedora-33.dockerfile").read(),
+                    followStartupLogs=False,
+                    masterFQDN='buildbot.mariadb.org',
+                    hostconfig={ 'shm_size':'6G' },
+                    build_wait_timeout=0,
+                    max_builds=1,
+                    properties={ 'jobs':1, 'save_packages':False }))
 
 ## Add Power workers
 for w_name in ['ppc64le-rhel7-bbw']:
@@ -416,6 +426,27 @@ f_eco_mysqljs.addStep(steps.ShellCommand(
     name="test mysqljs-v2.18.1",
     command=["sh", "-xc", "/buildbot/test-mysqljs.sh v2.18.1"]))
 
+## flawfinder
+f_flawfinder = util.BuildFactory()
+f_flawfinder.addStep(steps.ShellCommand(
+    name="yum install",
+    command=["sh", "-xc", "yum install -y python3 python3-pip jq diffutils"]))
+f_flawfinder.addStep(steps.ShellCommand(
+    name="install flawfinder",
+    command=["sh", "-xc", "pip install flawfinder"]))
+f_flawfinder.addStep(steps.ShellCommand(
+    name="show all flawfinder vulnerabilities",
+    command=["sh", "-xc", "flawfinder --falsepositive --quiet --html ."]))
+f_flawfinder.addStep(steps.ShellCommand(
+    name="output flawfinder to json",
+    command=["sh", "-xc", "flawfinder --falsepositive --quiet --minlevel=5 --sarif . > flawfinder-output.json"]))
+f_flawfinder.addStep(steps.ShellCommand(
+    name="filter and sort vulnerabilities",
+    command=["sh", "-xc", "jq 'del(.runs[] | .tool | .driver | .rules) | del(.runs[] | .results[] | select(.rank < 1)) | .runs[0].results|=sort_by(.fingerprints)' flawfinder-output.json > flawfinder-min-level5.json"]))
+f_flawfinder.addStep(steps.ShellCommand(
+    name="screen against ignorelist for new vulnerabilities",
+    command=["sh", "-xc", "diff flawfinder-min-level5.json flawfinder-ignorelist.json"])) 
+
 ####### BUILDERS LIST
 
 c['builders'] = []
@@ -577,6 +608,16 @@ c['builders'].append(
       canStartBuild=canStartBuild,
       locks=getLocks,
       factory=f_valgrind_build))
+
+c['builders'].append(
+    util.BuilderConfig(name="flawfinder",
+      workernames=workers["flawfinder-worker"],
+      tags=["SAST", "flawfinder"],
+      collapseRequests=True,
+      nextBuild=nextBuild,
+      canStartBuild=canStartBuild,
+      locks=getLocks,
+      factory=f_flawfinder))
 
 c['logEncoding'] = 'utf-8'
 


### PR DESCRIPTION
WIP / UNTESTED:

In order to enforce the rules of FlawFinder and to ensure that no new high-level vulnerabilities are added, this job must be present in both GitLab CI and BuildBot. However, as a result of the high barrier to entry and the infrastructure required for BuildBot, getting a local instance running to test these changes was not possible. This new job was added by following the pattern of builders, workers and factories present in the existing jobs of BuildBot.

Initial PR and discussion regarding adding FlawFinder job to GitLab CI [here](https://github.com/MariaDB/server/pull/2175).

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.