### PR TITLE
Use galera from BB artifacts

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -311,6 +311,17 @@ rpm_setup_bb_galera_artifacts_mirror() {
   set +u
 }
 
+deb_setup_bb_galera_artifacts_mirror() {
+  # stop if any variable is undefined
+  set -u
+  bb_log_info "setup buildbot galera artifact repository"
+  sudo wget "$artifactsURL/galera/mariadb-4.x-latest-gal-${parentbuildername/-deb-autobake/}.sources" -O /etc/apt/sources.list.d/galera.sources || {
+    bb_log_err "unable to download $artifactsURL/galera/mariadb-4.x-latest-gal-${parentbuildername/-deb-autobake/}.sources"
+    exit 1
+  }
+  set +u
+}
+
 deb_arch() {
   case $(arch) in
     "x86_64")

--- a/scripts/deb-install.sh
+++ b/scripts/deb-install.sh
@@ -36,6 +36,9 @@ done
 # supposed to be done directly from artifacts, but maybe it is for dependencies?
 # deb_setup_mariadb_mirror "$master_branch"
 
+# setup galera repository (we need to test mariadb with latest produced galera version)A
+deb_setup_bb_galera_artifacts_mirror
+
 # setup repository for BB artifacts
 deb_setup_bb_artifacts_mirror
 


### PR DESCRIPTION
When doing installation test, we need to use the latest version of galera that was produced by BB.