### PR TITLE
eco: "/buildbot/installdb.sh " not found - space

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -390,8 +390,8 @@ addWorker(
 
 ####### FACTORY CODE
 
-f_quick_build = getQuickBuildFactory('nm', mtrDbPool)
-f_quick_debug = getQuickBuildFactory('debug', mtrDbPool)
+f_quick_build = getQuickBuildFactory("nm", mtrDbPool)
+f_quick_debug = getQuickBuildFactory("debug", mtrDbPool)
 f_rpm_autobake = getRpmAutobakeFactory(mtrDbPool)
 
 ## f_asan_ubsan_build
@@ -456,7 +456,7 @@ f_asan_ubsan_build.addStep(
 f_asan_ubsan_build.addStep(
     steps.MTR(
         logfiles={"mysqld*": "/buildbot/mysql_logs.html", "syslog": "/var/log/syslog"},
-        test_type='ubsan',
+        test_type="ubsan",
         command=[
             "sh",
             "-c",
@@ -577,7 +577,7 @@ f_asan_build.addStep(
 f_asan_build.addStep(
     steps.MTR(
         logfiles={"mysqld*": "/buildbot/mysql_logs.html", "syslog": "/var/log/syslog"},
-        test_type='asan',
+        test_type="asan",
         command=[
             "sh",
             "-c",
@@ -692,7 +692,7 @@ f_msan_build.addStep(
 f_msan_build.addStep(
     steps.MTR(
         logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
-        test_type='msan',
+        test_type="msan",
         command=[
             "bash",
             "-xc",
@@ -804,7 +804,7 @@ f_valgrind_build.addStep(
 f_valgrind_build.addStep(
     steps.MTR(
         logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
-        test_type='valgrind',
+        test_type="valgrind",
         command=[
             "sh",
             "-c",
@@ -928,7 +928,7 @@ f_big_test.addStep(
 f_big_test.addStep(
     steps.MTR(
         logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
-        test_type='nm',
+        test_type="nm",
         command=[
             "sh",
             "-c",
@@ -1045,7 +1045,7 @@ f_full_test.addStep(
     steps.MTR(
         addLogs=True,
         name="test emb",
-        test_type='emb',
+        test_type="emb",
         command=[
             "sh",
             "-c",
@@ -1064,7 +1064,7 @@ f_full_test.addStep(
     steps.MTR(
         addLogs=True,
         name="test n",
-        test_type='nm',
+        test_type="nm",
         command=[
             "sh",
             "-c",
@@ -1083,7 +1083,7 @@ f_full_test.addStep(
     steps.MTR(
         addLogs=True,
         name="test ps-protocol",
-        test_type='ps',
+        test_type="ps",
         command=[
             "sh",
             "-c",
@@ -1102,7 +1102,7 @@ f_full_test.addStep(
     steps.MTR(
         addLogs=True,
         name="test ps-embedded",
-        test_type='emb-ps',
+        test_type="emb-ps",
         command=[
             "sh",
             "-c",
@@ -1121,7 +1121,7 @@ f_full_test.addStep(
     steps.MTR(
         addLogs=True,
         name="test funcs_1,2,stress,jp with big",
-        test_type='nm',
+        test_type="nm",
         command=[
             "sh",
             "-c",
@@ -1140,7 +1140,7 @@ f_full_test.addStep(
     steps.MTR(
         addLogs=True,
         name="test engines",
-        test_type='nm',
+        test_type="nm",
         command=[
             "sh",
             "-c",
@@ -1159,7 +1159,7 @@ f_full_test.addStep(
     steps.MTR(
         addLogs=True,
         name="test view-protocol",
-        test_type='view',
+        test_type="view",
         command=[
             "sh",
             "-c",
@@ -1285,17 +1285,15 @@ f_eco_php.addStep(
     steps.ShellCommand(
         name="fetching and installing database",
         command=[
-            "sh",
-            "-xc",
+            "/buildbot/installdb.sh",
             util.Interpolate(
-                """
-                "/buildbot/installdb.sh " """
-                + os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
-                + """/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s" --plugin-load-add=auth_pam --pam_use_cleartext_plugin"
-            """
+                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
             ),
+            "--plugin-load-add=auth_pam",
+            "--pam_use_cleartext_plugin",
         ],
-    )
+    ),
 )
 f_eco_php.addStep(
     steps.ShellCommand(
@@ -1344,17 +1342,13 @@ f_eco_pymysql.addStep(
     steps.ShellCommand(
         name="fetching and installing database",
         command=[
-            "sh",
-            "-xc",
+            "/buildbot/installdb.sh",
             util.Interpolate(
-                """
-                "/buildbot/installdb.sh " """
-                + os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
-                + """/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
-            """
+                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
             ),
         ],
-    )
+    ),
 )
 f_eco_pymysql.addStep(
     steps.ShellCommand(
@@ -1394,17 +1388,13 @@ f_eco_mysqljs.addStep(
     steps.ShellCommand(
         name="fetching and installing database",
         command=[
-            "sh",
-            "-xc",
+            "/buildbot/installdb.sh",
             util.Interpolate(
-                """
-                "/buildbot/installdb.sh " """
-                + os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
-                + """/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
-            """
+                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
             ),
         ],
-    )
+    ),
 )
 f_eco_mysqljs.addStep(
     steps.ShellCommand(
@@ -1482,7 +1472,7 @@ f_bintar.addStep(
 f_bintar.addStep(
     steps.MTR(
         logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
-        test_type='nm',
+        test_type="nm",
         command=[
             "sh",
             "-c",


### PR DESCRIPTION
"/buildbot/installdb.sh " not found. We didn't download it with a space.

Can be run without a shell, easier to read quoting too.

+ blackify