### PR TITLE
fedora - add gdb to build image

### DIFF
--- a/ci_build_images/fedora.Dockerfile
+++ b/ci_build_images/fedora.Dockerfile
@@ -26,6 +26,7 @@ RUN dnf -y upgrade \
     fmt-devel \
     galera \
     gawk \
+    gdb \
     iproute \
     java-1.8.0-openjdk-devel \
     java-1.8.0-openjdk \


### PR DESCRIPTION

from [amd64-fedora-38-last-N-failed](https://buildbot.mariadb.org/#/builders/620)[2102](https://buildbot.mariadb.org/#/builders/620/builds/2102)debug-emb-ps test[stdio](https://buildbot.mariadb.org/#/builders/620/builds/2102/steps/20/logs/stdio):
```
select 2 is true = 3 AS `2 IS TRUE = 3`,2 is false = 3 AS `2 IS FALSE = 3`,/*always not null*/ 1 is null = 3 AS `2 IS UNKNOWN = 3`,/*always not null*/ 1 is null = 3 AS `2 IS NULL = 3`,/*always not null*/ 1 is null = 1 AS `ISNULL(2) = 1`
drop view v1;
 - found 'core', moving it to '/home/buildbot/amd64-fedora-38-last-N-failed/build/mysql-test/var/11/log/main.precedence'
 - found 'core' (1/1)
gdb not found, cannot get the stack trace
```