### PR TITLE
Disable buster build

### DIFF
--- a/.github/workflows/bbw_build_container.yml
+++ b/.github/workflows/bbw_build_container.yml
@@ -31,10 +31,6 @@ jobs:
             image: almalinux:9
             platforms: linux/amd64
           - dockerfile: debian.Dockerfile
-            image: debian:10
-            branch: 10.11
-            platforms: linux/amd64, linux/arm64/v8
-          - dockerfile: debian.Dockerfile
             image: debian:11
             branch: 10.11
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le


### PR DESCRIPTION
- EOL end of June 2024;
- libpmem is only available on AMD64;
- libfmt is too old.