### PR TITLE
MDBF-337: add galera package to builders

### DIFF
--- a/ci_build_images/centos.Dockerfile
+++ b/ci_build_images/centos.Dockerfile
@@ -37,6 +37,7 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     cracklib-devel \
     createrepo \
     curl-devel \
+    galera \
     java-1.8.0-openjdk \
     java-1.8.0-openjdk-devel \
     jemalloc-devel \
@@ -62,3 +63,5 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     # dumb-init rpm is not available on centos (official repo) \
     && curl -sL "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_$(uname -m)" >/usr/local/bin/dumb-init \
     && chmod +x /usr/local/bin/dumb-init
+
+ENV WSREP_PROVIDER=/usr/lib64/galera/libgalera_smm.so

--- a/ci_build_images/centos7.Dockerfile
+++ b/ci_build_images/centos7.Dockerfile
@@ -23,6 +23,7 @@ RUN yum -y --enablerepo=extras install epel-release \
     cracklib-devel \
     createrepo \
     curl-devel \
+    galera \
     gnutls-devel \
     java-1.8.0-openjdk \
     java-1.8.0-openjdk-devel \
@@ -55,3 +56,5 @@ RUN yum -y --enablerepo=extras install epel-release \
     # dumb-init rpm is not available on centos
     && curl -sL "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_$(uname -m)" >/usr/local/bin/dumb-init \
     && chmod +x /usr/local/bin/dumb-init
+
+ENV WSREP_PROVIDER=/usr/lib64/galera/libgalera_smm.so

--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -56,6 +56,9 @@ RUN apt-get update \
     scons \
     sudo  \
     wget \
+    && if ! grep -qE 'bionic|buster' /etc/apt/sources.list; then \
+      apt-get -y install --no-install-recommends galera-4 galera-arbitrator-4; \
+    fi \
     && if ! grep -q 'stretch' /etc/apt/sources.list; then \
       apt-get -y install --no-install-recommends python3-buildbot-worker; \
     fi \
@@ -64,3 +67,5 @@ RUN apt-get update \
         apt-get -y install --no-install-recommends python3-pip; \
     fi \
     && apt-get clean
+
+ENV WSREP_PROVIDER=/usr/lib/galera/libgalera_smm.so

--- a/ci_build_images/fedora.Dockerfile
+++ b/ci_build_images/fedora.Dockerfile
@@ -24,6 +24,7 @@ RUN dnf -y upgrade \
     dumb-init \
     flex \
     fmt-devel \
+    galera \
     java-latest-openjdk \
     java-latest-openjdk-devel \
     java-latest-openjdk-headless \
@@ -49,3 +50,5 @@ RUN dnf -y upgrade \
     && if [ "$VERSION_ID" = 36 ]; then dnf -y install gnutls-devel; fi \
     && if [ "$(uname -m)" = "x86_64" ]; then dnf -y install libpmem-devel; fi \
     && dnf clean all
+
+ENV WSREP_PROVIDER=/usr/lib64/galera/libgalera_smm.so

--- a/ci_build_images/rhel.Dockerfile
+++ b/ci_build_images/rhel.Dockerfile
@@ -53,6 +53,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     cracklib-devel \
     createrepo \
     curl-devel \
+    galera \
     java-1.8.0-openjdk \
     jemalloc-devel --allowerasing \
     krb5-devel \
@@ -89,3 +90,5 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     # dumb-init rpm is not available on rhel \
     && curl -sL "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_$(uname -m)" >/usr/local/bin/dumb-init \
     && chmod +x /usr/local/bin/dumb-init
+
+ENV WSREP_PROVIDER=/usr/lib64/galera/libgalera_smm.so

--- a/ci_build_images/rhel7.Dockerfile
+++ b/ci_build_images/rhel7.Dockerfile
@@ -27,6 +27,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     cracklib-devel \
     createrepo \
     curl-devel \
+    galera \
     jemalloc-devel \
     libffi-devel \
     libxml2-devel \
@@ -50,3 +51,5 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     && chmod +x /usr/local/bin/dumb-init
 
 ENV CRYPTOGRAPHY_ALLOW_OPENSSL_102=1
+
+ENV WSREP_PROVIDER=/usr/lib64/galera/libgalera_smm.so


### PR DESCRIPTION
Export WSREP_PROVIDER for MTR use.

While this is a galera-4 provider, mtr will
ignore this if running 10.3 after doing a version check.

opensuse galera package not included as it pulled
in MariaDB-10.4 as a dependency. Others allowed a
stand alone install.

Bionic has galera-3 only. 10.3 uses galera-3. It will be out of date by the time we add it here.