### PR TITLE
Changed debian files or cpack_rpm.cmake should trigger save_packages

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -169,7 +169,7 @@ for w_name in master_config["workers"]:
 
 ####### FACTORY CODE
 
-f_quick_build = getQuickBuildFactory('nm', mtrDbPool)
+f_quick_build = getQuickBuildFactory("nm", mtrDbPool)
 f_rpm_autobake = getRpmAutobakeFactory(mtrDbPool)
 
 ## f_deb_autobake
@@ -383,6 +383,22 @@ for builder in master_config["builders"]:
             factory=factory_instance,
         )
     )
+
+
+def file_change_hook(change):
+    changed_files = change.files
+    properties = {}
+    for file_path in changed_files:
+        if fnmatch.fnmatch(file, "debian/*"):
+            properties["debian_changes"] = True
+        if fnmatch.fnmatch(file, "cmake/cpack_rpm.cmake"):
+            properties["debian_changes"] = True
+    if properties:
+        properties["save_packages"] = True
+    return properties
+
+
+c["change_hooks"] = [file_change_hook]
 
 c["logEncoding"] = "utf-8"
 


### PR DESCRIPTION
Changes to package fundamentals should save the packages, and this will trigger the post testing like install/upgrade tests.

This avoid situations encountered in #3210 where the pull request didn't actually trigger any install/upgrade tests. Once merged into the main branch many things where failing.

This is something half AI generated and I could wrong in how to do this and the github interactions that make this possible. Draft concept.