### PR TITLE
WIP: mtr run that runs last N failed tests

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -35,7 +35,7 @@ class FetchTestData(MTR):
 
             if tests:
                 test_args = ' '.join(tests)
-                self.setProperty('tests_to_run', test_args)
+                self.setProperty('tests_to_run', '--skip-not-found ' + test_args)
 
         return results.SUCCESS
 

--- a/common_factories.py
+++ b/common_factories.py
@@ -39,127 +39,7 @@ class FetchTestData(MTR):
 
         return results.SUCCESS
 
-def getBaseBuildFactory(mtrDbPool, mtrArgs):
-    f_quick_build = util.BuildFactory()
-    f_quick_build.addStep(
-        steps.ShellCommand(
-            name="Environment details",
-            command=["bash", "-c", "date -u && uname -a && ulimit -a"],
-        )
-    )
-    f_quick_build.addStep(
-        steps.SetProperty(
-            property="dockerfile",
-            value=util.Interpolate("%(kw:url)s", url=dockerfile),
-            description="dockerfile",
-        )
-    )
-    f_quick_build.addStep(downloadSourceTarball())
-    f_quick_build.addStep(
-        steps.ShellCommand(
-            command=util.Interpolate(
-                "tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1"
-            )
-        )
-    )
-    f_quick_build.addStep(
-        steps.ShellCommand(
-            name="create html log file",
-            command=[
-                "bash",
-                "-c",
-                util.Interpolate(
-                    getHTMLLogString(),
-                    jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-                ),
-            ],
-        )
-    )
-    f_quick_build.addStep(FetchTestData(name="Get last N failed tests", mtrDbPool=mtrDbPool))
-    # build steps
-    f_quick_build.addStep(
-        steps.Compile(
-            command=[
-                "sh",
-                "-c",
-                util.Interpolate(
-                    "cmake . -DCMAKE_BUILD_TYPE=%(kw:build_type)s -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=YES -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=%(kw:perf_schema)s -DPLUGIN_SPHINX=NO %(kw:additional_args)s && make %(kw:verbose_build)s -j%(kw:jobs)s %(kw:create_package)s",
-                    perf_schema=util.Property("perf_schema", default="YES"),
-                    build_type=util.Property("build_type", default="RelWithDebInfo"),
-                    jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-                    c_compiler=util.Property("c_compiler", default="gcc"),
-                    cxx_compiler=util.Property("cxx_compiler", default="g++"),
-                    additional_args=util.Property("additional_args", default=""),
-                    create_package=util.Property("create_package", default="package"),
-                    verbose_build=util.Property("verbose_build", default=""),
-                ),
-            ],
-            env={"CCACHE_DIR": "/mnt/ccache"},
-            haltOnFailure="true",
-        )
-    )
-    f_quick_build.addStep(
-        steps.MTR(
-            logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
-            command=[
-                "sh",
-                "-c",
-                util.Interpolate(
-                    """
-            cd mysql-test &&
-            exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2) %(kw:mtr_additional_args)s
-            """, mtr_additional_args=mtrArgs,
-            jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'),
-        )],
-        timeout=950,
-        haltOnFailure="true",
-        parallel=mtrJobsMultiplier,
-        dbpool=mtrDbPool,
-        autoCreateTables=True,
-        env=MTR_ENV,
-    ))
-    f_quick_build.addStep(steps.ShellCommand(name="move mariadb log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN'))]))
-    f_quick_build.addStep(steps.ShellCommand(name="create var archive", alwaysRun=True, command=['bash', '-c', util.Interpolate(createVar())], doStepIf=hasFailed))
-    f_quick_build.addStep(steps.MTR(
-        description="testing galera",
-        descriptionDone="test galera",
-        logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
-        command=["sh", "-c", util.Interpolate("""
-           cd mysql-test &&
-           if [ -f "$WSREP_PROVIDER" ]; then exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=10 --max-test-fail=20 --mem --big-test --parallel=$(expr %(kw:jobs)s \* 2) %(kw:mtr_additional_args)s --suite=wsrep,galera,galera_3nodes,galera_3nodes_sr; fi
-           """,
-                    mtr_additional_args=util.Property(
-                        "mtr_additional_args", default=""
-                    ),
-                    jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-                ),
-            ],
-            timeout=950,
-            haltOnFailure="true",
-            parallel=mtrJobsMultiplier,
-            dbpool=mtrDbPool,
-            autoCreateTables=True,
-            env=MTR_ENV,
-            doStepIf=hasGalera,
-        )
-    )
-    f_quick_build.addStep(
-        steps.ShellCommand(
-            name="move mariadb galera log files",
-            alwaysRun=True,
-            command=[
-                "bash",
-                "-c",
-                util.Interpolate(
-                    "mv /buildbot/logs /buildbot/logs_main\n"
-                    + moveMTRLogs()
-                    + "\nmv /buildbot/logs /buildbot/logs_galera; mv /buildbot/logs_main /buildbot/logs; mv /buildbot/logs_galera /buildbot/logs/galera\n",
-                    jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-                ),
-            ],
-            doStepIf=hasGalera,
-        )
-    )
+def addPostTests(f_quick_build):
     f_quick_build.addStep(
         steps.DirectoryUpload(
             name="save log files",
@@ -254,10 +134,139 @@ def getBaseBuildFactory(mtrDbPool, mtrArgs):
     )
     return f_quick_build
 
-def getQuickBuildFactory(mtrDbPool):
-    return getBaseBuildFactory(mtrDbPool,util.Property(
+def getBuildFactoryPreTest():
+    f_quick_build = util.BuildFactory()
+    f_quick_build.addStep(
+        steps.ShellCommand(
+            name="Environment details",
+            command=["bash", "-c", "date -u && uname -a && ulimit -a"],
+        )
+    )
+    f_quick_build.addStep(
+        steps.SetProperty(
+            property="dockerfile",
+            value=util.Interpolate("%(kw:url)s", url=dockerfile),
+            description="dockerfile",
+        )
+    )
+    f_quick_build.addStep(downloadSourceTarball())
+    f_quick_build.addStep(
+        steps.ShellCommand(
+            command=util.Interpolate(
+                "tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1"
+            )
+        )
+    )
+    f_quick_build.addStep(
+        steps.ShellCommand(
+            name="create html log file",
+            command=[
+                "bash",
+                "-c",
+                util.Interpolate(
+                    getHTMLLogString(),
+                    jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+                ),
+            ],
+        )
+    )
+    # build steps
+    f_quick_build.addStep(
+        steps.Compile(
+            command=[
+                "sh",
+                "-c",
+                util.Interpolate(
+                    "cmake . -DCMAKE_BUILD_TYPE=%(kw:build_type)s -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=YES -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=%(kw:perf_schema)s -DPLUGIN_SPHINX=NO %(kw:additional_args)s && make %(kw:verbose_build)s -j%(kw:jobs)s %(kw:create_package)s",
+                    perf_schema=util.Property("perf_schema", default="YES"),
+                    build_type=util.Property("build_type", default="RelWithDebInfo"),
+                    jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+                    c_compiler=util.Property("c_compiler", default="gcc"),
+                    cxx_compiler=util.Property("cxx_compiler", default="g++"),
+                    additional_args=util.Property("additional_args", default=""),
+                    create_package=util.Property("create_package", default="package"),
+                    verbose_build=util.Property("verbose_build", default=""),
+                ),
+            ],
+            env={"CCACHE_DIR": "/mnt/ccache"},
+            haltOnFailure="true",
+        )
+    )
+    return f_quick_build
+
+def addTests(f_quick_build, mtrDbPool, mtrArgs):
+    f_quick_build.addStep(
+        steps.MTR(
+            logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
+            command=[
+                "sh",
+                "-c",
+                util.Interpolate(
+                    """
+            cd mysql-test &&
+            exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2) %(kw:mtr_additional_args)s
+            """, mtr_additional_args=mtrArgs,
+            jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'),
+        )],
+        timeout=950,
+        haltOnFailure="true",
+        parallel=mtrJobsMultiplier,
+        dbpool=mtrDbPool,
+        autoCreateTables=True,
+        env=MTR_ENV,
+    ))
+    f_quick_build.addStep(steps.ShellCommand(name="move mariadb log files", alwaysRun=True, command=['bash', '-c', util.Interpolate(moveMTRLogs(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN'))]))
+    f_quick_build.addStep(steps.ShellCommand(name="create var archive", alwaysRun=True, command=['bash', '-c', util.Interpolate(createVar())], doStepIf=hasFailed))
+    return f_quick_build
+
+def addGaleraTests(f_quick_build, mtrDbPool):
+    f_quick_build.addStep(steps.MTR(
+        description="testing galera",
+        descriptionDone="test galera",
+        logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
+        command=["sh", "-c", util.Interpolate("""
+           cd mysql-test &&
+           if [ -f "$WSREP_PROVIDER" ]; then exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=10 --max-test-fail=20 --mem --big-test --parallel=$(expr %(kw:jobs)s \* 2) %(kw:mtr_additional_args)s --suite=wsrep,galera,galera_3nodes,galera_3nodes_sr; fi
+           """,
+                    mtr_additional_args=util.Property(
                         "mtr_additional_args", default=""
-                    ))
+                    ),
+                    jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+                ),
+            ],
+            timeout=950,
+            haltOnFailure="true",
+            parallel=mtrJobsMultiplier,
+            dbpool=mtrDbPool,
+            autoCreateTables=True,
+            env=MTR_ENV,
+            doStepIf=hasGalera,
+        )
+    )
+    f_quick_build.addStep(
+        steps.ShellCommand(
+            name="move mariadb galera log files",
+            alwaysRun=True,
+            command=[
+                "bash",
+                "-c",
+                util.Interpolate(
+                    "mv /buildbot/logs /buildbot/logs_main\n"
+                    + moveMTRLogs()
+                    + "\nmv /buildbot/logs /buildbot/logs_galera; mv /buildbot/logs_main /buildbot/logs; mv /buildbot/logs_galera /buildbot/logs/galera\n",
+                    jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+                ),
+            ],
+            doStepIf=hasGalera,
+        )
+    )
+    return f_quick_build
+
+def getQuickBuildFactory(mtrDbPool):
+    f = getBuildFactoryPreTest()
+    addTests(f, mtrDbPool, util.Property( "mtr_additional_args", default=""))
+    addGaleraTests(f, mtrDbPool)
+    return addPostTests(f)
 
 def getLastNFailedBuildsFactory(mtrDbPool):
     @util.renderer
@@ -269,7 +278,10 @@ def getLastNFailedBuildsFactory(mtrDbPool):
 
         return mtr_additional_args
 
-    return getBaseBuildFactory(mtrDbPool, getTests)
+    f = getBuildFactoryPreTest()
+    f.addStep(FetchTestData(name="Get last N failed tests", mtrDbPool=mtrDbPool))
+    addTests(f, mtrDbPool, getTests)
+    return addPostTests(f)
 
 def getRpmAutobakeFactory(mtrDbPool):
     ## f_rpm_autobake

--- a/common_factories.py
+++ b/common_factories.py
@@ -259,7 +259,7 @@ def getQuickBuildFactory(mtrDbPool):
                         "mtr_additional_args", default=""
                     ))
 
-def getLastNFailedBuildFactory(mtrDbPool):
+def getLastNFailedBuildsFactory(mtrDbPool):
     @util.renderer
     def getTests(props):
         mtr_additional_args = props.getProperty('mtr_additional_args', '--suite=main')

--- a/common_factories.py
+++ b/common_factories.py
@@ -25,7 +25,7 @@ class FetchTestData(steps.BuildStep):
 
         if master_branch:
             query = """
-            select concat(test_name,',',test_variant) from (select id, test_name,test_variant from test_failure,test_run where branch like '%%%s%%' and test_run_id=id order by test_run_id desc limit %d) x group by test_name,test_variant order by max(id) desc limit %d
+            select concat(test_name,',',test_variant) from (select id, test_name,test_variant from test_failure,test_run where branch='%s' and test_run_id=id order by test_run_id desc limit %d) x group by test_name,test_variant order by max(id) desc limit %d
             """
             tests = yield self.mtrDbPool.runQuery(query % (master_branch, overlimit, limit))
             tests = list(t[0] for t in tests)

--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -247,6 +247,7 @@ for w_name in ["hz-bbw"]:
 ####### FACTORY CODE
 
 f_quick_build = getQuickBuildFactory(mtrDbPool)
+f_last_n_failed = getLastNFailedBuildsFactory(mtrDbPool)
 
 ## f_tarball - create source tarball
 f_tarball = util.BuildFactory()
@@ -522,7 +523,7 @@ c["builders"].append(
         canStartBuild=canStartBuild,
         locks=getLocks,
         properties={"mtr_additional_args": protected_branches_mtr_additional_args},
-        factory=f_quick_build,
+        factory=f_last_n_failed,
     )
 )
 
@@ -536,7 +537,7 @@ c["builders"].append(
         canStartBuild=canStartBuild,
         locks=getLocks,
         properties={"mtr_additional_args": protected_branches_mtr_additional_args},
-        factory=f_quick_build,
+        factory=f_last_n_failed,
     )
 )
 


### PR DESCRIPTION
This is work-in-progress commit to have fast branch protection builders with a guarantee that a test, once failed, is fixed before further pushes are allowed. It works by running last N failed tests.

Note:
* it likely uses twisted incorrectly, needs to be fixed
* commit only provides a factory, it's not actually used for any builders, let's switch one builder over

After it is made to work and proves useful, needs to be extended as:

* [x] better to use `MTR.runQueryWithRetry` instead of `runQuery`
* [x] also test new/touched tests from the commit ~and remove removed tests from the list~
* [ ] do something about skips (makes little sense to run N failed tests if they're all skipped)
* [ ] typ values made consistent over all builders so that they could be used for filtering
* [ ] it uses only normal protocol, should be changed to take ps/embedded/view/etc as an argument. When branch protection quick builders will run ps/embedded/view/etc
* [ ] the way SELECT works it looks for 50 unique test names within last 1000 failures. I want to make buildbot to autotune the second limit. The smaller it is, the faster will the query run
* [ ] use failures from old buildbot too _or may be not, if we're shutting it down_
* [ ] uses N=50 now, this could be increases to catch more failures or decreased to run faster
* [ ] need to have "test everything" builder, even if slow
* [ ] more branch protection builders should use it
* [ ] gcov builder