### PR TITLE
hasCompat simplify

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -466,15 +466,11 @@ def hasEco(props):
 def hasCompat(step):
     builderName = str(step.getProperty("buildername"))
 
-    # For s390x there are no compat files
-    if "s390x" in builderName:
+    # For s390x and the listed distros there are no compat files
+    if any(builderName.find(sub) != -1 for sub in {"s390x", "fedora", "alma", "rocky"}):
         return False
     if "rhel" in builderName or "centos" in builderName:
         return step.getProperty("rpm_type")[-1] in ["7", "8"]
-    if "fedora" in builderName:
-        return step.getProperty("rpm_type")[-1] in ["35", "36"]
-    if "alma" in builderName or "rocky" in builderName:
-        return False
     return True
 
 


### PR DESCRIPTION
Fedora case was always false (was only comparing one char), but given that we're only doing 38+ it doesn't matter any more.

Compact on rejections.

btw why is rocky compat being fetched on https://buildbot.mariadb.org/#/builders/654