### PR TITLE
Add missing builder images

### DIFF
--- a/.github/workflows/bbw_build_container.yml
+++ b/.github/workflows/bbw_build_container.yml
@@ -24,6 +24,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - dockerfile: centos.Dockerfile
+            image: almalinux:8
+            platforms: linux/amd64
+          - dockerfile: centos.Dockerfile pip.Dockerfile
+            image: almalinux:9
+            platforms: linux/amd64
           - dockerfile: debian.Dockerfile
             image: debian:10
             branch: 10.11
@@ -37,6 +43,11 @@ jobs:
             tag: debian12
             branch: 10.11
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
+          - dockerfile: debian.Dockerfile
+            image: debian:12
+            tag: debian12-386
+            branch: 10.11
+            platforms: linux/386
           - dockerfile: debian.Dockerfile aocc.Dockerfile
             image: debian:11
             tag: debian11-aocc
@@ -107,6 +118,12 @@ jobs:
             image: opensuse/leap:15.3
             tag: opensuse15
             platforms: linux/amd64
+          - dockerfile: centos.Dockerfile
+            image: rockylinux:8
+            platforms: linux/amd64, linux/arm64/v8
+          - dockerfile: centos.Dockerfile pip.Dockerfile
+            image: rockylinux:9
+            platforms: linux/amd64, linux/arm64/v8
     env:
       BUILD_RHEL: false
       DEPLOY_IMAGES: false

--- a/ci_build_images/README.md
+++ b/ci_build_images/README.md
@@ -14,6 +14,12 @@ docker build . -t mariadb.org/buildbot/ubuntu:22.04 --build-arg MARIADB_BRANCH=1
 # fedora
 cat fedora.Dockerfile common.Dockerfile >Dockerfile
 docker build . -t mariadb.org/buildbot/fedora:39 --build-arg BASE_IMAGE=fedora:39
+# almalinux9
+cat centos.Dockerfile pip.Dockerfile common.Dockerfile >Dockerfile
+docker build . -t mariadb.org/buildbot/almalinux:9 --build-arg BASE_IMAGE=almalinux:9
+# rockylinux9
+cat centos.Dockerfile pip.Dockerfile common.Dockerfile >Dockerfile
+docker build . -t mariadb.org/buildbot/rockylinux:9 --build-arg BASE_IMAGE=rockylinux:9
 # rhel9
 cat rhel.Dockerfile qpress.Dockerfile buildbot-worker.Dockerfile >Dockerfile
 echo "12345_KEYNAME" >rhel_keyname

--- a/ci_build_images/centos.Dockerfile
+++ b/ci_build_images/centos.Dockerfile
@@ -11,9 +11,9 @@ LABEL maintainer="MariaDB Buildbot maintainers"
 # hadolint ignore=SC2086
 RUN dnf -y install 'dnf-command(config-manager)' \
     && source /etc/os-release \
-    && case "$VERSION" in \
-        "9") \
-          # centosstream9 \
+    && case "$PLATFORM_ID" in \
+        "platform:el9") \
+          # centosstream9/almalinux9/rockylinux9 \
           dnf -y install epel-release; \
           dnf config-manager --set-enabled crb; \
           extra="python3-pip"; \


### PR DESCRIPTION
Build the images for the following builders:
* AlmaLinux 8,9
* Debian 12 386
* RockyLinux 8,9