### PR TITLE
Fix check to identify Ubuntu 2004

### DIFF
--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -389,7 +389,7 @@ for os_i in os_info:
             factory = f_deb_build
 
         env = {}
-        if os == "ubuntu-2004":
+        if os_i == "ubuntu-2004":
             print("using gcc/++-10")
             env = {"CC": "gcc-10", "CXX": "g++10"}
 


### PR DESCRIPTION
The check now uses the os_i variable and not the os module