### PR TITLE
MDBF-337: enable galera mtr tests

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -41,6 +41,11 @@ builders_eco = [
         "amd64-ubuntu-2004-eco-php",
         ]
 builders_wordpress = ["amd64-rhel8-wordpress"]
+builders_galera = [
+        "aarch64-debian-12",
+        "amd64-fedora-37",
+        "amd64-ubuntu-2304",
+        ]
 
 # Defines branches for which we save packages
 savedPackageBranches = branches_main + [

--- a/utils.py
+++ b/utils.py
@@ -392,6 +392,14 @@ def hasAutobake(props):
             return True
     return False
 
+def hasGalera(props):
+    builderName = str(props.getProperty("buildername"))
+
+    for b in builders_galera:
+        if builderName in b:
+            return True
+    return False
+
 def hasBigtest(props):
     builderName = str(props.getProperty("buildername"))
 


### PR DESCRIPTION
Add mtr tests on a few BB workers.

Debian/Ubuntu get Galera from MDRB bb (very latest) and RPM gets it from the distro. Both should run correctly.

Also choose BB workers that don't run 10.3 as no Galera-3 providers are installed.