### PR TITLE
[MDBF-445] Add clang to CI pipeline. Build CI Ubuntu images with Clang

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -85,7 +85,7 @@ jobs:
             image: ubuntu:22.04
             branch: 10.7
             tag: ubuntu22.04-clang
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
+            platforms: linux/amd64, linux/arm64/v8, linux/s390x
           - dockerfile: debian.Dockerfile
             image: ubuntu:22.10
             branch: 10.7

--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -58,13 +58,33 @@ jobs:
             branch: 10.7
             tag: ubuntu18.04-386
             platforms: linux/386
+          - dockerfile: debian.Dockerfile clang.Dockerfile
+            image: ubuntu:18.04
+            branch: 10.7
+            tag: ubuntu18.04-clang
+            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
+          - dockerfile: debian.Dockerfile clang.Dockerfile
+            image: ubuntu:18.04
+            branch: 10.7
+            tag: ubuntu18.04-386-clang
+            platforms: linux/386
           - dockerfile: debian.Dockerfile
             image: ubuntu:20.04
             branch: 10.7
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
+          - dockerfile: debian.Dockerfile clang.Dockerfile
+            image: ubuntu:20.04
+            branch: 10.7
+            tag: ubuntu20.04-clang
+            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
           - dockerfile: debian.Dockerfile
             image: ubuntu:22.04
             branch: 10.7
+            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
+          - dockerfile: debian.Dockerfile clang.Dockerfile
+            image: ubuntu:22.04
+            branch: 10.7
+            tag: ubuntu22.04-clang
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
           - dockerfile: debian.Dockerfile
             image: ubuntu:22.10

--- a/ci_build_images/clang.Dockerfile
+++ b/ci_build_images/clang.Dockerfile
@@ -4,8 +4,16 @@ RUN . /etc/os-release \
         18.04*) \
           apt-get -y install --no-install-recommends clang-10; \
           ;; \
-        *) \
+        20.04*) \
           apt-get -y install --no-install-recommends clang-11; \
+          ;; \
+        *) \
+          curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | \
+            gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/llvm-snapshot.gpg] \
+            http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" > /etc/apt/sources.list.d/llvm-toolchain.list \
+          && apt-get update \
+          && apt-get -y install --no-install-recommends clang-15; \
           ;; \
     esac \
     && apt-get clean

--- a/ci_build_images/clang.Dockerfile
+++ b/ci_build_images/clang.Dockerfile
@@ -1,0 +1,11 @@
+# this is to create images with Clang compiler for BB workers
+RUN . /etc/os-release \
+    && case "$VERSION" in \
+        18.04*) \
+          apt-get -y install --no-install-recommends clang-10; \
+          ;; \
+        *) \
+          apt-get -y install --no-install-recommends clang-11; \
+          ;; \
+    esac \
+    && apt-get clean


### PR DESCRIPTION
To be able to compile MariaDB during CI using Clang compiler.