### PR TITLE
Skip DNS resolution by using localhost

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -703,7 +703,7 @@ c['multiMaster'] = True
 
 c['mq'] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     'type' : 'wamp',
-    'router_url': 'ws://buildbot.mariadb.org:8085/ws',
+    'router_url': 'ws://localhost:8085/ws',
     'realm': 'realm1',
     # valid are: none, critical, error, warn, info, debug, trace
     'wamp_debug_level' : 'info'

--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -245,7 +245,7 @@ c['multiMaster'] = True
 
 c['mq'] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     'type' : 'wamp',
-    'router_url': 'ws://buildbot.mariadb.org:8085/ws',
+    'router_url': 'ws://localhost:8085/ws',
     'realm': 'realm1',
     # valid are: none, critical, error, warn, info, debug, trace
     'wamp_debug_level' : 'info'

--- a/master-libvirt/master.cfg
+++ b/master-libvirt/master.cfg
@@ -287,7 +287,7 @@ c['multiMaster'] = True
 
 c['mq'] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     'type' : 'wamp',
-    'router_url': 'ws://buildbot.mariadb.org:8085/ws',
+    'router_url': 'ws://localhost:8085/ws',
     'realm': 'realm1',
     # valid are: none, critical, error, warn, info, debug, trace
     'wamp_debug_level' : 'info'

--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -345,7 +345,7 @@ c['multiMaster'] = True
 
 c['mq'] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     'type' : 'wamp',
-    'router_url': 'ws://buildbot.mariadb.org:8085/ws',
+    'router_url': 'ws://localhost:8085/ws',
     'realm': 'realm1',
     # valid are: none, critical, error, warn, info, debug, trace
     'wamp_debug_level' : 'info'

--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -325,7 +325,7 @@ c['multiMaster'] = True
 
 c['mq'] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     'type' : 'wamp',
-    'router_url': 'ws://buildbot.mariadb.org:8085/ws',
+    'router_url': 'ws://localhost:8085/ws',
     'realm': 'realm1',
     # valid are: none, critical, error, warn, info, debug, trace
     'wamp_debug_level' : 'info'

--- a/master-web/master.cfg
+++ b/master-web/master.cfg
@@ -96,7 +96,7 @@ c['buildbotNetUsageData'] = None
 
 c['mq'] = {
     'type' : 'wamp',
-    'router_url': 'ws://buildbot.mariadb.org:8085/ws',
+    'router_url': 'ws://localhost:8085/ws',
     'realm': 'realm1',
     # valid are: none, critical, error, warn, info, debug, trace
     'wamp_debug_level' : 'warn'

--- a/master.cfg
+++ b/master.cfg
@@ -255,7 +255,7 @@ c['multiMaster'] = True
 
 c['mq'] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     'type' : 'wamp',
-    'router_url': 'ws://buildbot.mariadb.org:8085/ws',
+    'router_url': 'ws://localhost:8085/ws',
     'realm': 'realm1',
     # valid are: none, critical, error, warn, info, debug, trace
     'wamp_debug_level' : 'info'


### PR DESCRIPTION
There is no reason to use DNS resolution for crossbar and we also probably need to only listen locally for that service.