### PR TITLE
Improve rpm installation/upgrade scripts

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -377,27 +377,19 @@ upgrade_test_type() {
 }
 
 check_mariadb_server_and_create_structures() {
-  if [ "$prev_major_version" != 10.3 ]; then
-    # 10.4+ uses unix_socket by default
-    sudo mysql -e "set password=password('rootpass')"
-  else
-    # Even without unix_socket, on some of VMs the password might be not pre-created as expected. This command should normally fail.
-    mysql -uroot -e "set password = password('rootpass')" >>/dev/null 2>&1
-  fi
-
   # All the commands below should succeed
   set -e
-  mysql -uroot -prootpass -e "CREATE DATABASE db"
-  mysql -uroot -prootpass -e "CREATE TABLE db.t_innodb(a1 SERIAL, c1 CHAR(8)) ENGINE=InnoDB; INSERT INTO db.t_innodb VALUES (1,'foo'),(2,'bar')"
-  mysql -uroot -prootpass -e "CREATE TABLE db.t_myisam(a2 SERIAL, c2 CHAR(8)) ENGINE=MyISAM; INSERT INTO db.t_myisam VALUES (1,'foo'),(2,'bar')"
-  mysql -uroot -prootpass -e "CREATE TABLE db.t_aria(a3 SERIAL, c3 CHAR(8)) ENGINE=Aria; INSERT INTO db.t_aria VALUES (1,'foo'),(2,'bar')"
-  mysql -uroot -prootpass -e "CREATE TABLE db.t_memory(a4 SERIAL, c4 CHAR(8)) ENGINE=MEMORY; INSERT INTO db.t_memory VALUES (1,'foo'),(2,'bar')"
-  mysql -uroot -prootpass -e "CREATE ALGORITHM=MERGE VIEW db.v_merge AS SELECT * FROM db.t_innodb, db.t_myisam, db.t_aria"
-  mysql -uroot -prootpass -e "CREATE ALGORITHM=TEMPTABLE VIEW db.v_temptable AS SELECT * FROM db.t_innodb, db.t_myisam, db.t_aria"
-  mysql -uroot -prootpass -e "CREATE PROCEDURE db.p() SELECT * FROM db.v_merge"
-  mysql -uroot -prootpass -e "CREATE FUNCTION db.f() RETURNS INT DETERMINISTIC RETURN 1"
+  sudo mysql -e "CREATE DATABASE db"
+  sudo mysql -e "CREATE TABLE db.t_innodb(a1 SERIAL, c1 CHAR(8)) ENGINE=InnoDB; INSERT INTO db.t_innodb VALUES (1,'foo'),(2,'bar')"
+  sudo mysql -e "CREATE TABLE db.t_myisam(a2 SERIAL, c2 CHAR(8)) ENGINE=MyISAM; INSERT INTO db.t_myisam VALUES (1,'foo'),(2,'bar')"
+  sudo mysql -e "CREATE TABLE db.t_aria(a3 SERIAL, c3 CHAR(8)) ENGINE=Aria; INSERT INTO db.t_aria VALUES (1,'foo'),(2,'bar')"
+  sudo mysql -e "CREATE TABLE db.t_memory(a4 SERIAL, c4 CHAR(8)) ENGINE=MEMORY; INSERT INTO db.t_memory VALUES (1,'foo'),(2,'bar')"
+  sudo mysql -e "CREATE ALGORITHM=MERGE VIEW db.v_merge AS SELECT * FROM db.t_innodb, db.t_myisam, db.t_aria"
+  sudo mysql -e "CREATE ALGORITHM=TEMPTABLE VIEW db.v_temptable AS SELECT * FROM db.t_innodb, db.t_myisam, db.t_aria"
+  sudo mysql -e "CREATE PROCEDURE db.p() SELECT * FROM db.v_merge"
+  sudo mysql -e "CREATE FUNCTION db.f() RETURNS INT DETERMINISTIC RETURN 1"
   if [[ $test_mode == "columnstore" ]]; then
-    if ! mysql -uroot -prootpass -e "CREATE TABLE db.t_columnstore(a INT, c VARCHAR(8)) ENGINE=ColumnStore; SHOW CREATE TABLE db.t_columnstore; INSERT INTO db.t_columnstore VALUES (1,'foo'),(2,'bar')"; then
+    if ! mysql -e "CREATE TABLE db.t_columnstore(a INT, c VARCHAR(8)) ENGINE=ColumnStore; SHOW CREATE TABLE db.t_columnstore; INSERT INTO db.t_columnstore VALUES (1,'foo'),(2,'bar')"; then
       get_columnstore_logs
       exit 1
     fi
@@ -407,24 +399,24 @@ check_mariadb_server_and_create_structures() {
 
 check_mariadb_server_and_verify_structures() {
   # Print "have_xx" capabilitites for the new server
-  mysql -uroot -prootpass -e "select 'Stat' t, variable_name name, variable_value val from information_schema.global_status where variable_name like '%have%' union select 'Vars' t, variable_name name, variable_value val from information_schema.global_variables where variable_name like '%have%' order by t, name"
+  mysql -e "select 'Stat' t, variable_name name, variable_value val from information_schema.global_status where variable_name like '%have%' union select 'Vars' t, variable_name name, variable_value val from information_schema.global_variables where variable_name like '%have%' order by t, name"
   # All the commands below should succeed
   set -e
-  mysql -uroot -prootpass -e "select @@version, @@version_comment"
-  mysql -uroot -prootpass -e "SHOW TABLES IN db"
-  mysql -uroot -prootpass -e "SELECT * FROM db.t_innodb; INSERT INTO db.t_innodb VALUES (3,'foo'),(4,'bar')"
-  mysql -uroot -prootpass -e "SELECT * FROM db.t_myisam; INSERT INTO db.t_myisam VALUES (3,'foo'),(4,'bar')"
-  mysql -uroot -prootpass -e "SELECT * FROM db.t_aria; INSERT INTO db.t_aria VALUES (3,'foo'),(4,'bar')"
+  sudo mysql -e "select @@version, @@version_comment"
+  sudo mysql -e "SHOW TABLES IN db"
+  sudo mysql -e "SELECT * FROM db.t_innodb; INSERT INTO db.t_innodb VALUES (3,'foo'),(4,'bar')"
+  sudo mysql -e "SELECT * FROM db.t_myisam; INSERT INTO db.t_myisam VALUES (3,'foo'),(4,'bar')"
+  sudo mysql -e "SELECT * FROM db.t_aria; INSERT INTO db.t_aria VALUES (3,'foo'),(4,'bar')"
   bb_log_info "If the next INSERT fails with a duplicate key error,"
   bb_log_info "it is likely because the server was not upgraded or restarted after upgrade"
-  mysql -uroot -prootpass -e "SELECT * FROM db.t_memory; INSERT INTO db.t_memory VALUES (1,'foo'),(2,'bar')"
-  mysql -uroot -prootpass -e "SELECT COUNT(*) FROM db.v_merge"
-  mysql -uroot -prootpass -e "SELECT COUNT(*) FROM db.v_temptable"
-  mysql -uroot -prootpass -e "CALL db.p()"
-  mysql -uroot -prootpass -e "SELECT db.f()"
+  sudo mysql -e "SELECT * FROM db.t_memory; INSERT INTO db.t_memory VALUES (1,'foo'),(2,'bar')"
+  sudo mysql -e "SELECT COUNT(*) FROM db.v_merge"
+  sudo mysql -e "SELECT COUNT(*) FROM db.v_temptable"
+  sudo mysql -e "CALL db.p()"
+  sudo mysql -e "SELECT db.f()"
 
   if [[ $test_mode == "columnstore" ]]; then
-    if ! mysql -uroot -prootpass -e "SELECT * FROM db.t_columnstore; INSERT INTO db.t_columnstore VALUES (3,'foo'),(4,'bar')"; then
+    if ! mysql -e "SELECT * FROM db.t_columnstore; INSERT INTO db.t_columnstore VALUES (3,'foo'),(4,'bar')"; then
       get_columnstore_logs
       exit 1
     fi
@@ -445,9 +437,9 @@ control_mariadb_server() {
 }
 
 store_mariadb_server_info() {
-  mysql -uroot -prootpass --skip-column-names -e "select @@version" | awk -F'-' '{ print $1 }' >"/tmp/version.$1"
-  mysql -uroot -prootpass --skip-column-names -e "select engine, support, transactions, savepoints from information_schema.engines" | sort >"/tmp/engines.$1"
-  mysql -uroot -prootpass --skip-column-names -e "select plugin_name, plugin_status, plugin_type, plugin_library, plugin_license from information_schema.all_plugins" | sort >"/tmp/plugins.$1"
+  sudo mysql --skip-column-names -e "select @@version" | awk -F'-' '{ print $1 }' >"/tmp/version.$1"
+  sudo mysql --skip-column-names -e "select engine, support, transactions, savepoints from information_schema.engines" | sort >"/tmp/engines.$1"
+  sudo mysql --skip-column-names -e "select plugin_name, plugin_status, plugin_type, plugin_library, plugin_license from information_schema.all_plugins" | sort >"/tmp/plugins.$1"
 }
 
 check_upgraded_versions() {

--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -251,22 +251,11 @@ rpm_setup_mariadb_mirror() {
     bb_log_err "wget command not found"
     exit 1
   }
-  # 10.2 is EOL and only on archive.mariadb.org
-  if [[ $branch == "10.2" ]]; then
-    mirror="https://archive.mariadb.org/mariadb-10.2/yum"
-  else
-    mirror="https://rpm.mariadb.org/$branch"
-  fi
-  if wget -q --spider "$mirror/$arch"; then
-    cat <<EOF | sudo tee /etc/yum.repos.d/MariaDB.repo
-[mariadb]
-name=MariaDB
-baseurl=$mirror/$arch
-# //TEMP following is probably not needed for all OS
-module_hotfixes = 1
-gpgkey=https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck=1
-EOF
+  #//TEMP it's probably better to install the last stable release here...?
+  if wget -q --spider "https://rpm.mariadb.org/$branch/$arch"; then
+    baseurl="https://rpm.mariadb.org/$branch/$arch"
+  elif wget -q --spider "https://archive.mariadb.org/mariadb-$branch/$arch"; then
+    baseurl="https://archive.mariadb.org/mariadb-$branch/$arch"
   else
     # the correct way of handling this would be to not even start the check
     # since we know it will always fail. But apparently, it's not going to
@@ -275,6 +264,15 @@ EOF
     bb_log_warn "rpm_setup_mariadb_mirror: $branch packages for $dist_name $version_name does not exist on https://rpm.mariadb.org/"
     exit 0
   fi
+  cat <<EOF | sudo tee /etc/yum.repos.d/MariaDB.repo
+[mariadb]
+name=MariaDB
+baseurl=$baseurl
+# //TEMP following is probably not needed for all OS
+module_hotfixes = 1
+gpgkey=https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1
+EOF
   set +u
 }
 

--- a/scripts/deb-install.sh
+++ b/scripts/deb-install.sh
@@ -99,17 +99,8 @@ if [[ -n $spider_package_list ]]; then
   sudo sh -c "DEBIAN_FRONTEND=noninteractive MYSQLD_STARTUP_TIMEOUT=180 apt-get install -y $spider_package_list"
 fi
 
-# Unix socket (after 10.3)
-if [ "${master_branch}" != 10.3 ]; then
-  sudo mysql -e "set password=password('rootpass')"
-else
-  # Even without unix_socket, on some of VMs the password might be not
-  # pre-created as expected. This command should normally fail.
-  sudo mysql -uroot -e "set password = password('rootpass')" >/dev/null 2>&1
-fi
-
-mysql --verbose -uroot -prootpass -e "create database test; use test; create table t(a int primary key) engine=innodb; insert into t values (1); select * from t; drop table t; drop database test; create user galera identified by 'gal3ra123'; grant all on *.* to galera;"
-mysql -uroot -prootpass -e "select @@version"
+sudo mysql --verbose -e "create database test; use test; create table t(a int primary key) engine=innodb; insert into t values (1); select * from t; drop table t; drop database test; create user galera identified by 'gal3ra123'; grant all on *.* to galera;"
+sudo mysql -e "select @@version"
 bb_log_info "test for MDEV-18563, MDEV-18526"
 set +e
 

--- a/scripts/deb-upgrade.sh
+++ b/scripts/deb-upgrade.sh
@@ -226,11 +226,11 @@ wait_for_mariadb_upgrade
 
 # run mysql_upgrade for non GA branches
 if [[ $major_version == "$development_branch" ]]; then
-  sudo -u mysql mysql_upgrade -uroot -prootpass
+  sudo mysql_upgrade
 fi
 
 # Make sure that the new server is running
-if mysql -uroot -prootpass -e "select @@version" | grep "$(cat /tmp/version.old)"; then
+if sudo mysql -e "select @@version" | grep "$(cat /tmp/version.old)"; then
   bb_log_err "the server was not upgraded or was not restarted after upgrade"
   exit 1
 fi

--- a/scripts/rpm-upgrade.sh
+++ b/scripts/rpm-upgrade.sh
@@ -269,14 +269,14 @@ if [[ $test_type == "major" ]]; then
 fi
 
 # Make sure that the new server is running
-if mysql -uroot -prootpass -e "select @@version" | grep "$old_version"; then
+if sudo mysql -e "select @@version" | grep "$old_version"; then
   bb_log_err "the server was not upgraded or was not restarted after upgrade"
   exit 1
 fi
 
 # Run mysql_upgrade for non-GA branches (minor upgrades in GA branches shouldn't need it)
 if [[ $major_version == "$development_branch" ]] || [[ $test_type == "major" ]]; then
-  sudo -u mysql mysql_upgrade -uroot -prootpass
+  sudo mysql_upgrade
 fi
 set +e
 

--- a/scripts/rpm-upgrade.sh
+++ b/scripts/rpm-upgrade.sh
@@ -48,13 +48,13 @@ case $test_mode in
   all)
     # retrieve full package list from repo
     pkg_list=$(rpm_repoquery) ||
-      bb_log_err "Unable to retrieve package list from repository"
+      bb_log_err "unable to retrieve package list from repository"
     ;;
   server)
     pkg_list="MariaDB-server MariaDB-client"
     ;;
   *)
-    bb_log_err "unknown test mode: $test_mode"
+    bb_log_err "unknown test mode ($test_mode)"
     exit 1
     ;;
 esac


### PR DESCRIPTION
follow-up on https://github.com/MariaDB/buildbot/pull/308

- Install previous major from archive if not available from rpm.mariadb.org;
- use socket for mariadb client;
- install only server/client packages for now (get back to a stable test/upgrade suite).