### PR TITLE
MDBF-440: add rpm lint to opensuse

### DIFF
--- a/ci_build_images/opensuse.Dockerfile
+++ b/ci_build_images/opensuse.Dockerfile
@@ -31,6 +31,7 @@ RUN zypper update -y && \
     python-pip \
     python3-pip \
     rpm-build \
+    rpmlint \
     scons \
     snappy-devel \
     subversion \


### PR DESCRIPTION

Also retriggered rhel9/centosstream9 on https://github.com/MariaDB/buildbot/actions/runs/4284376503 as bb was running without the rpmlinter on those.