### PR TITLE
docker library: save_packages True for worker

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -107,7 +107,7 @@ aix_worker = mkWorker("aix-worker", properties={'jobs': 12})
 c['workers'].append(aix_worker)
 
 # Docker Library
-dockerlibrary_worker = mkWorker("bb-rhel8-docker", properties={'jobs': 1})
+dockerlibrary_worker = mkWorker("bb-rhel8-docker", properties={'jobs': 1, 'save_packages': True})
 c['workers'].append(dockerlibrary_worker)
 
 ## windows-bbw1-docker


### PR DESCRIPTION
This is needed for the savePackage step to be true and the manifest to be generated for the worker.