### PR TITLE
Add a new instance for master-docker-nonstandard

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -397,6 +397,40 @@ services:
       - mariadb
       - crossbar
 
+  master-docker-nonstandard-2:
+    image: quay.io/mariadb-foundation/bb-master:master
+    restart: unless-stopped
+    container_name: master-docker-nonstandard-2
+    environment:
+      - GALERA_PACKAGES_DIR
+      - ENVIRON
+      - TITLE
+      - BRANCH
+      - ARTIFACTS_URL
+      - TITLE_URL
+      - BUILDMASTER_WG_IP
+      - NGINX_ARTIFACTS_VHOST
+      - MASTER_PACKAGES_DIR
+      - MQ_ROUTER_URL
+      - BUILDMASTER_URL
+      - PORT=10004
+    hostname: master-docker-nonstandard-2
+    volumes:
+      - ./logs:/var/log/buildbot
+      - ./buildbot/:/srv/buildbot/master
+    entrypoint:
+      - /bin/bash
+      - -c
+      - "/srv/buildbot/master/docker-compose/start.sh master-docker-nonstandard-2"
+    networks:
+      net_front:
+      net_back:
+    ports:
+      - "100.64.101.1:10007:10007"
+    depends_on:
+      - mariadb
+      - crossbar
+
   master-galera:
     image: quay.io/mariadb-foundation/bb-master:master
     restart: unless-stopped

