### PR TITLE
core save - parallel mtr as additional numbered path

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -228,10 +228,7 @@ def createVar():
     return """
 if [ -d mysql-test/var ]; then
     extra=
-    if compgen -G ./mysql-test/var/log/*/mysqld.*/data/core*gz > /dev/null; then
-      if compgen -G mysql-test/var/[0-9]*/{mysqld.[0-9],my.cnf} > /dev/null; then
-        extra=mysql-test/var/[0-9]*/{mysqld.[0-9],my.cnf}
-      fi
+    if compgen -G  ./mysql-test/var/*/log/*/mysqld.*/data/core* > /dev/null; then
       if [ -f sql/mysqld ]; then extra="$extra sql/mysqld"; fi
       if [ -f sql/mariadbd ]; then extra="$extra sql/mariadbd"; fi
     fi


### PR DESCRIPTION
Saving cnf files is already under the mysql-test/var/log/ directory so no additional save is required.