### PR TITLE
MDBF-598 Remove checks for spider changes

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -19,7 +19,7 @@ def getQuickBuildFactory(mtrDbPool):
     f_quick_build.addStep(steps.ShellCommand(name="create html log file", command=['bash', '-c', util.Interpolate(getHTMLLogString(), jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'))]))
     # build steps
     f_quick_build.addStep(steps.Compile(
-        command=["sh", "-c", util.Interpolate("cmake . -DCMAKE_BUILD_TYPE=%(kw:build_type)s -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=%(kw:spider_changed)s -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=%(kw:perf_schema)s -DPLUGIN_SPHINX=NO %(kw:additional_args)s && make %(kw:verbose_build)s -j%(kw:jobs)s %(kw:create_package)s",
+        command=["sh", "-c", util.Interpolate("cmake . -DCMAKE_BUILD_TYPE=%(kw:build_type)s -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=YES -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=%(kw:perf_schema)s -DPLUGIN_SPHINX=NO %(kw:additional_args)s && make %(kw:verbose_build)s -j%(kw:jobs)s %(kw:create_package)s",
             perf_schema=util.Property('perf_schema', default='YES'),
             build_type=util.Property('build_type', default='RelWithDebInfo'),
             jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'),
@@ -28,7 +28,6 @@ def getQuickBuildFactory(mtrDbPool):
             additional_args=util.Property('additional_args', default=''),
             create_package=util.Property('create_package', default='package'),
             verbose_build=util.Property('verbose_build', default=''),
-            spider_changed=util.Property('spider_changed', default='NO'),
         )], env={'CCACHE_DIR':'/mnt/ccache'}, haltOnFailure="true"))
     f_quick_build.addStep(steps.MTR(
         logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
@@ -36,11 +35,7 @@ def getQuickBuildFactory(mtrDbPool):
             cd mysql-test &&
             exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2) %(kw:mtr_additional_args)s
             """,
-            mtr_additional_args=util.Transform(
-                lambda spider_changed, mtr_additional_args: mtr_additional_args.replace('--suite=main', '--suite=main,spider,spider/bg,spider/bugfix,spider/feature,spider/regression/e1121,spider/regression/e112122') if spider_changed == 'YES' else mtr_additional_args,
-                util.Property('spider_changed'),
-                util.Property('mtr_additional_args', default=''),
-            ),
+            mtr_additional_args=util.Property('mtr_additional_args', default=''),
             jobs=util.Property('jobs', default='$(getconf _NPROCESSORS_ONLN)'),
         )],
         timeout=950,

--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -169,20 +169,13 @@ f_tarball.addStep(steps.GitHub(
   mode='full',
   method='clobber',
   workdir='build/server',
-  shallow=5,
+  shallow=True,
   submodules=True
 ))
 f_tarball.addStep(steps.Compile(command=["cmake","../server"], workdir='build/mkdist', description="cmake"))
 f_tarball.addStep(steps.Compile(command=["make", "dist"], workdir='build/mkdist', description="make dist"))
 f_tarball.addStep(steps.SetPropertyFromCommand(property="mariadb_version", command="basename mariadb-*.tar.gz .tar.gz", workdir="build/mkdist"))
 f_tarball.addStep(steps.SetPropertyFromCommand(property="master_branch", command=util.Interpolate("echo " + "%(prop:mariadb_version)s" + " | cut -d'-' -f 2 | cut -d'.' -f 1,2")))
-f_tarball.addStep(steps.SetPropertyFromCommand(
-    property="spider_changed",
-    command='[ -n "$(git diff-tree --no-commit-id --name-only -r HEAD storage/spider)" ] && echo "YES" || echo "NO"',
-    name="check_spider_path_change",
-    description="checking if spider path was changed in the latest commit",
-    workdir='build/server',
-))
 f_tarball.addStep(steps.ShellCommand(command=util.Interpolate("mkdir -p %(prop:buildnumber)s/logs"), workdir="build/mkdist"))
 f_tarball.addStep(steps.ShellCommand(command=util.Interpolate("sha256sum %(prop:mariadb_version)s" + ".tar.gz >> " + " %(prop:buildnumber)s" + "/sha256sums.txt" + " && mv %(prop:mariadb_version)s" +".tar.gz" + " %(prop:buildnumber)s"), workdir="build/mkdist"))
 f_tarball.addStep(steps.SetPropertyFromCommand(command="ls -1 *.tar.gz", extract_fn=ls2list, workdir=util.Interpolate("build/mkdist/" + "%(prop:buildnumber)s")))
@@ -198,7 +191,6 @@ f_tarball.addStep(steps.Trigger(
         "tarbuildnum" : Property("buildnumber"),
         "mariadb_version" : Property("mariadb_version"),
         "master_branch" : Property("master_branch"),
-        "spider_changed" : Property("spider_changed"),
         }
     ))
 f_tarball.addStep(steps.Trigger(
@@ -209,7 +201,6 @@ f_tarball.addStep(steps.Trigger(
         "tarbuildnum" : Property("buildnumber"),
         "mariadb_version" : Property("mariadb_version"),
         "master_branch" : Property("master_branch"),
-        "spider_changed" : Property("spider_changed"),
         }
     ))
 f_tarball.addStep(steps.SetPropertyFromCommand(command=util.Interpolate("echo " + "prot-" + "%(prop:master_branch)s"), property="master_staging_branch"))
@@ -226,7 +217,7 @@ f_tarball.addStep(steps.ShellSequence( commands=[
 f_tarball.addStep(steps.ShellCommand(name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True))
 
 ####### BUILDERS LIST
-protected_branches_mtr_additional_args = '--suite=main --skip-test="^stack_crash$|^float$|^derived_split_innodb$|^mysql_client_test$|^kill$|^processlist_not_embedded$|^sp-big$"'
+protected_branches_mtr_additional_args = '--suite=main,spider,spider/bg,spider/bugfix,spider/feature,spider/regression/e1121,spider/regression/e112122 --skip-test="^stack_crash$|^float$|^derived_split_innodb$|^mysql_client_test$|^kill$|^processlist_not_embedded$|^sp-big$"'
 
 c['builders'] = []
 


### PR DESCRIPTION
MDBF-535 enables conditional spider tests for protected branches in Buildbot when the commit has touched spider code. It is time to remove this condition as the trial shows these spider test runs have generally not been a problem for development.