### PR TITLE
Comment mirror setup since install is done from BB artifacts

### DIFF
--- a/scripts/deb-install.sh
+++ b/scripts/deb-install.sh
@@ -32,8 +32,9 @@ for cmd in wget gunzip; do
   command -v $cmd >/dev/null || { bb_log_err "$cmd command not found" && exit 1; }
 done
 
-# setup repository
-deb_setup_mariadb_mirror "$master_branch"
+# setup repository //TEMP this should not be needed since installation is
+# supposed to be done directly from artifacts, but maybe it is for dependencies?
+# deb_setup_mariadb_mirror "$master_branch"
 
 # setup repository for BB artifacts
 deb_setup_bb_artifacts_mirror


### PR DESCRIPTION
I am not entirely sure about this. My understanding is that the mirror setup (from deb.mariadb.org) should only be done for minor/major upgrades since the VM needs to install previous versions of MariaDB and then test the upgrade from artifacts. The test should be skipped if there is no previous version (minor/major) for the OS.