### PR TITLE
Always push to ghcr.io for testing and as rollback mechanism

### DIFF
--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -276,7 +276,7 @@ jobs:
           printf "\n${line}\n${msg}\n${line}\n"
           skopeo copy --all --src-tls-verify=0 \
             docker://localhost:5000/${{ env.REPO }}:${{ env.IMG }} \
-            docker://ghcr.io/${{ GITHUB_REPOSITORY }}:${{ env.IMG }}
+            docker://ghcr.io/$GITHUB_REPOSITORY:${{ env.IMG }}
       - name: Login to registry
         if: ${{ env.DEPLOY_IMAGES == 'true' }}
         uses: docker/login-action@v2

--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -247,22 +247,6 @@ jobs:
             docker run -i "$image" dumb-init twistd --pidfile= -y /home/buildbot/buildbot.tac
             docker run -u root -i "$image" bash -c "touch /tmp/foo && qpress -r /tmp /root/qpress.qp"
           done
-      - name: Check for registry credentials
-        if: >
-          github.ref == 'refs/heads/main' &&
-          github.repository == 'MariaDB/buildbot'
-        run: |
-          missing=()
-          [[ -n "${{ secrets.QUAY_USER }}" ]] || missing+=(QUAY_USER)
-          [[ -n "${{ secrets.QUAY_TOKEN }}" ]] || missing+=(QUAY_TOKEN)
-          for i in "${missing[@]}"; do
-            echo "Missing github secret: $i"
-          done
-          if (( ${#missing[@]} == 0 )); then
-            echo "DEPLOY_IMAGES=true" >> $GITHUB_ENV
-          else
-            echo "Not pushing images to registry"
-          fi
       - name: Login to ghcr.io
         uses: docker/login-action@v2
         with:
@@ -277,6 +261,22 @@ jobs:
           skopeo copy --all --src-tls-verify=0 \
             docker://localhost:5000/${{ env.REPO }}:${{ env.IMG }} \
             docker://ghcr.io/$GITHUB_REPOSITORY:${{ env.IMG }}
+      - name: Check for quay.io registry credentials
+        if: >
+          github.ref == 'refs/heads/main' &&
+          github.repository == 'MariaDB/buildbot'
+        run: |
+          missing=()
+          [[ -n "${{ secrets.QUAY_USER }}" ]] || missing+=(QUAY_USER)
+          [[ -n "${{ secrets.QUAY_TOKEN }}" ]] || missing+=(QUAY_TOKEN)
+          for i in "${missing[@]}"; do
+            echo "Missing github secret: $i"
+          done
+          if (( ${#missing[@]} == 0 )); then
+            echo "DEPLOY_IMAGES=true" >> $GITHUB_ENV
+          else
+            echo "Not pushing images to quay.io"
+          fi
       - name: Login to registry
         if: ${{ env.DEPLOY_IMAGES == 'true' }}
         uses: docker/login-action@v2

--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -260,7 +260,7 @@ jobs:
           printf "\n${line}\n${msg}\n${line}\n"
           skopeo copy --all --src-tls-verify=0 \
             docker://localhost:5000/${{ env.REPO }}:${{ env.IMG }} \
-            docker://ghcr.io/$GITHUB_REPOSITORY:${{ env.IMG }}
+            docker://ghcr.io/${GITHUB_REPOSITORY,,}:${{ env.IMG }}
       - name: Check for quay.io registry credentials
         if: >
           github.ref == 'refs/heads/main' &&

--- a/.github/workflows/bb_containers.yml
+++ b/.github/workflows/bb_containers.yml
@@ -264,21 +264,19 @@ jobs:
             echo "Not pushing images to registry"
           fi
       - name: Login to ghcr.io
-        if: ${{ env.DEPLOY_IMAGES == 'true' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push images to ghcr.io
-        if: ${{ env.DEPLOY_IMAGES == 'true' }}
         run: |
           msg="Push docker image to ghcr.io (${{ env.IMG }})"
           line="${msg//?/=}"
           printf "\n${line}\n${msg}\n${line}\n"
           skopeo copy --all --src-tls-verify=0 \
             docker://localhost:5000/${{ env.REPO }}:${{ env.IMG }} \
-            docker://ghcr.io/mariadb/buildbot:${{ env.IMG }}
+            docker://ghcr.io/${{ GITHUB_REPOSITORY }}:${{ env.IMG }}
       - name: Login to registry
         if: ${{ env.DEPLOY_IMAGES == 'true' }}
         uses: docker/login-action@v2

--- a/.github/workflows/bbm_build_container.yml
+++ b/.github/workflows/bbm_build_container.yml
@@ -48,7 +48,23 @@ jobs:
           docker run -i localhost:5000/${{ env.REPO }}:master buildbot --version
           #//TEMP there is probably a better way for master-web here
           docker run -i localhost:5000/${{ env.REPO }}:master-web buildbot --version
-      - name: Check for registry credentials
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push images to ghcr.io
+        run: |
+          msg="Push docker images to ghcr.io"
+          line="${msg//?/=}"
+          printf "\n${line}\n${msg}\n${line}\n"
+          for image in master master-web; do
+            skopeo copy --all --src-tls-verify=0 \
+            docker://localhost:5000/${{ env.REPO }}:${image} \
+            docker://ghcr.io/$GITHUB_REPOSITORY:${image}
+          done
+      - name: Check for quay.io registry credentials
         if: >
           github.ref == 'refs/heads/main' &&
           github.repository == 'MariaDB/buildbot'
@@ -62,26 +78,8 @@ jobs:
           if (( ${#missing[@]} == 0 )); then
             echo "DEPLOY_IMAGES=true" >> $GITHUB_ENV
           else
-            echo "Not pushing images to registry"
+            echo "Not pushing images to quay.io"
           fi
-      - name: Login to ghcr.io
-        if: ${{ env.DEPLOY_IMAGES == 'true' }}
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push images to ghcr.io
-        if: ${{ env.DEPLOY_IMAGES == 'true' }}
-        run: |
-          msg="Push docker images to ghcr.io"
-          line="${msg//?/=}"
-          printf "\n${line}\n${msg}\n${line}\n"
-          for image in master master-web; do
-            skopeo copy --all --src-tls-verify=0 \
-            docker://localhost:5000/${{ env.REPO }}:${image} \
-            docker://ghcr.io/mariadb/buildbot:${image}
-          done
       - name: Login to quay.io
         if: ${{ env.DEPLOY_IMAGES == 'true' }}
         uses: docker/login-action@v2

--- a/.github/workflows/bbm_build_container.yml
+++ b/.github/workflows/bbm_build_container.yml
@@ -62,7 +62,7 @@ jobs:
           for image in master master-web; do
             skopeo copy --all --src-tls-verify=0 \
             docker://localhost:5000/${{ env.REPO }}:${image} \
-            docker://ghcr.io/$GITHUB_REPOSITORY:${image}
+            docker://ghcr.io/${{GITHUB_REPOSITORY,,}:${image}
           done
       - name: Check for quay.io registry credentials
         if: >


### PR DESCRIPTION
The ghcr.io registry keeps more history than quay.io, it can be convenient for rollback of images and backups.
This PR also permits to forks to push in their local GitHub registry (packages) and helps contributor to test images produced by the CI.