### PR TITLE
MDBF-660 Move builders to other machines

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -258,11 +258,14 @@ for w_name in ["ppc64le-db-bbw"]:
         save_packages=True,
     )
 
-## ns-x64-bbw-docker
-for w_name in ["ns-x64-bbw"]:
-    end_range = 6
-    for i in range(1, end_range):
-        jobs = 7
+## x64-bbw-docker
+for w_name in ["ns-x64-bbw", "apexis-bbw"]:
+    worker_ids = list(range(1, 5))
+    jobs = 7
+    if "apexis" in w_name:
+        worker_ids = [3]
+        jobs = 10
+    for i in worker_ids:
         addWorker(
             w_name,
             i,
@@ -1625,7 +1628,7 @@ c["builders"] = []
 c["builders"].append(
     util.BuilderConfig(
         name="amd64-debian-11-aocc",
-        workernames=workers["ns-x64-bbw-docker-aocc-debian-11"],
+        workernames=workers["x64-bbw-docker-aocc-debian-11"],
         tags=["Ubuntu", "quick", "aocc"],
         collapseRequests=True,
         nextBuild=nextBuild,
@@ -1651,7 +1654,7 @@ c["builders"].append(
 c["builders"].append(
     util.BuilderConfig(
         name="amd64-ubuntu-2204-icc",
-        workernames=workers["ns-x64-bbw-docker-icc-ubuntu-2204"],
+        workernames=workers["x64-bbw-docker-icc-ubuntu-2204"],
         tags=["Ubuntu", "quick", "icc", "icpc"],
         collapseRequests=True,
         nextBuild=nextBuild,
@@ -1714,7 +1717,7 @@ c["builders"].append(
 c["builders"].append(
     util.BuilderConfig(
         name="amd64-ubuntu-2004-fulltest",
-        workernames=workers["ns-x64-bbw-docker-ubuntu-2004"],
+        workernames=workers["x64-bbw-docker-ubuntu-2004"],
         tags=["Ubuntu", "full", "gcc"],
         collapseRequests=True,
         nextBuild=nextBuild,
@@ -1740,7 +1743,7 @@ c["builders"].append(
 c["builders"].append(
     util.BuilderConfig(
         name="amd64-ubuntu-2204-clang14-asan",
-        workernames=workers["ns-x64-bbw-docker-asan-ubuntu-2204"],
+        workernames=workers["x64-bbw-docker-asan-ubuntu-2204"],
         tags=["Ubuntu", "quick", "clang-14", "asan"],
         collapseRequests=True,
         nextBuild=nextBuild,

--- a/utils.py
+++ b/utils.py
@@ -83,6 +83,8 @@ def createWorker(
         b_name = "x64-bbw"
     elif worker_name_prefix.startswith("apexis"):
         b_name = "x64-bbw"
+    elif worker_name_prefix.startswith("ns"):
+        b_name = "x64-bbw"
     else:
         b_name = worker_name_prefix
     base_name = b_name + "-docker" + worker_type


### PR DESCRIPTION
Disable the bg-bbw[4,5] builders since they have very high CPU IO wait time. Move the load to apexis-bbw3 for the builders using these machines including the ASAN builder mentioned in MDBF-660