### PR TITLE
Use full dependencies for JDK

### DIFF
--- a/ci_build_images/centos.Dockerfile
+++ b/ci_build_images/centos.Dockerfile
@@ -40,7 +40,7 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     flex \
     galera \
     java-1.8.0-openjdk-devel \
-    java-1.8.0-openjdk-headless \
+    java-1.8.0-openjdk \
     jemalloc-devel \
     libcurl-devel \
     libevent-devel \

--- a/ci_build_images/centos7.Dockerfile
+++ b/ci_build_images/centos7.Dockerfile
@@ -26,7 +26,7 @@ RUN yum -y --enablerepo=extras install epel-release \
     galera \
     gnutls-devel \
     java-1.8.0-openjdk-devel \
-    java-1.8.0-openjdk-headless \
+    java-1.8.0-openjdk \
     jemalloc-devel \
     libcurl-devel \
     libevent-devel \

--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -46,7 +46,7 @@ RUN . /etc/os-release; \
     build-essential \
     ccache \
     check \
-    default-jdk-headless \
+    default-jdk\
     dumb-init \
     gawk \
     git \

--- a/ci_build_images/fedora.Dockerfile
+++ b/ci_build_images/fedora.Dockerfile
@@ -28,7 +28,7 @@ RUN dnf -y upgrade \
     gawk \
     iproute \
     java-latest-openjdk-devel \
-    java-latest-openjdk-headless \
+    java-latest-openjdk \
     jemalloc-devel \
     libcurl-devel \
     libevent-devel \

--- a/ci_build_images/rhel.Dockerfile
+++ b/ci_build_images/rhel.Dockerfile
@@ -57,7 +57,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     flex \
     galera \
     java-1.8.0-openjdk-devel \
-    java-1.8.0-openjdk-headless \
+    java-1.8.0-openjdk \
     jemalloc-devel --allowerasing \
     krb5-devel \
     libaio-devel \

--- a/ci_build_images/rhel7.Dockerfile
+++ b/ci_build_images/rhel7.Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     curl-devel \
     galera \
     java-latest-openjdk-devel \
-    java-latest-openjdk-headless \
+    java-latest-openjdk \
     jemalloc-devel \
     libffi-devel \
     libxml2-devel \


### PR DESCRIPTION
- Based on patch 658b914996807f9f33999bd3daf399101f99a32c we need `JNI` to be installed `jni.h` and respective `JAVA_AWT_LIBRARY` and `JAVA_AWT_INCLUDE_PATH` to be set,and that is done from `jdk` instead of `headless`.
- Note for rpm: `-devel` should be equals to `jdk`, maybe the change is not needed.