### PR TITLE
Use podman commands instead of GH action

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -19,9 +19,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-        # this is needed because we restart the docker daemon for experimental
-        # support
-        options: "--restart always"
     name: ${{ matrix.image }} (${{ matrix.tag }} ${{ matrix.platforms }})
     strategy:
       fail-fast: false
@@ -124,11 +121,12 @@ jobs:
             exit 1
           }
           if [[ -n "${{ matrix.tag }}" ]]; then
-            echo "TAG=${{ matrix.tag }}" >>$GITHUB_ENV
+            echo "IMG=${{ matrix.tag }}" >>$GITHUB_ENV
           else
             TAG_TMP=${{ matrix.image }}
-            echo "TAG=${TAG_TMP/:/}" >>$GITHUB_ENV
+            echo "IMG=${TAG_TMP/:/}" >>$GITHUB_ENV
           fi
+          echo "REPO=bb-worker" >>$GITHUB_ENV
       - name: Check for rhel subscription credentials
         if: >
           (contains(matrix.dockerfile, 'rhel')) &&
@@ -142,24 +140,6 @@ jobs:
           done
           (( ${#missing[@]} == 0 )) || exit 1
           echo "BUILD_RHEL=true" >> $GITHUB_ENV
-      - name: Enable experimental support
-        run: |
-          config='/etc/docker/daemon.json'
-          if [[ -e "$config" ]]; then
-            sudo sed -i -e 's/{/{ "experimental": true, /' "$config"
-          else
-            echo '{ "experimental": true }' | sudo tee "$config"
-          fi
-          sudo systemctl restart docker
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx (local builds)
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
-          # config-inline: |
-          #   [worker.oci]
-          #     max-parallelism = 3
       - name: Generate Dockerfile and necessary files
         run: |
           cd ${{ env.WORKDIR }}
@@ -169,39 +149,60 @@ jobs:
         run: |
           cp /home/runner/work/Dockerfile .
           docker run -i -v $(pwd):/mnt -w /mnt hadolint/hadolint:latest hadolint /mnt/Dockerfile
+      - name: Install qemu-user-static
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
       - name: Build image
         if: (!contains(matrix.dockerfile, 'rhel'))
-        uses: docker/build-push-action@v2
-        with:
-          build-args: |
-            base_image=${{ matrix.image }}
-            mariadb_branch=${{ matrix.branch }}
-          context: /home/runner/work
-          file: /home/runner/work/Dockerfile
-          platforms: ${{ matrix.platforms }}
-          push: true
-          tags: localhost:5000/test/bb-worker:${{ env.TAG }}
+        run: |
+          podman manifest create ${{ env.REPO }}:${{ env.IMG }}
+          for arch in $(echo ${{ matrix.platforms }} | sed 's/,/ /g'); do
+            msg="Build $arch:"
+            line="${msg//?/=}"
+            printf "\n${line}\n${msg}\n${line}\n"
+            podman buildx build --tag ${{ env.REPO }}:${{ env.IMG }}-${arch//\//-} \
+              --platform $arch \
+              --manifest ${{ env.REPO }}:${{ env.IMG }} \
+              -f /home/runner/work/Dockerfile \
+              --build-arg base_image=${{ matrix.image }} \
+              --build-arg mariadb_branch=${{ matrix.branch }}
+          done
+          podman images
       - name: Build image (rhel)
         if: ${{ env.BUILD_RHEL == 'true' }}
-        uses: docker/build-push-action@v2
-        with:
-          build-args: |
-            base_image=${{ matrix.image }}
-            mariadb_branch=${{ matrix.branch }}
-          secrets: |
-            "rhel_orgid=${{ secrets.RHEL_ORGID }}"
-            "rhel_keyname=${{ secrets.RHEL_KEYNAME }}"
-          context: /home/runner/work
-          file: /home/runner/work/Dockerfile
-          platforms: ${{ matrix.platforms }}
-          push: true
-          tags: localhost:5000/test/bb-worker:${{ env.TAG }}
+        run: |
+          podman manifest create ${{ env.REPO }}:${{ env.IMG }}
+          for arch in $(echo ${{ matrix.platforms }} | sed 's/,/ /g'); do
+            msg="Build $arch:"
+            line="${msg//?/=}"
+            printf "\n${line}\n${msg}\n${line}\n"
+            podman buildx build --tag ${{ env.REPO }}:${{ env.IMG }}-${arch//\//-} \
+              --platform $arch \
+              --manifest ${{ env.REPO }}:${{ env.IMG }} \
+              -f /home/runner/work/Dockerfile \
+              --build-arg base_image=${{ matrix.image }} \
+              --build-arg mariadb_branch=${{ matrix.branch }}
+          done
+          podman images
+      - name: Push images to local registry
+        if: (!contains(matrix.dockerfile, 'rhel'))
+        run: |
+          podman manifest push --tls-verify=0 \
+            --all ${{ env.REPO }}:${{ env.IMG }} \
+            docker://localhost:5000/${{ env.REPO }}:${{ env.IMG }}
+      - name: Push images to local registry (rhel)
+        if: ${{ env.BUILD_RHEL == 'true' }}
+        run: |
+          podman manifest push --tls-verify=0 \
+            --all ${{ env.REPO }}:${{ env.IMG }} \
+            docker://localhost:5000/${{ env.REPO }}:${{ env.IMG }}
       - name: Check multi-arch container
         if: (!contains(matrix.dockerfile, 'rhel'))
         run: |
           for p in ${{ matrix.platforms }}; do
             platform="${p/,/}"
-            image="localhost:5000/test/bb-worker:${{ env.TAG }}"
+            image="localhost:5000/bb-worker:${{ env.IMG }}"
             msg="Testing docker image $image on platform $platform"
             line="${msg//?/=}"
             printf "\n${line}\n${msg}\n${line}\n"
@@ -215,7 +216,7 @@ jobs:
         run: |
           for p in ${{ matrix.platforms }}; do
             platform="${p/,/}"
-            image="localhost:5000/test/bb-worker:${{ env.TAG }}"
+            image="localhost:5000/bb-worker:${{ env.IMG }}"
             msg="Testing docker image $image on platform $platform"
             line="${msg//?/=}"
             printf "\n${line}\n${msg}\n${line}\n"
@@ -250,9 +251,9 @@ jobs:
       - name: Push images to registry
         if: ${{ env.DEPLOY_IMAGES == 'true' }}
         run: |
-          msg="Push docker image to registry (${{ env.TAG }})"
+          msg="Push docker image to registry (${{ env.IMG }})"
           line="${msg//?/=}"
           printf "\n${line}\n${msg}\n${line}\n"
           skopeo copy --all --src-tls-verify=0 \
-          docker://localhost:5000/test/bb-worker:${{ env.TAG }} \
-          docker://quay.io/mariadb-foundation/bb-worker:${{ env.TAG }}
+          docker://localhost:5000/bb-worker:${{ env.IMG }} \
+          docker://quay.io/mariadb-foundation/bb-worker:${{ env.IMG }}

--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -24,88 +24,88 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dockerfile: debian.Dockerfile
-            image: debian:10
-            branch: 10.7
-            platforms: linux/amd64, linux/arm64/v8
-          - dockerfile: debian.Dockerfile
-            image: debian:11
-            branch: 10.7
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
-          - dockerfile: debian.Dockerfile aocc.Dockerfile
-            image: debian:11
-            tag: debian11-aocc
-            branch: 10.7
-            platforms: linux/amd64
-          - dockerfile: debian.Dockerfile
-            image: debian:sid
-            branch: 10.7
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
-          - dockerfile: debian.Dockerfile
-            image: debian:sid
-            tag: debiansid-386
-            branch: 10.7
-            platforms: linux/386
-          - dockerfile: debian.Dockerfile
-            image: ubuntu:18.04
-            branch: 10.7
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
-          - dockerfile: debian.Dockerfile
-            image: ubuntu:18.04
-            branch: 10.7
-            tag: ubuntu18.04-386
-            platforms: linux/386
-          - dockerfile: debian.Dockerfile
-            image: ubuntu:20.04
-            branch: 10.7
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-          - dockerfile: debian.Dockerfile
-            image: ubuntu:22.04
-            branch: 10.7
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-          - dockerfile: debian.Dockerfile
-            image: ubuntu:22.10
-            branch: 10.7
-            platforms: linux/amd64, linux/arm64/v8
+          # - dockerfile: debian.Dockerfile
+          #   image: debian:10
+          #   branch: 10.7
+          #   platforms: linux/amd64, linux/arm64/v8
+          # - dockerfile: debian.Dockerfile
+          #   image: debian:11
+          #   branch: 10.7
+          #   platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
+          # - dockerfile: debian.Dockerfile aocc.Dockerfile
+          #   image: debian:11
+          #   tag: debian11-aocc
+          #   branch: 10.7
+          #   platforms: linux/amd64
+          # - dockerfile: debian.Dockerfile
+          #   image: debian:sid
+          #   branch: 10.7
+          #   platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
+          # - dockerfile: debian.Dockerfile
+          #   image: debian:sid
+          #   tag: debiansid-386
+          #   branch: 10.7
+          #   platforms: linux/386
+          # - dockerfile: debian.Dockerfile
+          #   image: ubuntu:18.04
+          #   branch: 10.7
+          #   platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
+          # - dockerfile: debian.Dockerfile
+          #   image: ubuntu:18.04
+          #   branch: 10.7
+          #   tag: ubuntu18.04-386
+          #   platforms: linux/386
+          # - dockerfile: debian.Dockerfile
+          #   image: ubuntu:20.04
+          #   branch: 10.7
+          #   platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
+          # - dockerfile: debian.Dockerfile
+          #   image: ubuntu:22.04
+          #   branch: 10.7
+          #   platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
+          # - dockerfile: debian.Dockerfile
+          #   image: ubuntu:22.10
+          #   branch: 10.7
+          #   platforms: linux/amd64, linux/arm64/v8
           - dockerfile: debian.Dockerfile
             image: ubuntu:23.04
             branch: 10.11
             platforms: linux/amd64, linux/arm64/v8
-          - dockerfile: fedora.Dockerfile
-            image: fedora:36
-            platforms: linux/amd64, linux/arm64/v8
+          # - dockerfile: fedora.Dockerfile
+          #   image: fedora:36
+          #   platforms: linux/amd64, linux/arm64/v8
           - dockerfile: fedora.Dockerfile
             image: fedora:37
             platforms: linux/amd64, linux/arm64/v8
-          - dockerfile: centos7.Dockerfile pip.Dockerfile
-            image: centos:7
-            platforms: linux/amd64
-          - dockerfile: centos.Dockerfile
-            image: quay.io/centos/centos:stream8
-            tag: centosstream8
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
-          - dockerfile: centos.Dockerfile pip.Dockerfile
-            image: quay.io/centos/centos:stream9
-            tag: centosstream9
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
-            # //TEMP Error: Unable to find a match: ccache python3-scons (on
-            # s390x)
-            # platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-          - dockerfile: rhel7.Dockerfile pip.Dockerfile
-            image: rhel7
-            platforms: linux/amd64
-          - dockerfile: rhel.Dockerfile
-            image: ubi8
-            tag: rhel8
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-          - dockerfile: rhel.Dockerfile pip.Dockerfile
-            image: ubi9
-            tag: rhel9
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-          - dockerfile: opensuse.Dockerfile pip.Dockerfile
-            image: opensuse/leap:15.3
-            tag: opensuse15
-            platforms: linux/amd64
+          # - dockerfile: centos7.Dockerfile pip.Dockerfile
+          #   image: centos:7
+          #   platforms: linux/amd64
+          # - dockerfile: centos.Dockerfile
+          #   image: quay.io/centos/centos:stream8
+          #   tag: centosstream8
+          #   platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
+          # - dockerfile: centos.Dockerfile pip.Dockerfile
+          #   image: quay.io/centos/centos:stream9
+          #   tag: centosstream9
+          #   platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
+          #   # //TEMP Error: Unable to find a match: ccache python3-scons (on
+          #   # s390x)
+          #   # platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
+          # - dockerfile: rhel7.Dockerfile pip.Dockerfile
+          #   image: rhel7
+          #   platforms: linux/amd64
+          # - dockerfile: rhel.Dockerfile
+          #   image: ubi8
+          #   tag: rhel8
+          #   platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
+          # - dockerfile: rhel.Dockerfile pip.Dockerfile
+          #   image: ubi9
+          #   tag: rhel9
+          #   platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
+          # - dockerfile: opensuse.Dockerfile pip.Dockerfile
+          #   image: opensuse/leap:15.3
+          #   tag: opensuse15
+          #   platforms: linux/amd64
     env:
       BUILD_RHEL: false
       DEPLOY_IMAGES: false

--- a/.github/workflows/bbm_build_container.yml
+++ b/.github/workflows/bbm_build_container.yml
@@ -26,31 +26,28 @@ jobs:
       - name: Check Dockerfile with hadolint
         run: |
           docker run -i -v $(pwd):/mnt -w /mnt hadolint/hadolint:latest hadolint /mnt/Dockerfile
-      - name: Create empty context
+      - name: Set up env vars
         run: |
-          # //TEMP there is probably a better way to not include context
-          mkdir empty
+          echo "REPO=bb-master" >>$GITHUB_ENV
       - name: Build master image
-        uses: docker/build-push-action@v2
-        with:
-          context: /home/runner/work/buildbot/buildbot/empty
-          file: /home/runner/work/buildbot/buildbot/Dockerfile
-          push: true
-          tags: localhost:5000/test/bb-master:master
+        run: |
+            podman build . --tag ${{ env.REPO }}:master
       - name: Build master-web image
-        uses: docker/build-push-action@v2
-        with:
-          context: /home/runner/work/buildbot/buildbot/empty
-          build-args: |
-            master_type=master-web
-          file: /home/runner/work/buildbot/buildbot/Dockerfile
-          push: true
-          tags: localhost:5000/test/bb-master:master-web
+        run: |
+            podman build . --tag ${{ env.REPO }}:master-web \
+              --build-arg master_type=master-web
+      - name: Push images to local registry
+        run: |
+          for img in master master-web; do
+            podman push --tls-verify=0 \
+              ${{ env.REPO }}:$img \
+              docker://localhost:5000/${{ env.REPO }}:$img
+          done
       - name: Check images
         run: |
-          docker run -i localhost:5000/test/bb-master:master buildbot --version
+          docker run -i localhost:5000/${{ env.REPO }}:master buildbot --version
           #//TEMP there is probably a better way for master-web here
-          docker run -i localhost:5000/test/bb-master:master-web buildbot --version
+          docker run -i localhost:5000/${{ env.REPO }}:master-web buildbot --version
       - name: Check for registry credentials
         if: >
           github.ref == 'refs/heads/main' &&
@@ -82,6 +79,6 @@ jobs:
           printf "\n${line}\n${msg}\n${line}\n"
           for image in master master-web; do
             skopeo copy --all --src-tls-verify=0 \
-            docker://localhost:5000/test/bb-master:${image} \
-            docker://quay.io/mariadb-foundation/bb-master:${image}
+            docker://localhost:5000/${{ env.REPO }}:${image} \
+            docker://quay.io/mariadb-foundation/${{ env.REPO }}:${image}
           done


### PR DESCRIPTION
This remove adherence to GH CI and make image generation less obscure. The fact that images are created in a serial order by platform should also help to find which platform is not building and help debugging.