### PR TITLE
core detection on SIGASERT by mtr

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -228,7 +228,8 @@ def createVar():
     return """
 if [ -d mysql-test/var ]; then
     extra=
-    if compgen -G  ./mysql-test/var/*/log/*/mysqld.*/data/core* > /dev/null; then
+    if compgen -G  ./mysql-test/var/*/log/*/mysqld.*/data/core* > /dev/null ||
+      compgen -G ./mysql-test/var/log/*/core* > /dev/null; then
       if [ -f sql/mysqld ]; then extra="$extra sql/mysqld"; fi
       if [ -f sql/mariadbd ]; then extra="$extra sql/mariadbd"; fi
     fi


### PR DESCRIPTION
like ./mysql-test/var/log/main.func_json_notembedded/core.gz

example - https://ci.mariadb.org/38839/logs/s390x-sles-12/var.tar.gz

build - https://buildbot.mariadb.org/#/builders/504/builds/7945

mtr timeout and hit the assert, so core was in different location.