### PR TITLE
Add repo creation tool

### DIFF
--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -68,6 +68,7 @@ RUN . /etc/os-release; \
     python3-buildbot-worker \
     python3-dev \
     python3-setuptools \
+    reprepro \
     rsync \
     scons \
     socat \


### PR DESCRIPTION
Targeting main on purpose so I can test the repo creation with new images (only pushed to registries from main branch).