### PR TITLE
wp: work around test failure

### DIFF
--- a/eco_build_images/wordpress_phpunit_test_runner.env
+++ b/eco_build_images/wordpress_phpunit_test_runner.env
@@ -12,11 +12,11 @@
 ###
 
 # Path to the directory where files can be prepared before being delivered to the environment.
-export WPT_PREPARE_DIR=/wp-test-runner
+export WPT_PREPARE_DIR=/wp-test-runner/wordpress-develop
 
 # Path to the directory where the WordPress develop checkout can be placed and tests can be run.
 # When running tests in the same environment, set WPT_TEST_DIR to WPT_PREPARE_DIR
-export WPT_TEST_DIR=/wp-test-runner
+export WPT_TEST_DIR=/wp-test-runner/wordpress-develop
 
 # API key to authenticate with the reporting service in 'username:password' format.
 export WPT_REPORT_API_KEY=


### PR DESCRIPTION
Upstream flaw in testcase:

Tests_Admin_WpAutomaticUpdater::test_is_allowed_dir_should_return_false_if_open_basedir_is_set_and_path_is_not_allowed

Thanks to invaluable assitance from Colin Stewart.