### PR TITLE
wordpress cleanup

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -215,7 +215,7 @@ f_wordpress.addStep(steps.ShellCommand(
     alwaysRun=True))
 f_wordpress.addStep(steps.ShellCommand(
     name="cleanup test image",
-    command=["buildah", "rmi", util.Interpolate("mariadb-%(prop:tarbuildnum)s-amd64-wordpress")],
+    command=["podman", "untag", util.Interpolate("mariadb-%(prop:tarbuildnum)s-amd64-wordpress")],
     alwaysRun=True))
 
 # f_dockerlibrary


### PR DESCRIPTION
buildah rmi was incorrect and created errors where there image is used in a manifest.

buildah rmi mariadb-28609-amd64-wordpress
 in dir /home/buildbot/amd64-rhel8-wordpress/build (timeout 1200 secs)
....
1 error occurred:
	* Image used by 559e7e0431b04f9dbf41cd9491a477eb35a3166b1ea98ee29733a6fff986cd09: image is in use by a container

As the mariadb-X-amd64-wordpress image is created with `podman tag` it can be removed with `podman untag`.

Tested with podman version on server:
```
[dan@bb-rhel8-docker ~]$ podman  tag quay.io/mariadb-foundation/mariadb-devel:10.6 quay.io/mariadb-foundation/mariadb-devel:10.6a
[dan@bb-rhel8-docker ~]$ podman untag quay.io/mariadb-foundation/mariadb-devel:10.6a
```