### PR TITLE
Debian sid has 10.11 now, so define that as the minimum version

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -42,12 +42,12 @@ jobs:
             platforms: linux/amd64
           - dockerfile: debian.Dockerfile
             image: debian:sid
-            branch: 10.7
+            branch: 10.11
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
           - dockerfile: debian.Dockerfile
             image: debian:sid
             tag: debiansid-386
-            branch: 10.7
+            branch: 10.11
             platforms: linux/386
           - dockerfile: debian.Dockerfile
             image: ubuntu:18.04

--- a/constants.py
+++ b/constants.py
@@ -113,19 +113,15 @@ supportedPlatforms["10.5"] = [
         's390x-sles-12',
         's390x-sles-15',
         's390x-ubuntu-2004',
-        'x86-debian-sid',
         ]
 supportedPlatforms["10.5"] += supportedPlatforms["10.4"]
 
 supportedPlatforms["10.6"] = [
-        'aarch64-debian-sid',
         'aarch64-ubuntu-2204',
         'aarch64-ubuntu-2210',
-        'amd64-debian-sid',
         'amd64-ubuntu-2004-fulltest',
         'amd64-ubuntu-2204',
         'amd64-ubuntu-2210',
-        'ppc64le-debian-sid',
         'ppc64le-ubuntu-2204',
         's390x-ubuntu-2204',
         ]
@@ -142,8 +138,12 @@ supportedPlatforms["10.10"] += supportedPlatforms["10.9"]
 
 supportedPlatforms["10.11"] = supportedPlatforms["10.10"]
 supportedPlatforms["10.11"] += [
+        'aarch64-debian-sid',
         'aarch64-ubuntu-2304',
+        'amd64-debian-sid',
         'amd64-ubuntu-2304',
+        'ppc64le-debian-sid',
+        'x86-debian-sid',
         ]
 supportedPlatforms["10.12"] = supportedPlatforms["10.11"]
 supportedPlatforms["11.0"] = supportedPlatforms["10.11"]


### PR DESCRIPTION
https://packages.debian.org/sid/mariadb-server

https://buildbot.mariadb.org/#/builders/431/builds/2814

Install failures happen otherwise:
```
The following packages have unmet dependencies:
 libmariadb-dev-dbgsym : Depends: libmariadb-dev (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 libmariadb3 : Breaks: libmariadbclient18 but 1:10.6.12+maria~debsid is to be installed
 libmariadb3-dbgsym : Depends: libmariadb3 (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 libmariadbclient18 : Depends: libmariadb3 (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 libmariadbd19-dbgsym : Depends: libmariadbd19 (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 libmysqlclient18 : Depends: libmariadb3 (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 mariadb-backup-dbgsym : Depends: mariadb-backup (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 mariadb-client : Conflicts: virtual-mysql-client
                  Breaks: mariadb-client-10.6 but 1:10.6.12+maria~debsid is to be installed
                  Breaks: mariadb-client-core-10.6 but 1:10.6.12+maria~debsid is to be installed
                  Breaks: mariadb-server-10.6 but 1:10.6.12+maria~debsid is to be installed
 mariadb-client-10.6 : Conflicts: virtual-mysql-client
 mariadb-client-core : Conflicts: virtual-mysql-client-core
                       Breaks: mariadb-client-core-10.6 but 1:10.6.12+maria~debsid is to be installed
                       Breaks: mariadb-server-core-10.6 but 1:10.6.12+maria~debsid is to be installed
 mariadb-client-core-10.6 : Conflicts: virtual-mysql-client-core
 mariadb-plugin-connect-dbgsym : Depends: mariadb-plugin-connect (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 mariadb-plugin-cracklib-password-check-dbgsym : Depends: mariadb-plugin-cracklib-password-check (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 mariadb-plugin-gssapi-client-dbgsym : Depends: mariadb-plugin-gssapi-client (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 mariadb-plugin-gssapi-server-dbgsym : Depends: mariadb-plugin-gssapi-server (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 mariadb-plugin-mroonga-dbgsym : Depends: mariadb-plugin-mroonga (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 mariadb-plugin-oqgraph-dbgsym : Depends: mariadb-plugin-oqgraph (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 mariadb-plugin-rocksdb-dbgsym : Depends: mariadb-plugin-rocksdb (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 mariadb-plugin-s3-dbgsym : Depends: mariadb-plugin-s3 (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
 mariadb-server : Conflicts: virtual-mysql-server
                  Breaks: mariadb-server-10.6 but 1:10.6.12+maria~debsid is to be installed
 mariadb-server-10.6 : Conflicts: virtual-mysql-server
 mariadb-server-core : Conflicts: virtual-mysql-server-core
                       Breaks: mariadb-server-core-10.6 but 1:10.6.12+maria~debsid is to be installed
 mariadb-server-core-10.6 : Conflicts: virtual-mysql-server-core
 mariadb-test-dbgsym : Depends: mariadb-test (= 1:10.6.12+maria~debsid) but 1:10.11.1-1 is to be installed
E: Unable to correct problems, you have held broken packages.
```