--- a/docker-compose/generate-config.py
+++ b/docker-compose/generate-config.py
@@ -19,6 +19,7 @@ MASTER_DIRECTORIES = [
     "master-docker-nonstandard",
     "master-galera",
     "master-protected-branches",
+    "master-docker-nonstandard-2",
 ]
 
 START_TEMPLATE = """

--- a/master-docker-nonstandard-2/buildbot.tac
+++ b/master-docker-nonstandard-2/buildbot.tac
@@ -1,0 +1,33 @@
+import os
+
+from twisted.application import service
+from buildbot.master import BuildMaster
+
+basedir = '.'
+log_basedir = '/var/log/buildbot/'
+
+rotateLength = 20000000
+maxRotatedFiles = 30
+configfile = 'master.cfg'
+
+# Default umask for server
+umask = None
+
+# if this is a relocatable tac file, get the directory containing the TAC
+if basedir == '.':
+    import os
+    basedir = os.path.abspath(os.path.dirname(__file__))
+
+# note: this line is matched against to check that this is a buildmaster
+# directory; do not edit it.
+application = service.Application('buildmaster')
+from twisted.python.logfile import LogFile
+from twisted.python.log import ILogObserver, FileLogObserver
+logfile = LogFile.fromFullPath(os.path.join(log_basedir, "master-docker-non-standard-2.log"), rotateLength=rotateLength,
+                                maxRotatedFiles=maxRotatedFiles)
+application.setComponent(ILogObserver, FileLogObserver(logfile).emit)
+
+m = BuildMaster(basedir, configfile, umask)
+m.setServiceParent(application)
+m.log_rotation.rotateLength = rotateLength
+m.log_rotation.maxRotatedFiles = maxRotatedFiles

--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -1,0 +1,1393 @@
+# -*- python -*-
+# ex: set filetype=python:
+
+from buildbot.plugins import *
+from buildbot.process.properties import Property, Properties
+from buildbot.steps.shell import ShellCommand, Compile, Test, SetPropertyFromCommand
+from buildbot.steps.mtrlogobserver import MTR, MtrLogObserver
+from buildbot.steps.source.github import GitHub
+from buildbot.process.remotecommand import RemoteCommand
+from datetime import timedelta
+from twisted.internet import defer
+
+import docker
+import os
+import sys
+
+sys.path.insert(0, "/srv/buildbot/master")
+sys.setrecursionlimit(10000)
+
+from common_factories import *
+from constants import *
+from locks import *
+from schedulers_definition import *
+from utils import *
+
+FQDN = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
+
+# This is the dictionary that the buildmaster pays attention to. We also use
+# a shorter alias to save typing.
+c = BuildmasterConfig = {}
+
+# Load the slave, database passwords and 3rd-party tokens from an external private file, so
+# that the rest of the configuration can be public.
+config = {"private": {}}
+exec(open("../master-private.cfg").read(), config, {})
+
+####### BUILDBOT SERVICES
+
+# 'services' is a list of BuildbotService items like reporter targets. The
+# status of each build will be pushed to these targets. buildbot/reporters/*.py
+# has a variety to choose from, like IRC bots.
+
+
+c["services"] = []
+context = util.Interpolate("buildbot/%(prop:buildername)s")
+gs = reporters.GitHubStatusPush(
+    token=config["private"]["gh_mdbci"]["access_token"],
+    context=context,
+    startDescription="Build started.",
+    endDescription="Build done.",
+    verbose=True,
+    builders=github_status_builders,
+)
+c["services"].append(gs)
+
+####### PROJECT IDENTITY
+
+# the 'title' string will appear at the top of this buildbot installation's
+# home pages (linked to the 'titleURL').
+c["title"] = os.getenv("TITLE", default="MariaDB CI")
+c["titleURL"] = os.getenv("TITLE_URL", default="https://github.com/MariaDB/server")
+
+# the 'buildbotURL' string should point to the location where the buildbot's
+# internal web server is visible. This typically uses the port number set in
+# the 'www' entry below, but with an externally-visible host name which the
+# buildbot cannot figure out without some help.
+c["buildbotURL"] = os.getenv("BUILDMASTER_URL", default="https://buildbot.mariadb.org/")
+
+# 'protocols' contains information about protocols which master will use for
+# communicating with workers. You must define at least 'port' option that workers
+# could connect to your master with this protocol.
+# 'port' must match the value configured into the workers (with their
+# --master option)
+port = int(os.getenv("PORT", default="9992"))
+c["protocols"] = {"pb": {"port": port}}
+
+####### DB URL
+
+c["db"] = {
+    # This specifies what database buildbot uses to store its state.
+    "db_url": config["private"]["db_url"]
+}
+
+mtrDbPool = util.EqConnectionPool(
+    "MySQLdb",
+    config["private"]["db_host"],
+    config["private"]["db_user"],
+    config["private"]["db_password"],
+    config["private"]["db_mtr_db"],
+)
+
+####### Disable net usage reports from being sent to buildbot.net
+c["buildbotNetUsageData"] = None
+
+####### SCHEDULERS
+
+# Configure the Schedulers, which decide how to react to incoming changes.
+c["schedulers"] = getSchedulers()
+
+####### WORKERS
+
+# The 'workers' list defines the set of recognized workers. Each element is
+# a Worker object, specifying a unique worker name and password.  The same
+# worker name and password must be configured on the worker.
+c["workers"] = []
+
+workers = {}
+
+
+def addWorker(
+    worker_name_prefix,
+    worker_id,
+    worker_type,
+    dockerfile,
+    jobs=5,
+    save_packages=False,
+    shm_size="15G",
+):
+    name, instance = createWorker(
+        worker_name_prefix,
+        worker_id,
+        worker_type,
+        dockerfile,
+        jobs,
+        save_packages,
+        shm_size,
+    )
+
+    if name[0] not in workers:
+        workers[name[0]] = [name[1]]
+    else:
+        workers[name[0]].append(name[1])
+
+    c["workers"].append(instance)
+
+
+# Docker workers
+fqdn = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
+
+addWorker(
+    "apexis-bbw",
+    3,
+    "-debian-12-32-bit",
+    "quay.io/mariadb-foundation/bb-worker:debian12-386",
+    jobs=20,
+    save_packages=False,
+)
+
+addWorker(
+    "apexis-bbw",
+    3,
+    "-msan-clang-16-debian-11",
+    "quay.io/mariadb-foundation/bb-worker:debian11-msan-clang-16",
+    jobs=20,
+    save_packages=False,
+)
+
+####### FACTORY CODE
+
+f_quick_build = getQuickBuildFactory("nm", mtrDbPool)
+f_quick_debug = getQuickBuildFactory("debug", mtrDbPool)
+f_rpm_autobake = getRpmAutobakeFactory(mtrDbPool)
+
+## f_asan_ubsan_build
+f_asan_ubsan_build = util.BuildFactory()
+f_asan_ubsan_build.addStep(
+    steps.ShellCommand(
+        name="Environment details",
+        command=["bash", "-c", "date -u && uname -a && ulimit -a"],
+    )
+)
+f_asan_ubsan_build.addStep(
+    steps.SetProperty(
+        property="dockerfile",
+        value=util.Interpolate("%(kw:url)s", url=dockerfile),
+        description="dockerfile",
+    )
+)
+f_asan_ubsan_build.addStep(downloadSourceTarball())
+f_asan_ubsan_build.addStep(
+    steps.ShellCommand(
+        command=util.Interpolate(
+            "tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1"
+        )
+    )
+)
+f_asan_ubsan_build.addStep(
+    steps.ShellCommand(
+        name="create html log file",
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                getHTMLLogString(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+# build steps
+f_asan_ubsan_build.addStep(
+    steps.ShellCommand(
+        command='echo "leak:libtasn1\nleak:libgnutls\nleak:libgmp" > mysql-test/lsan.supp',
+        doStepIf=filterBranch,
+    )
+)
+f_asan_ubsan_build.addStep(
+    steps.ShellCommand(command="cat mysql-test/lsan.supp", doStepIf=filterBranch)
+)
+f_asan_ubsan_build.addStep(
+    steps.Compile(
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                "cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DWITH_ASAN=YES -DWITH_UBSAN=YES -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF -DWITH_ZLIB=bundled -DWITH_SSL=bundled -DWITH_DBUG_TRACE=OFF -DWITH_SAFEMALLOC=OFF && make VERBOSE=1 -j%(kw:jobs)s package",
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        haltOnFailure="true",
+    )
+)
+f_asan_ubsan_build.addStep(
+    steps.MTR(
+        logfiles={"mysqld*": "/buildbot/mysql_logs.html", "syslog": "/var/log/syslog"},
+        test_type="ubsan",
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                'cd mysql-test && MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=`pwd`/lsan.supp" perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)',
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        timeout=950,
+        haltOnFailure="true",
+        parallel=mtrJobsMultiplier,
+        dbpool=mtrDbPool,
+        autoCreateTables=True,
+        env=MTR_ENV,
+    )
+)
+f_asan_ubsan_build.addStep(
+    steps.ShellCommand(
+        name="move mysqld log files",
+        alwaysRun=True,
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                moveMTRLogs(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+f_asan_ubsan_build.addStep(
+    steps.ShellCommand(
+        name="create var archive",
+        alwaysRun=True,
+        command=["bash", "-c", util.Interpolate(createVar())],
+        doStepIf=hasFailed,
+    )
+)
+f_asan_ubsan_build.addStep(
+    steps.DirectoryUpload(
+        name="save mysqld log files",
+        compress="bz2",
+        alwaysRun=True,
+        workersrc="/buildbot/logs/",
+        masterdest=util.Interpolate(
+            "/srv/buildbot/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/logs/"
+            + "%(prop:buildername)s"
+        ),
+    )
+)
+f_asan_ubsan_build.addStep(
+    steps.ShellCommand(
+        name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True
+    )
+)
+
+## f_asan_build
+f_asan_build = util.BuildFactory()
+f_asan_build.addStep(
+    steps.ShellCommand(
+        name="Environment details",
+        command=["bash", "-c", "date -u && uname -a && ulimit -a"],
+    )
+)
+f_asan_build.addStep(
+    steps.SetProperty(
+        property="dockerfile",
+        value=util.Interpolate("%(kw:url)s", url=dockerfile),
+        description="dockerfile",
+    )
+)
+f_asan_build.addStep(downloadSourceTarball())
+f_asan_build.addStep(
+    steps.ShellCommand(
+        command=util.Interpolate(
+            "tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1"
+        )
+    )
+)
+f_asan_build.addStep(
+    steps.ShellCommand(
+        name="create html log file",
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                getHTMLLogString(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+# build steps
+f_asan_build.addStep(
+    steps.ShellCommand(
+        command='echo "leak:libtasn1\nleak:libgnutls\nleak:libgmp" > mysql-test/lsan.supp',
+        doStepIf=filterBranch,
+    )
+)
+f_asan_build.addStep(
+    steps.ShellCommand(command="cat mysql-test/lsan.supp", doStepIf=filterBranch)
+)
+f_asan_build.addStep(
+    steps.Compile(
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                'cmake . -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_C_FLAGS="-O2 -msse4.2 -Wno-unused-command-line-argument -fdebug-macro -Wno-inconsistent-missing-override" -DCMAKE_CXX_FLAGS="-O2 -msse4.2 -Wno-unused-command-line-argument -fdebug-macro -Wno-inconsistent-missing-override" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DWITH_ASAN=YES -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF -DWITH_ZLIB=bundled -DWITH_SSL=bundled -DWITH_DBUG_TRACE=OFF -DWITH_SAFEMALLOC=OFF && make VERBOSE=1 -j%(kw:jobs)s package',
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        haltOnFailure="true",
+    )
+)
+f_asan_build.addStep(
+    steps.MTR(
+        logfiles={"mysqld*": "/buildbot/mysql_logs.html", "syslog": "/var/log/syslog"},
+        test_type="asan",
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                'cd mysql-test && MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=`pwd`/lsan.supp" perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)',
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        timeout=950,
+        haltOnFailure="true",
+        parallel=mtrJobsMultiplier,
+        dbpool=mtrDbPool,
+        autoCreateTables=True,
+        env=MTR_ENV,
+    )
+)
+f_asan_build.addStep(
+    steps.ShellCommand(
+        name="move mysqld log files",
+        alwaysRun=True,
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                moveMTRLogs(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+f_asan_build.addStep(
+    steps.ShellCommand(
+        name="create var archive",
+        alwaysRun=True,
+        command=["bash", "-c", util.Interpolate(createVar())],
+        doStepIf=hasFailed,
+    )
+)
+f_asan_build.addStep(
+    steps.DirectoryUpload(
+        name="save mysqld log files",
+        compress="bz2",
+        alwaysRun=True,
+        workersrc="/buildbot/logs/",
+        masterdest=util.Interpolate(
+            "/srv/buildbot/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/logs/"
+            + "%(prop:buildername)s"
+        ),
+    )
+)
+f_asan_build.addStep(
+    steps.ShellCommand(
+        name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True
+    )
+)
+
+## f_msan_build
+f_msan_build = util.BuildFactory()
+f_msan_build.addStep(
+    steps.ShellCommand(
+        name="Environment details",
+        command=["bash", "-c", "date -u && uname -a && ulimit -a"],
+    )
+)
+f_msan_build.addStep(
+    steps.SetProperty(
+        property="dockerfile",
+        value=util.Interpolate("%(kw:url)s", url=dockerfile),
+        description="dockerfile",
+    )
+)
+f_msan_build.addStep(
+    steps.ShellCommand(
+        name="create html log file",
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                getHTMLLogString(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+f_msan_build.addStep(downloadSourceTarball())
+f_msan_build.addStep(
+    steps.ShellCommand(
+        command=util.Interpolate(
+            "tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1"
+        )
+    )
+)
+# build steps
+f_msan_build.addStep(steps.ShellCommand(command="ls /msan-libs"))
+f_msan_build.addStep(
+    steps.Compile(
+        command=[
+            "bash",
+            "-xc",
+            util.Interpolate(
+                'cmake . -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DCMAKE_C_FLAGS="-O2 -Wno-unused-command-line-argument -fdebug-macro" -DCMAKE_CXX_FLAGS="-stdlib=libc++ -O2 -Wno-unused-command-line-argument -fdebug-macro" -DWITH_EMBEDDED_SERVER=OFF -DWITH_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DWITH_INNODB_{BZIP2,LZ4,LZMA,LZO,SNAPPY}=OFF -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER}=NO -DWITH_SAFEMALLOC=OFF -DWITH_{ZLIB,SSL,PCRE}=bundled -DHAVE_LIBAIO_H=0 -DCMAKE_DISABLE_FIND_PACKAGE_{URING,LIBAIO}=1 -DWITH_MSAN=ON -DWITH_DBUG_TRACE=OFF && make -j%(kw:jobs)s package',
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+                c_compiler=util.Property("c_compiler", default="clang"),
+                cxx_compiler=util.Property("cxx_compiler", default="clang++"),
+            ),
+        ],
+        haltOnFailure="true",
+    )
+)
+f_msan_build.addStep(
+    steps.MTR(
+        logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
+        test_type="msan",
+        command=[
+            "bash",
+            "-xc",
+            util.Interpolate(
+                'cd mysql-test && LD_LIBRARY_PATH=/msan-libs MSAN_OPTIONS=abort_on_error=1:poison_in_dtor=0 ./mtr --mem --big-test --force --retry=0 --skip-test=".*compression.*|rpl\.rpl_non_direct_row_mixing_engines|perfschema\.table_io_aggregate_hist_\du_\dt|perfschema\.transaction_nested_events|perfschema\.events_waits_current_MDEV-29091|perfschema\.memory_aggregate_no_a_no_u_no_h|main\.show_explain|main\.show_analyze_json" --max-test-fail=100 --parallel=$(expr %(kw:jobs)s \* 2)',
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        timeout=950,
+        haltOnFailure="true",
+        parallel=mtrJobsMultiplier,
+        dbpool=mtrDbPool,
+        autoCreateTables=True,
+        env=MTR_ENV,
+    )
+)
+f_msan_build.addStep(
+    steps.ShellCommand(
+        name="move mysqld log files",
+        alwaysRun=True,
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                moveMTRLogs(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+f_msan_build.addStep(
+    steps.ShellCommand(
+        name="create var archive",
+        alwaysRun=True,
+        command=["bash", "-c", util.Interpolate(createVar())],
+        doStepIf=hasFailed,
+    )
+)
+f_msan_build.addStep(
+    steps.DirectoryUpload(
+        name="save mysqld log files",
+        compress="bz2",
+        alwaysRun=True,
+        workersrc="/buildbot/logs/",
+        masterdest=util.Interpolate(
+            "/srv/buildbot/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/logs/"
+            + "%(prop:buildername)s"
+        ),
+    )
+)
+f_msan_build.addStep(
+    steps.ShellCommand(
+        name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True
+    )
+)
+
+## f_valgrind_build
+f_valgrind_build = util.BuildFactory()
+f_valgrind_build.addStep(
+    steps.ShellCommand(
+        name="Environment details",
+        command=["bash", "-c", "date -u && uname -a && ulimit -a"],
+    )
+)
+f_valgrind_build.addStep(
+    steps.SetProperty(
+        property="dockerfile",
+        value=util.Interpolate("%(kw:url)s", url=dockerfile),
+        description="dockerfile",
+    )
+)
+f_valgrind_build.addStep(
+    steps.ShellCommand(
+        name="create html log file",
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                getHTMLLogString(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+f_valgrind_build.addStep(downloadSourceTarball())
+f_valgrind_build.addStep(
+    steps.ShellCommand(
+        command=util.Interpolate(
+            "tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1"
+        )
+    )
+)
+# build steps
+f_valgrind_build.addStep(
+    steps.Compile(
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                "cmake . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DENABLE_ASSEMBLER=1 -DWITH_EXTRA_CHARSETS=complex -DENABLE_THREAD_SAFE_CLIENT=1 -DWITH_BIG_TABLES=1 -DWITH_PLUGIN_ARIA=1 -DWITH_ARIA_TMP_TABLES=1 -DWITH_JEMALLOC=NO -DCMAKE_BUILD_TYPE=Debug -DSECURITY_HARDENED=OFF -DWITH_VALGRIND=1 -DHAVE_LIBAIO_H=0 -DCMAKE_DISABLE_FIND_PACKAGE_URING=1 -DCMAKE_DISABLE_FIND_PACKAGE_LIBAIO=1 -DWITH_SSL=bundled -DWITH_MAX=AUTO -DWITH_EMBEDDED_SERVER=1 -DWITH_LIBEVENT=bundled -DPLUGIN_PLUGIN_FILE_KEY_MANAGEMENT=NO -DPLUGIN_TEST_SQL_DISCOVERY=DYNAMIC -DPLUGIN_TOKUDB=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_AUTH_GSSAPI=NO -DENABLE_LOCAL_INFILE=1 -DMYSQL_SERVER_SUFFIX=-valgrind-max -DWITH_DBUG_TRACE=OFF && make -j%(kw:jobs)s",
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        haltOnFailure="true",
+    )
+)
+f_valgrind_build.addStep(
+    steps.MTR(
+        logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
+        test_type="valgrind",
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                'cd mysql-test && perl mysql-test-run.pl --valgrind="--leak-check=summary --gen-suppressions=yes --num-callers=10" --skip-test="encryption\.*|^perfschema\.short_option_1$" --mysqld="--loose-innodb-purge-threads=1" --force --retry=0 --max-save-core=1 --max-save-datadir=10 --max-test-fail=20 --parallel=$(expr %(kw:jobs)s \* 2)',
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        timeout=950,
+        haltOnFailure="true",
+        parallel=mtrJobsMultiplier,
+        dbpool=mtrDbPool,
+        autoCreateTables=True,
+        env=MTR_ENV,
+    )
+)
+f_valgrind_build.addStep(
+    steps.ShellCommand(
+        name="move mysqld log files",
+        alwaysRun=True,
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                moveMTRLogs(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+f_valgrind_build.addStep(
+    steps.ShellCommand(
+        name="create var archive",
+        alwaysRun=True,
+        command=["bash", "-c", util.Interpolate(createVar())],
+        doStepIf=hasFailed,
+    )
+)
+f_valgrind_build.addStep(
+    steps.DirectoryUpload(
+        name="save mysqld log files",
+        compress="bz2",
+        alwaysRun=True,
+        workersrc="/buildbot/logs/",
+        masterdest=util.Interpolate(
+            "/srv/buildbot/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/logs/"
+            + "%(prop:buildername)s"
+        ),
+    )
+)
+f_valgrind_build.addStep(
+    steps.ShellCommand(
+        name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True
+    )
+)
+
+## f_big_test
+f_big_test = util.BuildFactory()
+f_big_test.addStep(
+    steps.ShellCommand(
+        name="Environment details",
+        command=["bash", "-c", "date -u && uname -a && ulimit -a"],
+    )
+)
+f_big_test.addStep(
+    steps.SetProperty(
+        property="dockerfile",
+        value=util.Interpolate("%(kw:url)s", url=dockerfile),
+        description="dockerfile",
+    )
+)
+f_big_test.addStep(
+    steps.ShellCommand(
+        name="create html log file",
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                getHTMLLogString(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+# get the source tarball and extract it
+f_big_test.addStep(
+    steps.FileDownload(
+        mastersrc=util.Interpolate(
+            "/srv/buildbot/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/"
+            + "%(prop:mariadb_version)s"
+            + ".tar.gz"
+        ),
+        workerdest=util.Interpolate("%(prop:mariadb_version)s" + ".tar.gz"),
+    )
+)
+f_big_test.addStep(
+    steps.ShellCommand(
+        command=util.Interpolate(
+            "tar -xvzf " + "%(prop:mariadb_version)s" + ".tar.gz --strip-components=1"
+        )
+    )
+)
+# build steps
+f_big_test.addStep(
+    steps.Compile(
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                "export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DPLUGIN_ROCKSDB=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_SPHINX=NO && make -j%(kw:jobs)s VERBOSE=1 package",
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        env={"CCACHE_DIR": "/mnt/ccache"},
+    )
+)
+f_big_test.addStep(
+    steps.MTR(
+        logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
+        test_type="nm",
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                "cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=10 --max-test-fail=20 --big --mem --parallel=$(expr %(kw:jobs)s \* 2) --skip-test=archive.archive-big",
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        timeout=950,
+        dbpool=mtrDbPool,
+        parallel=mtrJobsMultiplier,
+        env=MTR_ENV,
+    )
+)
+f_big_test.addStep(
+    steps.ShellCommand(
+        name="move mysqld log files",
+        alwaysRun=True,
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                moveMTRLogs(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+f_big_test.addStep(
+    steps.ShellCommand(
+        name="create var archive",
+        alwaysRun=True,
+        command=["bash", "-c", util.Interpolate(createVar())],
+        doStepIf=hasFailed,
+    )
+)
+f_big_test.addStep(
+    steps.DirectoryUpload(
+        name="save mysqld log files",
+        compress="bz2",
+        alwaysRun=True,
+        workersrc="/buildbot/logs/",
+        masterdest=util.Interpolate(
+            "/srv/buildbot/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/logs/"
+            + "%(prop:buildername)s"
+        ),
+    )
+)
+# create package and upload to master
+f_big_test.addStep(
+    steps.SetPropertyFromCommand(
+        command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary"
+    )
+)
+# f_big_test.addStep(steps.ShellCommand(name='save_packages', timeout=7200, haltOnFailure=True, command=util.Interpolate('mkdir -p ' + '/packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s'+ ' && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp ' + '%(prop:mariadb_binary)s sha256sums.txt' + ' /packages/' + '%(prop:tarbuildnum)s' + '/' + '%(prop:buildername)s' + '/' +  ' && sync /packages/' + '%(prop:tarbuildnum)s'), doStepIf=savePackage))
+f_big_test.addStep(
+    steps.ShellCommand(
+        name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True
+    )
+)
+
+
+# Define a function to add test steps to a factory
+def add_test_steps(factory, test_types):
+    for test_type in test_types:
+        output_dir = test_type
+        # Common command before customizing per test_type
+        command_base = f"cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=0 --max-save-datadir=10 --mem"
+
+        # Custom parts of the command
+        extra_args = ""
+        if test_type == "emb":
+            extra_args = "--embedded-server"
+        elif test_type == "ps":
+            extra_args = "--ps-protocol"
+        elif test_type == "emb-ps":
+            extra_args = "--ps --embedded"
+        elif test_type == "nm_func_1_2_stress_jp_with_big":
+            extra_args = "--suite=funcs_1,funcs_2,stress,jp --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1"
+        elif test_type == "nm_engines":
+            extra_args = "--suite=spider,spider/bg,engines/funcs,engines/iuds --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1"
+        elif test_type == "view":
+            extra_args = "--view-protocol --suite=main"
+        else:
+            # Default case for 'nm' and any other unspecified types
+            pass
+
+        # Add steps for running MTR, moving logs, and creating archives
+        factory.addStep(
+            steps.MTR(
+                logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
+                name=f"test {test_type}",
+                test_type=test_type,
+                command=[
+                    "sh",
+                    "-c",
+                    util.Interpolate(
+                        f"{command_base} {extra_args} --parallel=$(expr %(kw:jobs)s \* 2)",
+                        jobs=util.Property(
+                            "jobs", default="$(getconf _NPROCESSORS_ONLN)"
+                        ),
+                    ),
+                ],
+                timeout=10800,
+                dbpool=mtrDbPool,
+                parallel=mtrJobsMultiplier,
+                env=MTR_ENV,
+            )
+        )
+        factory.addStep(
+            steps.ShellCommand(
+                name=f"move mysqld log files {test_type}",
+                alwaysRun=True,
+                command=[
+                    "bash",
+                    "-c",
+                    util.Interpolate(
+                        moveMTRLogs(output_dir=output_dir),
+                        jobs=util.Property(
+                            "jobs", default="$(getconf _NPROCESSORS_ONLN)"
+                        ),
+                    ),
+                ],
+            )
+        )
+        factory.addStep(
+            steps.ShellCommand(
+                name=f"create var archive {test_type}",
+                alwaysRun=True,
+                command=[
+                    "bash",
+                    "-c",
+                    util.Interpolate(createVar(output_dir=output_dir)),
+                ],
+                doStepIf=hasFailed,
+            )
+        )
+
+
+## f_full_test
+f_full_test = util.BuildFactory()
+f_full_test.addStep(
+    steps.ShellCommand(
+        name="Environment details",
+        command=["bash", "-c", "date -u && uname -a && ulimit -a"],
+    )
+)
+f_full_test.addStep(
+    steps.SetProperty(
+        property="dockerfile",
+        value=util.Interpolate("%(kw:url)s", url=dockerfile),
+        description="dockerfile",
+    )
+)
+# get the source tarball and extract it
+f_full_test.addStep(
+    steps.FileDownload(
+        mastersrc=util.Interpolate(
+            "/srv/buildbot/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/"
+            + "%(prop:mariadb_version)s"
+            + ".tar.gz"
+        ),
+        workerdest=util.Interpolate("%(prop:mariadb_version)s" + ".tar.gz"),
+    )
+)
+f_full_test.addStep(
+    steps.ShellCommand(
+        command=util.Interpolate(
+            "tar -xvzf " + "%(prop:mariadb_version)s" + ".tar.gz --strip-components=1"
+        )
+    )
+)
+# build steps
+f_full_test.addStep(
+    steps.Compile(
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                "export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DBUILD_CONFIG=mysql_release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DWITH_SSL=system -DWITH_JEMALLOC=auto -DWITH_EMBEDDED_SERVER=1 -DHAVE_EMBEDDED_PRIVILEGE_CONTROL=1 -DWITH_LIBARCHIVE=ON -Wno-dev && make -j%(kw:jobs)s VERBOSE=1 package",
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        env={"CCACHE_DIR": "/mnt/ccache"},
+    )
+)
+
+# List of test configurations: (test_type, output_dir, suite)
+full_test_configs = [
+    "emb",
+    "nm",
+    "ps",
+    "emb-ps",
+    "nm_func_1_2_stress_jp_with_big",
+    "nm_engines",
+    "view",
+]
+
+# Refactor the f_full_test factory to use the new function
+add_test_steps(f_full_test, full_test_configs)
+
+f_full_test.addStep(
+    steps.ShellCommand(
+        name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True
+    )
+)
+
+## f_without_server
+f_without_server = util.BuildFactory()
+f_without_server.addStep(
+    steps.ShellCommand(
+        name="Environment details",
+        command=["bash", "-c", "date -u && uname -a && ulimit -a"],
+    )
+)
+f_without_server.addStep(
+    steps.SetProperty(
+        property="dockerfile",
+        value=util.Interpolate("%(kw:url)s", url=dockerfile),
+        description="dockerfile",
+    )
+)
+f_without_server.addStep(steps.ShellCommand(command="ls -la"))
+f_without_server.addStep(downloadSourceTarball())
+f_without_server.addStep(steps.ShellCommand(command="ls -la"))
+f_without_server.addStep(
+    steps.ShellCommand(
+        command=util.Interpolate(
+            "tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1"
+        )
+    )
+)
+f_without_server.addStep(steps.ShellCommand(command="ls -la"))
+# build steps
+f_without_server.addStep(
+    steps.Compile(
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                "export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DWITHOUT_SERVER=1 && make -j%(kw:jobs)s package",
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+                c_compiler=util.Property("c_compiler", default="gcc"),
+                cxx_compiler=util.Property("cxx_compiler", default="g++"),
+            ),
+        ],
+        env={"CCACHE_DIR": "/mnt/ccache"},
+        haltOnFailure="true",
+    )
+)
+# create package and upload to master
+f_without_server.addStep(
+    steps.SetPropertyFromCommand(
+        command="basename mariadb-*-linux-*.tar.gz", property="mariadb_binary"
+    )
+)
+f_without_server.addStep(
+    steps.ShellCommand(
+        name="save_packages",
+        timeout=7200,
+        haltOnFailure=True,
+        command=util.Interpolate(
+            "mkdir -p "
+            + "/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/"
+            + "%(prop:buildername)s"
+            + " && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp "
+            + "%(prop:mariadb_binary)s sha256sums.txt"
+            + " /packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/"
+            + "%(prop:buildername)s"
+            + "/"
+            + " && sync /packages/"
+            + "%(prop:tarbuildnum)s"
+        ),
+        doStepIf=savePackage,
+    )
+)
+f_without_server.addStep(
+    steps.ShellCommand(
+        name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True
+    )
+)
+
+## f_eco_php
+f_eco_php = util.BuildFactory()
+f_eco_php.addStep(
+    steps.ShellCommand(
+        name="fetch_install_script",
+        command=[
+            "sh",
+            "-xc",
+            "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/installdb.sh -o /buildbot/installdb.sh && chmod a+x /buildbot/installdb.sh",
+        ],
+    )
+)
+f_eco_php.addStep(
+    steps.ShellCommand(
+        name="fetch_test_script",
+        command=[
+            "sh",
+            "-xc",
+            "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-php.sh -o /buildbot/test-php.sh && chmod a+x /buildbot/test-php.sh",
+        ],
+    )
+)
+f_eco_php.addStep(
+    steps.ShellCommand(
+        name="fetching and installing database",
+        command=[
+            "/buildbot/installdb.sh",
+            util.Interpolate(
+                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
+            ),
+            "--plugin-load-add=auth_pam",
+            "--pam_use_cleartext_plugin",
+        ],
+    ),
+)
+f_eco_php.addStep(
+    steps.ShellCommand(
+        name="test PHP-7.1", command=["sh", "-xc", "/buildbot/test-php.sh PHP-7.1"]
+    )
+)
+f_eco_php.addStep(
+    steps.ShellCommand(
+        name="test PHP-8.0", command=["sh", "-xc", "/buildbot/test-php.sh PHP-8.0"]
+    )
+)
+f_eco_php.addStep(
+    steps.ShellCommand(
+        name="test PHP-8.1", command=["sh", "-xc", "/buildbot/test-php.sh PHP-8.1"]
+    )
+)
+f_eco_php.addStep(
+    steps.ShellCommand(
+        name="test master", command=["sh", "-xc", "/buildbot/test-php.sh"]
+    )
+)
+
+## f_eco_pymysql
+f_eco_pymysql = util.BuildFactory()
+f_eco_pymysql.addStep(
+    steps.ShellCommand(
+        name="fetch_install_script",
+        command=[
+            "sh",
+            "-xc",
+            "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/installdb.sh -o /buildbot/installdb.sh && chmod a+x /buildbot/installdb.sh",
+        ],
+    )
+)
+f_eco_pymysql.addStep(
+    steps.ShellCommand(
+        name="fetch_test_script",
+        command=[
+            "sh",
+            "-xc",
+            "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-pymysql.sh -o /buildbot/test-pymysql.sh && chmod a+x /buildbot/test-pymysql.sh",
+        ],
+    )
+)
+f_eco_pymysql.addStep(
+    steps.ShellCommand(
+        name="fetching and installing database",
+        command=[
+            "/buildbot/installdb.sh",
+            util.Interpolate(
+                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
+            ),
+        ],
+    ),
+)
+f_eco_pymysql.addStep(
+    steps.ShellCommand(
+        name="test pymysql-main", command=["sh", "-xc", "/buildbot/test-pymysql.sh"]
+    )
+)
+f_eco_pymysql.addStep(
+    steps.ShellCommand(
+        name="test pymysql-v0.7.11",
+        command=["sh", "-xc", "/buildbot/test-pymysql.sh v0.7.11"],
+    )
+)
+
+## f_eco_mysqljs
+f_eco_mysqljs = util.BuildFactory()
+f_eco_mysqljs.addStep(
+    steps.ShellCommand(
+        name="fetch_install_script",
+        command=[
+            "sh",
+            "-xc",
+            "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/installdb.sh -o /buildbot/installdb.sh && chmod a+x /buildbot/installdb.sh",
+        ],
+    )
+)
+f_eco_mysqljs.addStep(
+    steps.ShellCommand(
+        name="fetch_test_script",
+        command=[
+            "sh",
+            "-xc",
+            "curl https://raw.githubusercontent.com/MariaDB/buildbot/main/dockerfiles/ecofiles/test-mysqljs.sh -o /buildbot/test-mysqljs.sh && chmod a+x /buildbot/test-mysqljs.sh",
+        ],
+    )
+)
+f_eco_mysqljs.addStep(
+    steps.ShellCommand(
+        name="fetching and installing database",
+        command=[
+            "/buildbot/installdb.sh",
+            util.Interpolate(
+                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
+            ),
+        ],
+    ),
+)
+f_eco_mysqljs.addStep(
+    steps.ShellCommand(
+        name="test mysqljs-master", command=["sh", "-xc", "/buildbot/test-mysqljs.sh"]
+    )
+)
+f_eco_mysqljs.addStep(
+    steps.ShellCommand(
+        name="test mysqljs-v2.18.1",
+        command=["sh", "-xc", "/buildbot/test-mysqljs.sh v2.18.1"],
+    )
+)
+
+## f_bintar
+f_bintar = util.BuildFactory()
+f_bintar.addStep(
+    steps.ShellCommand(
+        name="Environment details",
+        command=["bash", "-c", "date -u && uname -a && ulimit -a"],
+    )
+)
+f_bintar.addStep(
+    steps.SetProperty(
+        property="dockerfile",
+        value=util.Interpolate("%(kw:url)s", url=dockerfile),
+        description="dockerfile",
+    )
+)
+f_bintar.addStep(downloadSourceTarball())
+f_bintar.addStep(
+    steps.ShellCommand(
+        command=util.Interpolate(
+            "tar -xvzf /mnt/packages/%(prop:tarbuildnum)s_%(prop:mariadb_version)s.tar.gz --strip-components=1"
+        )
+    )
+)
+f_bintar.addStep(
+    steps.ShellCommand(
+        name="create html log file",
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                getHTMLLogString(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+# build steps
+f_bintar.addStep(
+    steps.Compile(
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                'cmake . -DWITH_READLINE=1 -DBUILD_CONFIG=mysql_release -DCMAKE_C_FLAGS="%(kw:gnutls_no_signal)s" -DCMAKE_CXX_FLAGS="%(kw:gnutls_no_signal)s" -DWITH_SSL=bundled -DPLATFORM=linux-systemd && make -j%(kw:jobs)s package',
+                perf_schema=util.Property("perf_schema", default="YES"),
+                build_type=util.Property("build_type", default="RelWithDebInfo"),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+                c_compiler=util.Property("c_compiler", default="gcc"),
+                cxx_compiler=util.Property("cxx_compiler", default="g++"),
+                additional_args=util.Property("additional_args", default=""),
+                create_package=util.Property("create_package", default="package"),
+                gnutls_no_signal=util.Property("gnutls_no_signal", default=" "),
+            ),
+        ],
+        env={
+            "CCACHE_DIR": "/mnt/ccache",
+            "CMAKE_LIBRARY_PATH": "/scripts/local/lib/",
+        },
+        haltOnFailure="true",
+    )
+)
+f_bintar.addStep(
+    steps.MTR(
+        logfiles={"mysqld*": "/buildbot/mysql_logs.html"},
+        test_type="nm",
+        command=[
+            "sh",
+            "-c",
+            util.Interpolate(
+                "cd mysql-test && exec perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=1 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2) %(kw:mtr_additional_args)s",
+                mtr_additional_args=util.Property("mtr_additional_args", default=""),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+        timeout=950,
+        haltOnFailure="true",
+        parallel=mtrJobsMultiplier,
+        dbpool=mtrDbPool,
+        autoCreateTables=True,
+        env=MTR_ENV,
+    )
+)
+f_bintar.addStep(
+    steps.ShellCommand(
+        name="move mysqld log files",
+        alwaysRun=True,
+        command=[
+            "bash",
+            "-c",
+            util.Interpolate(
+                moveMTRLogs(),
+                jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
+            ),
+        ],
+    )
+)
+f_bintar.addStep(
+    steps.ShellCommand(
+        name="create var archive",
+        alwaysRun=True,
+        command=["bash", "-c", util.Interpolate(createVar())],
+        doStepIf=hasFailed,
+    )
+)
+f_bintar.addStep(
+    steps.DirectoryUpload(
+        name="save log files",
+        compress="bz2",
+        alwaysRun=True,
+        workersrc="/buildbot/logs/",
+        masterdest=util.Interpolate(
+            "/srv/buildbot/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/logs/"
+            + "%(prop:buildername)s"
+        ),
+    )
+)
+## trigger packages
+f_bintar.addStep(
+    steps.Trigger(
+        schedulerNames=["s_packages"],
+        waitForFinish=False,
+        updateSourceStamp=False,
+        alwaysRun=True,
+        set_properties={
+            "parentbuildername": Property("buildername"),
+            "tarbuildnum": Property("tarbuildnum"),
+            "mariadb_version": Property("mariadb_version"),
+            "master_branch": Property("master_branch"),
+        },
+        doStepIf=hasAutobake,
+    )
+)
+## trigger bigtest
+f_bintar.addStep(
+    steps.Trigger(
+        schedulerNames=["s_bigtest"],
+        waitForFinish=False,
+        updateSourceStamp=False,
+        set_properties={
+            "parentbuildername": Property("buildername"),
+            "tarbuildnum": Property("tarbuildnum"),
+            "mariadb_version": Property("mariadb_version"),
+            "master_branch": Property("master_branch"),
+        },
+        doStepIf=hasBigtest,
+    )
+)
+# create package and upload to master
+f_bintar.addStep(
+    steps.SetPropertyFromCommand(
+        command="basename mariadb-*-linux-*.tar.gz",
+        property="mariadb_binary",
+        doStepIf=savePackage,
+    )
+)
+f_bintar.addStep(
+    steps.ShellCommand(
+        name="save_packages",
+        timeout=7200,
+        haltOnFailure=True,
+        command=util.Interpolate(
+            "mkdir -p "
+            + "/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/"
+            + "%(prop:buildername)s"
+            + " && sha256sum %(prop:mariadb_binary)s >> sha256sums.txt  && cp "
+            + "%(prop:mariadb_binary)s sha256sums.txt"
+            + " /packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/"
+            + "%(prop:buildername)s"
+            + "/"
+            + " && sync /packages/"
+            + "%(prop:tarbuildnum)s"
+        ),
+        doStepIf=savePackage,
+    )
+)
+f_bintar.addStep(
+    steps.Trigger(
+        name="eco",
+        schedulerNames=["s_eco"],
+        waitForFinish=False,
+        updateSourceStamp=False,
+        set_properties={
+            "parentbuildername": Property("buildername"),
+            "tarbuildnum": Property("tarbuildnum"),
+            "mariadb_binary": Property("mariadb_binary"),
+            "mariadb_version": Property("mariadb_version"),
+            "master_branch": Property("master_branch"),
+            "parentbuildername": Property("buildername"),
+        },
+        doStepIf=lambda step: savePackage(step) and hasEco(step),
+    )
+)
+f_bintar.addStep(
+    steps.ShellCommand(
+        name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True
+    )
+)
+
+# f_prep_local
+f_prep_local = util.BuildFactory()
+f_prep_local.addStep(
+    steps.ShellCommand(
+        name="dummy",
+        command="ls",
+    )
+)
+
+
+####### BUILDERS LIST
+
+c["builders"] = []
+
+c["builders"].append(
+    util.BuilderConfig(
+        name="x86-debian-12-fulltest",
+        workernames=workers["x64-bbw-docker-debian-12-32-bit"],
+        tags=["Ubuntu", "full", "gcc"],
+        collapseRequests=True,
+        nextBuild=nextBuild,
+        canStartBuild=canStartBuild,
+        locks=getLocks,
+        factory=f_full_test,
+    )
+)
+
+c["builders"].append(
+    util.BuilderConfig(
+        name="amd64-debian-11-msan-clang-16",
+        workernames=workers["x64-bbw-docker-msan-clang-16-debian-11"],
+        tags=["Debian", "quick", "clang-16", "msan"],
+        collapseRequests=True,
+        nextBuild=nextBuild,
+        canStartBuild=canStartBuild,
+        properties={"c_compiler": "clang-16", "cxx_compiler": "clang++-16"},
+        locks=getLocks,
+        factory=f_msan_build,
+    )
+)
+
+c["logEncoding"] = "utf-8"
+
+c["multiMaster"] = True
+
+c["mq"] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
+    "type": "wamp",
+    "router_url": os.getenv("MQ_ROUTER_URL", default="ws://localhost:8085/ws"),
+    "realm": "realm1",
+    # valid are: none, critical, error, warn, info, debug, trace
+    "wamp_debug_level": "info",
+}

--- a/master-private.cfg-sample
+++ b/master-private.cfg-sample
@@ -78,6 +78,7 @@ private["docker_workers"]= {
     "aarch64-bbw7-docker":"tcp://IP_address:port",
     "apexis-bbw1-docker":"tcp://IP_address:port",
     "apexis-bbw2-docker":"tcp://IP_address:port",
+    "apexis-bbw3-docker":"tcp://IP_address:port",
     "ns-x64-bbw1-docker":"tcp://IP_address:port", # bg-bbw1
     "ns-x64-bbw2-docker":"tcp://IP_address:port", # bg-bbw2
     "ns-x64-bbw3-docker":"tcp://IP_address:port", # bg-bbw3

--- a/validate_master_cfg.sh
+++ b/validate_master_cfg.sh
@@ -29,7 +29,7 @@ $RUNC run -i -v "$(pwd):/srv/buildbot/master" -w /srv/buildbot/master quay.io/ma
 echo -e "done\n"
 # not checking libvirt config file (//TEMP we need to find a solution
 # to not check ssh connection)
-for dir in master-docker-nonstandard master-galera master-nonlatent master-web master-protected-branches autogen/*; do
+for dir in master-docker-nonstandard master-docker-nonstandard-2 master-galera master-nonlatent master-web master-protected-branches autogen/*; do
   echo "Checking $dir/master.cfg"
   $RUNC run -i -v "$(pwd):/srv/buildbot/master" -w /srv/buildbot/master quay.io/mariadb-foundation/bb-master:master bash -c "cd $dir && buildbot checkconfig master.cfg"
   echo -e "done\n"


### PR DESCRIPTION
The current master process already handles too many builds, so a new instance is needed. This new instance currently handles the following builders:

* amd64-debian-11-msan-clang-16
* x86-debian-12-fulltest