### PR TITLE
RPM ci images - add perl-autodie (for preview-11.3-preview branch)

### DIFF
--- a/ci_build_images/centos.Dockerfile
+++ b/ci_build_images/centos.Dockerfile
@@ -49,6 +49,7 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     libffi-devel \
     libxml2-devel \
     libzstd-devel \
+    perl-autodie \
     python3-devel \
     python3-scons \
     readline-devel \

--- a/ci_build_images/centos7.Dockerfile
+++ b/ci_build_images/centos7.Dockerfile
@@ -37,6 +37,7 @@ RUN yum -y --enablerepo=extras install epel-release \
     libzstd-devel \
     lz4-devel \
     pcre2-devel \
+    perl-autodie \
     python3 \
     python3-pip \
     rpmlint \

--- a/ci_build_images/fedora.Dockerfile
+++ b/ci_build_images/fedora.Dockerfile
@@ -38,6 +38,7 @@ RUN dnf -y upgrade \
     lsof \
     lzo \
     lzo-devel \
+    perl-autodie \
     python-unversioned-command \
     python3-devel \
     readline-devel \

--- a/ci_build_images/rhel.Dockerfile
+++ b/ci_build_images/rhel.Dockerfile
@@ -74,6 +74,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     openssl-devel \
     pam-devel \
     pcre2-devel \
+    perl-autodie \
     pkgconfig \
     policycoreutils \
     python3 \

--- a/ci_build_images/rhel7.Dockerfile
+++ b/ci_build_images/rhel7.Dockerfile
@@ -36,6 +36,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     libffi-devel \
     libxml2-devel \
     lz4-devel \
+    perl-autodie \
     pcre2-devel \
     python3-pip \
     rpmlint \


### PR DESCRIPTION
right for fedora, lets see if other builds pick the package up.

resolves failures on https://buildbot.mariadb.org/#/grid?branch=preview-11.3-preview

ssl_autoverify