### PR TITLE
qpress: some files from /etc may not be readable

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -200,7 +200,7 @@ jobs:
             docker pull -q --platform "$platform" "$image"
             docker run -i "$image" buildbot-worker --version
             docker run -i "$image" dumb-init twistd --pidfile= -y /home/buildbot/buildbot.tac
-            docker run -u root -i "$image" qpress -r /etc /tmp/qpress.qp
+            docker run -u root -i "$image" bash -c "touch /tmp/foo && qpress -r /tmp /root/qpress.qp"
           done
       - name: Check for registry credentials
         if: >


### PR DESCRIPTION
Error was on rhel7:
| qpress: Error opening source file '/etc/system-fips' - aborted

or on centos7:
| qpress: Error opening source file '/etc/alternatives/jstat.1.gz' - aborted