### PR TITLE
Do not setup galera repo if absent from mirror

### DIFF
--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -64,12 +64,17 @@ sudo yum search mysql | { grep "^mysql" || true; }
 sudo yum search maria | { grep "^maria" || true; }
 sudo yum search percona | { grep percona || true; }
 
-# setup repository
+# setup repository for galera dependency
 if wget -q --spider https://rpm.mariadb.org/"$master_branch/$arch"; then
   galbranch=$master_branch
 else
   # as long as the galera major version maps this is ok
   galbranch=10.8
+  if ! wget -q --spider https://rpm.mariadb.org/"$galbranch/$arch"; then
+    bb_log_err "https://rpm.mariadb.org/$galbranch/$arch does not exist"
+    bb_log_err "unable to setup repository for galera"
+    exit 1
+  fi
 fi
 sudo sh -c "echo '[galera]
 name=galera


### PR DESCRIPTION
Error is:
Errors during downloading metadata for repository 'galera':
  - Status code: 404 for
    https://mirror.mariadb.org/yum/10.8/centosstream8-amd64/repodata/repomd.xml
    (IP: 162.55.42.214)

Error: Failed to download metadata for repo 'galera': Cannot download
repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried