### PR TITLE
repo symlink in /packages/ (for galera dev)

### DIFF
--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -332,7 +332,7 @@ baseurl=%(kw:url)s/%(prop:branch)s/%(prop:revision)s/%(prop:buildername)s/rpms
 gpgcheck=0
 EOF
         && cp -r rpms srpms sha256sums.txt /packages/%(prop:branch)s/%(prop:revision)s/%(prop:buildername)s/ \
-        && ln -sf %(prop:branch)s/%(prop:revision)s/%(prop:buildername)s/galera.repo %(prop:branch)s-latest-%(prop:buildername)s.repo \
+        && ln -sf %(prop:branch)s/%(prop:revision)s/%(prop:buildername)s/galera.repo /packages/%(prop:branch)s-latest-%(prop:buildername)s.repo \
         && sync /packages/%(prop:branch)s/%(prop:revision)s
 """,
             url=os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org"),

--- a/master.cfg
+++ b/master.cfg
@@ -191,7 +191,7 @@ Suites: $VERSION_CODENAME
 Components: main main/debug
 Trusted: yes
 EOF
-ln -sf %(prop:tarbuildnum)s/%(prop:buildername)s/mariadb.sources %(prop:branch)s-latest-%(prop:buildername)s.sources &&
+ln -sf %(prop:tarbuildnum)s/%(prop:buildername)s/mariadb.sources /packages/%(prop:branch)s-latest-%(prop:buildername)s.sources &&
 sync /packages/%(prop:tarbuildnum)s
     """), doStepIf=lambda step: hasFiles(step) and savePackage(step)))
 f_deb_autobake.addStep(steps.Trigger(name='dockerlibrary', schedulerNames=['s_dockerlibrary'], waitForFinish=False, updateSourceStamp=False,


### PR DESCRIPTION
Steps where executed in root, so the target is a absolute file path.