### PR TITLE
Try to fix the master-web build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
         libcairo2 \
         yarnpkg; \
       export PATH="/usr/share/nodejs/yarn/bin:$PATH"; \
-      yarn global add gulp yo generator-buildbot-dashboard; \
+      yarn global --ignore-engines add gulp yo generator-buildbot-dashboard; \
     fi \
     && git clone --branch grid https://github.com/vladbogo/buildbot . \
     && python3 -m venv .venv \


### PR DESCRIPTION
Error is:
```console
error isbinaryfile@5.0.0: The engine "node" is incompatible with this module. Expected version ">= 14.0.0". Got "12.22.12"
error Found incompatible module.
```

Suggested from: https://stackoverflow.com/questions/66429081/the-engine-node-is-incompatible-with-this-module-expected-version-12-x-got