### PR TITLE
cross-reference - default limit 50

### DIFF
--- a/cross-reference/crossreference/cr/models.py
+++ b/cross-reference/crossreference/cr/models.py
@@ -61,7 +61,7 @@ def select_test_failures(filters, include_failures=True):
   available_filters = ["branch", "revision", "platform", "dt", "bbnum", "typ", "info", "test_name", "test_variant", "info_text", "failure_text"]
 
   # New implementation
-  limit = 5
+  limit = 50
   if 'limit' in filters and filters['limit'] != '':
     limit = int(filters['limit'])
 


### PR DESCRIPTION
A limit of 5 doesn't show enough variety of errors to see if all branches are affected. A nieve usage could come to the conclusion that its not a common error.

The time of a 50 limit query isn't too much more,
so more is better.