### PR TITLE
Repoquery needs to be run in quiet mode

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -181,7 +181,7 @@ rpm_repoquery() {
   fi
 
   # return full package list from repository
-  sudo repoquery --disablerepo=* --enablerepo="${repo_name}" -a |
+  repoquery --disablerepo=* --enablerepo="${repo_name}" -a -q |
     cut -d ":" -f1 | sort -u | sed 's/-0//'
 }
 


### PR DESCRIPTION
If not it may print not only packages but other informations (on RHEL for instance).