### PR TITLE
Check branch name and MariaDB version

### DIFF
--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -176,6 +176,17 @@ f_tarball.addStep(steps.Compile(command=["cmake","../server"], workdir='build/mk
 f_tarball.addStep(steps.Compile(command=["make", "dist"], workdir='build/mkdist', description="make dist"))
 f_tarball.addStep(steps.SetPropertyFromCommand(property="mariadb_version", command="basename mariadb-*.tar.gz .tar.gz", workdir="build/mkdist"))
 f_tarball.addStep(steps.SetPropertyFromCommand(property="master_branch", command=util.Interpolate("echo " + "%(prop:mariadb_version)s" + " | cut -d'-' -f 2 | cut -d'.' -f 1,2")))
+f_tarball.addStep(steps.ShellCommand(name="Check branch version", command=['bash', '-c',
+    util.Interpolate('''
+        master_branch='\<%(prop:master_branch)s\>'
+        if [[ "%(prop:branch)s" =~ $master_branch ]]; then
+            exit 0
+        else
+            echo "Package VERSION and branch name differs"
+            exit 1
+        fi
+        ''')
+]))
 f_tarball.addStep(steps.ShellCommand(command=util.Interpolate("mkdir -p %(prop:buildnumber)s/logs"), workdir="build/mkdist"))
 f_tarball.addStep(steps.ShellCommand(command=util.Interpolate("sha256sum %(prop:mariadb_version)s" + ".tar.gz >> " + " %(prop:buildnumber)s" + "/sha256sums.txt" + " && mv %(prop:mariadb_version)s" +".tar.gz" + " %(prop:buildnumber)s"), workdir="build/mkdist"))
 f_tarball.addStep(steps.SetPropertyFromCommand(command="ls -1 *.tar.gz", extract_fn=ls2list, workdir=util.Interpolate("build/mkdist/" + "%(prop:buildnumber)s")))


### PR DESCRIPTION
Checks performed on dev

https://buildbot.dev.mariadb.org/#/builders/1/builds/2
https://buildbot.dev.mariadb.org/#/builders/1/builds/1

Currently the builds are not stopped if an error for this check occurs, but the tarball builder will be red (see https://buildbot.dev.mariadb.org/#/builders/1/builds/1)
