### PR TITLE
MDBF-560 Add JDK to CI build images

### DIFF
--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -45,6 +45,7 @@ RUN . /etc/os-release; \
     build-essential \
     ccache \
     check \
+    default-jdk \
     dumb-init \
     gawk \
     git \

--- a/ci_build_images/rhel7.Dockerfile
+++ b/ci_build_images/rhel7.Dockerfile
@@ -28,6 +28,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     createrepo \
     curl-devel \
     galera \
+    java-latest-openjdk \
     jemalloc-devel \
     libffi-devel \
     libxml2-devel \


### PR DESCRIPTION
Install default-jdk on debian and java-1.8.0-openjdk-devel on rhel7