### PR TITLE
Add Fedora 40 to build

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -175,10 +175,12 @@ supportedPlatforms["10.10"] += supportedPlatforms["10.9"]
 supportedPlatforms["10.11"] = [
     "aarch64-debian-12",
     "aarch64-debian-sid",
+    "aarch64-fedora-40",
     "aarch64-ubuntu-2310",
     "aarch64-ubuntu-2404",
     "amd64-debian-12",
     "amd64-debian-sid",
+    "amd64-fedora-40",
     "amd64-ubuntu-2310",
     "amd64-ubuntu-2404",
     "ppc64le-debian-sid",


### PR DESCRIPTION
Fedora 40 is targetting 10.11 - https://src.fedoraproject.org/rpms/mariadb10.11/tree/f40 - so lets build this so downstream can experience less problems in their packaging.