### PR TITLE
RHEL9 does not need to be 5.5/10.1 compat

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -289,7 +289,8 @@ def hasCompat(step):
     # For s390x there are no compat files
     if 's390x' in builderName:
         return False
-    return True
+    # Not needed for RHEL/Centos9 onwards
+    return util.Property('rpm_type')[-1] in ['7', '8']
 
 @util.renderer
 def getDockerLibraryNames(props):


### PR DESCRIPTION
5.5/ 10.1 shouldn't be a compat issue thanks Elena. And there's no package so lets not make the autobake install fail.