### PR TITLE
rpm-autobake factory - no sha256sums.txt file generated

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -89,7 +89,7 @@ def getRpmAutobakeFactory(mtrDbPool):
         haltOnFailure=True,
         command=util.Interpolate(
             'mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+
-            ' && cp -r rpms srpms sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +
+            ' && cp -r rpms srpms' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +
             ' && sync /packages/' + '%(prop:tarbuildnum)s'
             ),
         doStepIf=lambda step: hasFiles(step) and savePackage(step),


### PR DESCRIPTION
This was removed in #74 / 54d17d4682c2f51cc9e12c1aed99917316b29146.