### PR TITLE
wordpress bump

### DIFF
--- a/.github/workflows/eco_containers.yml
+++ b/.github/workflows/eco_containers.yml
@@ -46,6 +46,7 @@ jobs:
           context: ${{ env.WORKDIR }}
           archs: ${{ matrix.archs }}
           oci: true
+          extra-args: --ulimit nofile=16384:16384
       - name: Check for registry credentials
         if: >
           github.ref == 'refs/heads/main' &&

--- a/eco_build_images/wordpress_phpunit_test_runner.Dockerfile
+++ b/eco_build_images/wordpress_phpunit_test_runner.Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli
+FROM php:8.3-cli
 
 # https://github.com/WordPress/phpunit-test-runner/blob/master/README.md#0-requirements
 
@@ -24,7 +24,7 @@ ENV NVM_DIR="/root/.nvm"
 
 # Match nodejs version https://nodejs.org/en/download/releases to supported npm range
 # https://github.com/WordPress/wordpress-develop/blob/trunk/package.json
-RUN bash -c "set -o pipefail ; curl -o - https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash; . \"$NVM_DIR/nvm.sh\" && nvm install 16.20.2"
+RUN bash -c "set -o pipefail ; curl -o - https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash; . \"$NVM_DIR/nvm.sh\" && nvm install 20.11.0"
 
 COPY wordpress_phpunit_test_runner.env /phpunit-test-runner/.env
 COPY wordpress_phpunit_test_runner.entrypoint /entrypoint.sh

--- a/eco_build_images/wordpress_phpunit_test_runner.Dockerfile
+++ b/eco_build_images/wordpress_phpunit_test_runner.Dockerfile
@@ -32,7 +32,7 @@ COPY wordpress_phpunit_test_runner.entrypoint /entrypoint.sh
 WORKDIR /phpunit-test-runner
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
-RUN bash -c 'source /root/.bashrc && source .env && php prepare.php'
+RUN bash -c 'source /root/.bashrc && source .env && ulimit -a && php prepare.php'
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
current test failures
```
license.txt's year needs to be updated to 2024.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'2024'
+'2023'
```

https://buildbot.mariadb.org/#/builders/505/builds/2721

so just bumping. Any bump pulls latest wordpress that has contraints https://github.com/WordPress/wordpress-develop/blob/trunk/package.json