### PR TITLE
Do not add install/upgrade builds for unreleased OS

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -69,8 +69,10 @@ for os in os_info:
         builder_name_autobake = arch + '-' + os + '-' + os_info[os]['type'] + '-autobake'
         builders_autobake.append(builder_name_autobake)
         # Currently there are no VMs for x86 and s390x and OpenSUSE and SLES
-        # RHEL-9 is unreleased, so until packages are available skip install/upgrade
-        if arch not in ['s390x', 'x86'] and os not in ['opensuse-15', 'rhel-9', 'sles-12', 'sles-15']:
+        addInstall = True
+        if 'has_install' in os_info[os]:
+            addInstall = os_info[os]['has_install']
+        if arch not in ['s390x', 'x86'] and addInstall:
             builders_install.append(builder_name_autobake + '-install')
             builders_upgrade.append(builder_name_autobake + '-minor-upgrade')
             builders_upgrade.append(builder_name_autobake + '-major-upgrade')

--- a/master-libvirt/get_ssh_cnx_num.py
+++ b/master-libvirt/get_ssh_cnx_num.py
@@ -8,7 +8,10 @@ with open('../os_info.yaml', 'r') as f:
 SSH_CONNECTIONS = 0
 for os in os_info:
     for arch in os_info[os]['arch']:
-        if arch not in ['s390x', 'x86'] and os not in ['opensuse-15', 'rhel-9', 'sles-12', 'sles-15']:
+        addInstall = True
+        if 'has_install' in os_info[os]:
+            addInstall = os_info[os]['has_install']
+        if arch not in ['s390x', 'x86'] and addInstall:
             SSH_CONNECTIONS += 1
 
 print(SSH_CONNECTIONS)

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -11,6 +11,7 @@ centos-stream8:
     - aarch64
     - ppc64le
   type: rpm
+  has_install: False
 centos-stream9:
   version_name: 9
   arch:
@@ -18,6 +19,7 @@ centos-stream9:
     - aarch64
     - ppc64le
   type: rpm
+  has_install: False
 debian-10:
   version_name: buster
   arch:
@@ -57,6 +59,7 @@ opensuse-15:
   arch:
     - amd64
   type: rpm
+  has_install: False
 rhel-7:
   version_name: 7
   arch:
@@ -82,17 +85,20 @@ rhel-9:
   type: rpm
   mtr_additional_args:
     aarch64: -DPLUGIN_COLUMNSTORE=NO
+  has_install: False
 sles-12:
   version_name: 12
   arch:
     - amd64
   type: rpm
+  has_install: False
 sles-15:
   version_name: 15
   arch:
     - amd64
     - s390x
   type: rpm
+  has_install: False
 ubuntu-1804:
   version_name: bionic
   arch:


### PR DESCRIPTION
Add a new flag to os_info.yaml that indicates that the addition on
install/upgrade builds should be skipped or not. This needs to be used
for unreleased operating systems.