### PR TITLE
eco: wordpress_phpunit_test_runner trigger update

### DIFF
--- a/eco_build_images/wordpress_phpunit_test_runner.Dockerfile
+++ b/eco_build_images/wordpress_phpunit_test_runner.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update ; \
 	&& docker-php-ext-install -j"$(nproc)" gd mysqli \
         && rm -rf /var/lib/apt/lists/*
 
-# Waiting on upstream PRs #176, 177, #179, with issue #178 as added bonus
+# Waiting on upstream PRs #176, 177, with issue #178 as added bonus
 RUN git clone --branch all_changes --single-branch --depth 1 https://github.com/grooverdan/phpunit-test-runner.git /phpunit-test-runner
 
 # because of https://github.com/WordPress/wordpress-develop/commit/db0290b04264de1fa791b6973ce3122ccc160a90


### PR DESCRIPTION
wordpress_phpunit_test_runner updated based on upstream.

hoping to fix:

https://buildbot.mariadb.org/#/builders/505/builds/1280/steps/4/logs/stdio

There was 1 failure:
1) Tests_Admin_WpAutomaticUpdater::test_is_allowed_dir_should_return_false_if_open_basedir_is_set_and_path_is_not_allowed Failed asserting that true is false.

I updated my https://github.com/grooverdan/phpunit-test-runner branch so this will regenerate based on this.