### PR TITLE
Rename Windows extra step

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -479,7 +479,7 @@ f_windows_msi.addStep(
 f_windows_msi.addStep(
     steps.MTR(
         addLogs=True,
-        name="extra",
+        name="test extra",
         test_type="nm",
         command=[
             "dojob",


### PR DESCRIPTION
The extra testing on Windows packages is confusing so renaming it to "test extra" to better highlight that it's a testing step.