### PR TITLE
RHEL 9/CentOS 9 does not need to be 5.5/10.1 compat

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -289,6 +289,8 @@ def hasCompat(step):
     # For s390x there are no compat files
     if 's390x' in builderName:
         return False
+    if 'rhel' in builderName or 'centos' in builderName:
+        return util.Property('rpm_type')[-1] in ['7', '8']
     return True
 
 @util.renderer


### PR DESCRIPTION
@grooverdan not sure if it's the best approach, but I have no other idea