### PR TITLE
opensuse: jemalloc still needed in 10.4 (tokudb)

### DIFF
--- a/ci_build_images/opensuse.Dockerfile
+++ b/ci_build_images/opensuse.Dockerfile
@@ -21,6 +21,7 @@ RUN zypper update -y && \
     git \
     glibc-locale \
     gnutls-devel \
+    jemalloc-devel \
     libcurl-devel \
     libffi-devel \
     liblz4-devel \


### PR DESCRIPTION
ref: https://buildbot.mariadb.org/#/builders/197/builds/15507