### PR TITLE
Create var and correctly handle logs for fulltest

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -1180,6 +1180,7 @@ f_full_test.addStep(
     )
 )
 
+
 ## f_without_server
 f_without_server = util.BuildFactory()
 f_without_server.addStep(

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -992,6 +992,84 @@ f_big_test.addStep(
     )
 )
 
+
+# Define a function to add test steps to a factory
+def add_test_steps(factory, test_types):
+    for test_type in test_types:
+        output_dir = test_type
+        # Common command before customizing per test_type
+        command_base = f"cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=10 --mem"
+
+        # Custom parts of the command
+        extra_args = ""
+        if test_type == "emb":
+            extra_args = "--embedded-server"
+        elif test_type == "ps":
+            extra_args = "--ps-protocol"
+        elif test_type == "emb-ps":
+            extra_args = "--ps --embedded"
+        elif test_type == "nm_func_1_2_stress_jp_with_big":
+            extra_args = "--suite=funcs_1,funcs_2,stress,jp --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1"
+        elif test_type == "nm_engines":
+            extra_args = "--suite=spider,spider/bg,engines/funcs,engines/iuds --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1"
+        elif test_type == "view":
+            extra_args = "--view-protocol --suite=main"
+        else:
+            # Default case for 'nm' and any other unspecified types
+            pass
+
+        # Add steps for running MTR, moving logs, and creating archives
+        factory.addStep(
+            steps.MTR(
+                logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
+                name=f"test {test_type}",
+                test_type=test_type,
+                command=[
+                    "sh",
+                    "-c",
+                    util.Interpolate(
+                        f"{command_base} {extra_args} --parallel=$(expr %(kw:jobs)s \* 2)",
+                        jobs=util.Property(
+                            "jobs", default="$(getconf _NPROCESSORS_ONLN)"
+                        ),
+                    ),
+                ],
+                timeout=10800,
+                dbpool=mtrDbPool,
+                parallel=mtrJobsMultiplier,
+                env=MTR_ENV,
+            )
+        )
+        factory.addStep(
+            steps.ShellCommand(
+                name=f"move mysqld log files {test_type}",
+                alwaysRun=True,
+                command=[
+                    "bash",
+                    "-c",
+                    util.Interpolate(
+                        moveMTRLogs(output_dir=output_dir),
+                        jobs=util.Property(
+                            "jobs", default="$(getconf _NPROCESSORS_ONLN)"
+                        ),
+                    ),
+                ],
+            )
+        )
+        factory.addStep(
+            steps.ShellCommand(
+                name=f"create var archive {test_type}",
+                alwaysRun=True,
+                command=[
+                    "bash",
+                    "-c",
+                    util.Interpolate(createVar(output_dir=output_dir)),
+                ],
+                doStepIf=hasFailed,
+            )
+        )
+
+
 ## f_full_test
 f_full_test = util.BuildFactory()
 f_full_test.addStep(
@@ -1041,145 +1119,26 @@ f_full_test.addStep(
         env={"CCACHE_DIR": "/mnt/ccache"},
     )
 )
-f_full_test.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="test emb",
-        test_type="emb",
-        command=[
-            "sh",
-            "-c",
-            util.Interpolate(
-                "cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=10 --mem --embedded-server --parallel=$(expr %(kw:jobs)s \* 2)",
-                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-            ),
-        ],
-        timeout=10800,
-        dbpool=mtrDbPool,
-        parallel=mtrJobsMultiplier,
-        env=MTR_ENV,
-    )
-)
-f_full_test.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="test n",
-        test_type="nm",
-        command=[
-            "sh",
-            "-c",
-            util.Interpolate(
-                "cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=10 --mem --parallel=$(expr %(kw:jobs)s \* 2)",
-                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-            ),
-        ],
-        timeout=10800,
-        dbpool=mtrDbPool,
-        parallel=mtrJobsMultiplier,
-        env=MTR_ENV,
-    )
-)
-f_full_test.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="test ps-protocol",
-        test_type="ps",
-        command=[
-            "sh",
-            "-c",
-            util.Interpolate(
-                "cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=10 --mem --ps-protocol --parallel=$(expr %(kw:jobs)s \* 2)",
-                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-            ),
-        ],
-        timeout=10800,
-        dbpool=mtrDbPool,
-        parallel=mtrJobsMultiplier,
-        env=MTR_ENV,
-    )
-)
-f_full_test.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="test ps-embedded",
-        test_type="emb-ps",
-        command=[
-            "sh",
-            "-c",
-            util.Interpolate(
-                "cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=10 --ps --embedded --mem --parallel=$(expr %(kw:jobs)s \* 2)",
-                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-            ),
-        ],
-        timeout=10800,
-        dbpool=mtrDbPool,
-        parallel=mtrJobsMultiplier,
-        env=MTR_ENV,
-    )
-)
-f_full_test.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="test funcs_1,2,stress,jp with big",
-        test_type="nm",
-        command=[
-            "sh",
-            "-c",
-            util.Interpolate(
-                "cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=10 --mem --suite=funcs_1,funcs_2,stress,jp --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1 --parallel=$(expr %(kw:jobs)s \* 2)",
-                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-            ),
-        ],
-        timeout=10800,
-        dbpool=mtrDbPool,
-        parallel=mtrJobsMultiplier,
-        env=MTR_ENV,
-    )
-)
-f_full_test.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="test engines",
-        test_type="nm",
-        command=[
-            "sh",
-            "-c",
-            util.Interpolate(
-                "cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=10 --mem --suite=spider,spider/bg,engines/funcs,engines/iuds --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1 --parallel=$(expr %(kw:jobs)s \* 2)",
-                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-            ),
-        ],
-        timeout=10800,
-        dbpool=mtrDbPool,
-        parallel=mtrJobsMultiplier,
-        env=MTR_ENV,
-    )
-)
-f_full_test.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="test view-protocol",
-        test_type="view",
-        command=[
-            "sh",
-            "-c",
-            util.Interpolate(
-                "cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl  --view-protocol --suite=main --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=10 --parallel=$(expr %(kw:jobs)s \* 2)",
-                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
-            ),
-        ],
-        timeout=10800,
-        dbpool=mtrDbPool,
-        parallel=mtrJobsMultiplier,
-        env=MTR_ENV,
-    )
-)
+
+# List of test configurations: (test_type, output_dir, suite)
+full_test_configs = [
+    "emb",
+    "nm",
+    "ps",
+    "emb-ps",
+    "nm_func_1_2_stress_jp_with_big",
+    "nm_engines",
+    "view",
+]
+
+# Refactor the f_full_test factory to use the new function
+add_test_steps(f_full_test, full_test_configs)
+
 f_full_test.addStep(
     steps.ShellCommand(
         name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True
     )
 )
-
 
 ## f_without_server
 f_without_server = util.BuildFactory()


### PR DESCRIPTION
Properly handle logs and create the var.tar.gz files for all MTR runs on the fulltest builder. After each MTR step, the mysqld* logs files are now stored in a separate directory. The behaviour is now consistent with other builders.