### PR TITLE
MDBF-536: Correctly trigger builds

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -154,10 +154,6 @@ MTR_ENV = {
     'MTR_PRINT_CORE': 'detailed',
     }
 
-# Hack to remove all github_status_builders since they are triggered separately
-for k in supportedPlatforms:
-    supportedPlatforms[k] = list(filter(lambda x: x not in github_status_builders, supportedPlatforms[k]))
-
 # =============================================================================
 # ============================ AUTO-GENERATED BELOW ===========================
 # The following code is auto-generated based on the content of os_info.yaml.

--- a/schedulers_definition.py
+++ b/schedulers_definition.py
@@ -9,9 +9,8 @@ def getSchedulers():
         builderNames=getBranchBuilderNames))
 
     schedulerProtectedBranches = schedulers.Triggerable(name="s_protected_branches",
-        builderNames=github_status_builders)
+        builderNames=getProtectedBuilderNames)
     l.append(schedulerProtectedBranches)
-
 
     schedulerPackages = schedulers.Triggerable(name="s_packages",
             builderNames=getAutobakeBuilderNames)

--- a/utils.py
+++ b/utils.py
@@ -408,7 +408,21 @@ def getArch(props):
 def getBranchBuilderNames(props):
     mBranch = props.getProperty("master_branch")
 
-    return supportedPlatforms[mBranch]
+    builders = list(filter(
+        lambda x: x not in github_status_builders,
+        supportedPlatforms[mBranch]))
+
+    return builders
+
+@util.renderer
+def getProtectedBuilderNames(props):
+    mBranch = props.getProperty("master_branch")
+
+    builders = list(filter(
+        lambda x: x in supportedPlatforms[mBranch],
+        github_status_builders))
+
+    return builders
 
 @util.renderer
 def getAutobakeBuilderNames(props):


### PR DESCRIPTION
Only trigger the protected branches builders if they are defined to run for a particular branch.