### PR TITLE
Add to branches_main

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -14,6 +14,11 @@ branches_main = [
         '11.1',
         '11.2',
         '11.3',
+        '11.4',
+        '11.5',
+        '11.6',
+        '11.7',
+        '11.8',
         ]
 
 # Defines what builders report status to GitHub


### PR DESCRIPTION
To keep non-latent master changes to a minium we plan for 4 more 11.x series releases.

This way non-latent workers will pick up jobs as these new branches becomes active (every 3 months).