### PR TITLE
Make amd64-debian-11-msan-clang-16 report to GitHub

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -30,6 +30,7 @@ github_status_builders = [
     "amd64-debian-10-last-N-failed",
     "amd64-debian-11-debug-ps-embedded",
     "amd64-debian-11-msan",
+    "amd64-debian-11-msan-clang-16",
     "amd64-fedora-38",
     "amd64-fedora-38-last-N-failed",
     "amd64-ubuntu-2004-debug",

--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -167,8 +167,8 @@ addWorker(
 addWorker(
     "apexis-bbw",
     3,
-    "-msan-clang-16-debian-11",
-    "quay.io/mariadb-foundation/bb-worker:debian11-msan-clang-16",
+    "-msan-clang-debian-11",
+    "quay.io/mariadb-foundation/bb-worker:debian11-msan",
     jobs=20,
     save_packages=False,
 )
@@ -1286,13 +1286,13 @@ c["builders"].append(
 
 c["builders"].append(
     util.BuilderConfig(
-        name="amd64-debian-11-msan-clang-16",
-        workernames=workers["x64-bbw-docker-msan-clang-16-debian-11"],
-        tags=["Debian", "quick", "clang-16", "msan"],
+        name="amd64-debian-11-msan",
+        workernames=workers["x64-bbw-docker-msan-clang-debian-11"],
+        tags=["Debian", "quick", "clang-15", "msan"],
         collapseRequests=True,
         nextBuild=nextBuild,
         canStartBuild=canStartBuild,
-        properties={"c_compiler": "clang-16", "cxx_compiler": "clang++-16"},
+        properties={"c_compiler": "clang-15", "cxx_compiler": "clang++-15"},
         locks=getLocks,
         factory=f_msan_build,
     )

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -328,24 +328,24 @@ addWorker(
 addWorker(
     "hz-bbw",
     1,
-    "-msan-clang-debian-11",
-    "quay.io/mariadb-foundation/bb-worker:debian11-msan",
+    "-msan-clang-16-debian-11",
+    "quay.io/mariadb-foundation/bb-worker:debian11-msan-clang-16",
     jobs=20,
     save_packages=False,
 )
 addWorker(
     "hz-bbw",
     4,
-    "-msan-clang-debian-11",
-    "quay.io/mariadb-foundation/bb-worker:debian11-msan",
+    "-msan-clang-16-debian-11",
+    "quay.io/mariadb-foundation/bb-worker:debian11-msan-clang-16",
     jobs=20,
     save_packages=False,
 )
 addWorker(
     "hz-bbw",
     5,
-    "-msan-clang-debian-11",
-    "quay.io/mariadb-foundation/bb-worker:debian11-msan",
+    "-msan-clang-16-debian-11",
+    "quay.io/mariadb-foundation/bb-worker:debian11-msan-clang-16",
     jobs=30,
     save_packages=False,
 )
@@ -1679,13 +1679,13 @@ c["builders"].append(
 
 c["builders"].append(
     util.BuilderConfig(
-        name="amd64-debian-11-msan",
-        workernames=workers["x64-bbw-docker-msan-clang-debian-11"],
-        tags=["Debian", "quick", "clang-15", "msan", "protected"],
+        name="amd64-debian-11-msan-clang-16",
+        workernames=workers["x64-bbw-docker-msan-clang-16-debian-11"],
+        tags=["Debian", "quick", "clang-16", "msan", "protected"],
         collapseRequests=True,
         nextBuild=nextBuild,
         canStartBuild=canStartBuild,
-        properties={"c_compiler": "clang-15", "cxx_compiler": "clang++-15"},
+        properties={"c_compiler": "clang-16", "cxx_compiler": "clang++-16"},
         locks=getLocks,
         factory=f_msan_build,
     )


### PR DESCRIPTION
This will replace amd64-debian-11-msan as a branch protection builder, so swapping the hardware used by one with the other.