### PR TITLE
Un-necessary cleanup

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -978,13 +978,6 @@ f_macos.addStep(
 
 # f_freebsd
 f_freebsd = getQuickBuildFactory("nm", mtrDbPool)
-f_freebsd.addStep(
-    steps.ShellCommand(
-        name="cleanup",
-        command="for d in packages buildbot; do [[ -d $d ]] && rm -rf $d; done",
-        alwaysRun=True,
-    )
-)
 
 ####### BUILDERS LIST
 c["builders"] = []


### PR DESCRIPTION
This is already covered by previous cleanup:

`name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True`