### PR TITLE
Jemalloc-devel is missing from centosstream8 image

### DIFF
--- a/ci_build_images/centos.Dockerfile
+++ b/ci_build_images/centos.Dockerfile
@@ -38,6 +38,7 @@ RUN source /etc/os-release \
     curl-devel \
     java-1.8.0-openjdk \
     java-1.8.0-openjdk-devel \
+    jemalloc-devel \
     libcurl-devel \
     libevent-devel \
     libffi-devel \


### PR DESCRIPTION
See:
https://buildbot.mariadb.org/#/builders/359/builds/954

```console
-- Looking for malloc_stats_print in c - not found
CMake Error at cmake/jemalloc.cmake:38 (MESSAGE):
  jemalloc is not found
Call Stack (most recent call first):
  storage/tokudb/CMakeLists.txt:53 (CHECK_JEMALLOC)
```

For some reason this error only appears on AMD64