### PR TITLE
MDBF-620: Add libpcre3-dev to jammy for asan

### DIFF
--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -80,7 +80,7 @@ RUN . /etc/os-release; \
       apt-get -y install --no-install-recommends flex; \
     fi \
     && if [ "${VERSION_CODENAME}" = jammy ]; then \
-      apt-get -y install --no-install-recommends clang-14 llvm; \
+      apt-get -y install --no-install-recommends clang-14 libpcre3-dev llvm; \
     fi \
     && apt-get clean
 


### PR DESCRIPTION
This corrects ASAN failures on 10.4

Marko:
The reason is that the old PCRE (which was replaced in 10.5 by MDEV-14024) is really buggy. For ASAN, uninstrumented code is assumed to be good.

As only 10.4 needs this, and 10.5+ uses pcre2 and has mechisms to detect pcre2 over pcre(3) aka 8.x.

With this installed, the ASAN builder should autodetect WITH_PCRE=system. Currently without headers it fails to compile.