### PR TITLE
Enable replication tests for amd64-windows-packages

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -150,7 +150,7 @@ f_windows_env = {
 }
 f_windows_env.update(MTR_ENV)
 
-#f_quick_build = getQuickBuildFactory(mtrDbPool)
+# f_quick_build = getQuickBuildFactory(mtrDbPool)
 f_rpm_autobake = getRpmAutobakeFactory(mtrDbPool)
 
 ## f_windows
@@ -261,7 +261,7 @@ f_windows.addStep(
     steps.MTR(
         addLogs=True,
         name="test nm",
-        test_type='nm',
+        test_type="nm",
         command=[
             "dojob",
             '"',
@@ -285,7 +285,7 @@ f_windows.addStep(
     steps.MTR(
         addLogs=True,
         name="extra",
-        test_type='nm',
+        test_type="nm",
         command=[
             "dojob",
             '"',
@@ -456,7 +456,7 @@ f_windows_msi.addStep(
     steps.MTR(
         addLogs=True,
         name="test nm",
-        test_type='nm',
+        test_type="nm",
         command=[
             "dojob",
             '"',
@@ -480,12 +480,12 @@ f_windows_msi.addStep(
     steps.MTR(
         addLogs=True,
         name="extra",
-        test_type='nm',
+        test_type="nm",
         command=[
             "dojob",
             '"',
             util.Interpolate(
-                '"C:\Program Files (x86)\Microsoft Visual Studio\\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=%(kw:arch)s && cd mysql-test && perl mysql-test-run.pl  --verbose-restart --force  --testcase-timeout=8 --suite-timeout=600  --retry=3 --suites=connect --parallel=%(kw:jobs)s %(kw:mtr_additional_args)s',
+                '"C:\Program Files (x86)\Microsoft Visual Studio\\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=%(kw:arch)s && cd mysql-test && perl mysql-test-run.pl  --verbose-restart --force  --testcase-timeout=8 --suite-timeout=600  --retry=3 --suites=connect,replication --parallel=%(kw:jobs)s %(kw:mtr_additional_args)s',
                 mtr_additional_args=util.Property("mtr_additional_args", default=""),
                 jobs=util.Property("jobs", default=4),
                 arch=util.Property("arch", default="x64"),
@@ -775,7 +775,7 @@ f_aix.addStep(
 f_aix.addStep(
     steps.MTR(
         logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
-        test_type='nm',
+        test_type="nm",
         command=[
             "sh",
             "-c",
@@ -877,7 +877,7 @@ f_macos.addStep(
 f_macos.addStep(
     steps.MTR(
         logfiles={"mysqld*": "~/buildbot_logs/mysql_logs.html"},
-        test_type='nm',
+        test_type="nm",
         command=[
             "sh",
             "-c",
@@ -954,7 +954,7 @@ f_macos.addStep(
 )
 
 # f_freebsd
-f_freebsd = getQuickBuildFactory('nm', mtrDbPool)
+f_freebsd = getQuickBuildFactory("nm", mtrDbPool)
 f_freebsd.addStep(
     steps.ShellCommand(
         name="cleanup",


### PR DESCRIPTION
Run replication tests as part of the extra tests run by the builder.