### PR TITLE
Fedora 37 EOL

### DIFF
--- a/.github/workflows/bbw_build_container.yml
+++ b/.github/workflows/bbw_build_container.yml
@@ -73,9 +73,6 @@ jobs:
             branch: 10.11
             platforms: linux/amd64, linux/arm64/v8
           - dockerfile: fedora.Dockerfile
-            image: fedora:37
-            platforms: linux/amd64, linux/arm64/v8
-          - dockerfile: fedora.Dockerfile
             image: fedora:38
             platforms: linux/amd64, linux/arm64/v8
           - dockerfile: fedora.Dockerfile

--- a/ci_build_images/README.md
+++ b/ci_build_images/README.md
@@ -10,10 +10,10 @@ cat debian.Dockerfile common.Dockerfile >Dockerfile
 docker build . -t mariadb.org/buildbot/debian:sid --build-arg mariadb_branch=10.7 --build-arg base_image=debian:sid
 # ubuntu
 cat debian.Dockerfile common.Dockerfile >Dockerfile
-docker build . -t mariadb.org/buildbot/ubuntu:21.04 --build-arg mariadb_branch=10.7 --build-arg base_image=ubuntu:22.04
+docker build . -t mariadb.org/buildbot/ubuntu:22.04 --build-arg mariadb_branch=10.7 --build-arg base_image=ubuntu:22.04
 # fedora
 cat fedora.Dockerfile common.Dockerfile >Dockerfile
-docker build . -t mariadb.org/buildbot/fedora:34 --build-arg base_image=fedora:37
+docker build . -t mariadb.org/buildbot/fedora:39 --build-arg base_image=fedora:39
 # rhel9
 cat rhel.Dockerfile common.Dockerfile >Dockerfile
 echo "12345_KEYNAME" >rhel_keyname

--- a/constants.py
+++ b/constants.py
@@ -49,7 +49,7 @@ builders_eco = [
 builders_wordpress = ["amd64-rhel8-wordpress"]
 builders_galera_mtr = [
     "aarch64-debian-12",
-    "amd64-fedora-37",
+    "amd64-fedora-39",
     "amd64-ubuntu-2304",
     "s390x-ubuntu-2004",
     "s390x-ubuntu-2204",
@@ -109,7 +109,6 @@ supportedPlatforms["10.4"] = [
 supportedPlatforms["10.5"] = [
     "aarch64-centos-stream9",
     "aarch64-debian-11",
-    "aarch64-fedora-37",
     "aarch64-fedora-38",
     "aarch64-fedora-39",
     "aarch64-rhel-9",
@@ -119,7 +118,6 @@ supportedPlatforms["10.5"] = [
     "amd64-debian-11-msan",
     "amd64-debian-12-asan-ubsan",
     "amd64-debian-12-rocksdb",
-    "amd64-fedora-37",
     "amd64-fedora-38",
     "amd64-fedora-38-last-N-failed",
     "amd64-fedora-39",


### PR DESCRIPTION
ref https://docs.fedoraproject.org/en-US/releases/eol/

We haven't announced a last release for FC37, which I assume we're doing this release. So merge after release.