### PR TITLE
Change var.tar.gz link

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -367,8 +367,7 @@ echo '<!DOCTYPE html>
 <html>
 <body>' >> {base_path}/mysql_logs.html
 
-echo '<a href=" {os.getenv('ARTIFACTS_URL', default='https://ci.mariadb.org')}/%(prop:tarbuildnum)s/logs/%(prop:buildername)s/">mysqld* log dir</a><br>' >> {base_path}/mysql_logs.html
-echo '<a href=" {os.getenv('ARTIFACTS_URL', default='https://ci.mariadb.org')}/%(prop:tarbuildnum)s/logs/%(prop:buildername)s/var.tar.gz">var.tar.gz</a><br>' >> {base_path}/mysql_logs.html
+echo '<a href=" {os.getenv('ARTIFACTS_URL', default='https://ci.mariadb.org')}/%(prop:tarbuildnum)s/logs/%(prop:buildername)s/">logs (mysqld* + var.tar.gz)</a><br>' >> {base_path}/mysql_logs.html
 
 echo '</body>
 </html>' >> {base_path}/mysql_logs.html"""


### PR DESCRIPTION
Since builders can run multiple MTR runs, the logs are organized in the form <mtr-run-name>/<log-files>. This means that having a direct link to var.tar.gz is no longer possible in the current form. This commit removes the broken link to var.tar.gz and updates the text of the current logs link to specify that the archive is found among the logs.