### PR TITLE
Deb sourcelist format change and galera deps installation

### DIFF
--- a/ci_build_images/README.md
+++ b/ci_build_images/README.md
@@ -6,13 +6,13 @@ Command line example to manually build containers:
 
 ```console
 # debian
-cat debian.Dockerfile common.Dockerfile >Dockerfile
-docker build . -t mariadb.org/buildbot/debian:sid --build-arg MARIADB_BRANCH=10.7 --build-arg BASE_IMAGE=debian:sid
+cat debian.Dockerfile buildbot-worker.Dockerfile >Dockerfile
+docker build . -t mariadb.org/buildbot/debian:sid --build-arg MARIADB_BRANCH=11.1 --build-arg BASE_IMAGE=debian:sid
 # ubuntu
-cat debian.Dockerfile common.Dockerfile >Dockerfile
-docker build . -t mariadb.org/buildbot/ubuntu:22.04 --build-arg MARIADB_BRANCH=10.7 --build-arg BASE_IMAGE=ubuntu:22.04
+cat debian.Dockerfile buildbot-worker.Dockerfile >Dockerfile
+docker build . -t mariadb.org/buildbot/ubuntu:22.04 --build-arg MARIADB_BRANCH=11.1 --build-arg BASE_IMAGE=ubuntu:22.04
 # fedora
-cat fedora.Dockerfile common.Dockerfile >Dockerfile
+cat fedora.Dockerfile buildbot-worker.Dockerfile >Dockerfile
 docker build . -t mariadb.org/buildbot/fedora:39 --build-arg BASE_IMAGE=fedora:39
 # rhel9
 cat rhel.Dockerfile qpress.Dockerfile buildbot-worker.Dockerfile >Dockerfile

--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -13,32 +13,38 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Enable apt sources
-RUN if [ -f /etc/apt/sources.list ]; then \
-      sed 's/^deb /deb-src /g' /etc/apt/sources.list >/etc/apt/sources.list.d/debian-sources.list; \
-    fi \
-    # see man 5 sources.list (DEB822-STYLE FORMAT) \
-    && if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
-      sed -i 's/Types: deb/Types: deb deb-src/g' /etc/apt/sources.list.d/debian.sources; \
+RUN . /etc/os-release \
+    && if [ -f "/etc/apt/sources.list.d/$ID.sources" ]; then \
+      sed -i 's/Types: deb/Types: deb deb-src/g' "/etc/apt/sources.list.d/$ID.sources"; \
+    elif [ -f /etc/apt/sources.list ]; then \
+      sed 's/^deb /deb-src /g' /etc/apt/sources.list >"/etc/apt/sources.list.d/$ID-sources.list"; \
+    else \
+      echo "ERROR: can't find apt repo configuration file"; \
+      exit 1; \
     fi
 
 # Install updates and required packages
 # see: https://cryptography.io/en/latest/installation/
-RUN . /etc/os-release; \
-    apt-get update \
+RUN . /etc/os-release \
+    && apt-get update \
     && apt-get -y upgrade \
-    && apt-get -y install --no-install-recommends curl ca-certificates devscripts equivs lsb-release \
+    && apt-get -y install --no-install-recommends \
+    ca-certificates \
+    curl \
+    devscripts  \
+    equivs  \
+    lsb-release \
     && if [ "${VERSION_ID}" = "20.04" ]; then apt-get -y install --no-install-recommends g++-10; fi \
     && if [ "$(arch)" = "x86_64" ]; then ARCH="amd64"; else ARCH=$(arch); fi \
-    && curl -s "https://ci.mariadb.org/galera/mariadb-4.x-latest-gal-${ARCH}-${ID}-$(echo "$VERSION_ID" | sed 's/\.//').sources" >/etc/apt/sources.list.d/galera-4.sources \
-    # trixie VERSION_ID=13 once released \
-    # 24.04 noble - until galera build happens based on this image, then rebuild so galera tests can occur
-    && if [ "${VERSION_ID}" = 24.04 ] || [ "${VERSION_CODENAME}" = trixie ] || [ "$(getconf LONG_BIT)" = 32 ]; then rm /etc/apt/sources.list.d/galera-4.sources; fi \
+    && if curl --head --silent "https://ci.mariadb.org/galera/mariadb-4.x-latest-gal-${ARCH}-${ID}-$(echo "$VERSION_ID" | sed 's/\.//').sources" | head -n1 | grep -q 200; then \
+      curl -s "https://ci.mariadb.org/galera/mariadb-4.x-latest-gal-${ARCH}-${ID}-$(echo "$VERSION_ID" | sed 's/\.//').sources" >/etc/apt/sources.list.d/galera-4.sources; \
+    fi \
     && apt-get update \
     && curl -skO https://raw.githubusercontent.com/MariaDB/server/44e4b93316be8df130c6d87880da3500d83dbe10/debian/control \
     && mkdir debian \
     && mv control debian/control \
     && touch debian/rules VERSION debian/not-installed \
-    && curl -skO https://raw.githubusercontent.com/MariaDB/server/$MARIADB_BRANCH/debian/autobake-deb.sh \
+    && curl -skO "https://raw.githubusercontent.com/MariaDB/server/$MARIADB_BRANCH/debian/autobake-deb.sh" \
     && chmod a+x autobake-deb.sh \
     && AUTOBAKE_PREP_CONTROL_RULES_ONLY=1 ./autobake-deb.sh \
     && mk-build-deps -r -i debian/control \


### PR DESCRIPTION
The new APT source list format is now default in Ubuntu 24.04 (was already in Debian Sid).
Make galera installation from BB CI more dynamic.