### PR TITLE
Save images only on prod

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -599,9 +599,7 @@ f_wordpress.addStep(
         command=[
             "sh",
             "-c",
-            util.Interpolate(
-                "podman pod exists wptest || podman pod create -n wptest"
-            ),
+            util.Interpolate("podman pod exists wptest || podman pod create -n wptest"),
         ],
     )
 )
@@ -731,15 +729,13 @@ f_dockerlibrary.addStep(
 f_dockerlibrary.addStep(
     steps.ShellCommand(
         name="build quay.io manifest image for MariaDB",
-        env={'SAVE_PACKAGES': lambda step: str(savePackage(step))},
         command=[
             "bash",
             "-xc",
             util.Interpolate(
-                './docker-library-manifest.sh "%(prop:tarbuildnum)s" "%(prop:mariadb_version)s" "%(prop:parentbuildername)s" "%(prop:revision)s" "%(prop:branch)s" "${SAVE_PACKAGES:-False}"'
+                './docker-library-manifest.sh "%(prop:tarbuildnum)s" "%(prop:mariadb_version)s" "%(prop:parentbuildername)s" "%(prop:revision)s" "%(prop:branch)s" "%(prop:save_packages)s"'
             ),
         ],
-        doStepIf=lambda step: savePackage(step),
     )
 )
 
@@ -1005,6 +1001,7 @@ c["builders"].append(
         nextBuild=nextBuild,
         canStartBuild=canStartBuild,
         factory=f_dockerlibrary,
+        properties={"save_packages": os.getenv("ENVIRON") != "DEV"},
     )
 )
 


### PR DESCRIPTION
The dockerlibrary builder is always triggered only if packages need to be saved, so set the save_packages property to False for the DEV builder.