### PR TITLE
Limit galera jobs to 16 on ppc64le-db

### DIFF
--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -390,6 +390,8 @@ for os_i in os_info:
         if os_i == "ubuntu-2004":
             print("using gcc/++-10")
             env = {"CC": "gcc-10", "CXX": "g++-10"}
+        if worker_name.startswith("ppc64le-db"):
+            env = {"JOBS": "16"}
 
         c["builders"].append(
             util.BuilderConfig(


### PR DESCRIPTION
Otherwise it picks up 128 in the galera
build script scripts/build.sh and OOMs on
a compiler.

avoids - https://buildbot.dev.mariadb.org/#/builders/23/builds/5