### PR TITLE
Add protected tag to aarch64-macos-compile-only

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -1063,7 +1063,7 @@ c["builders"].append(
     util.BuilderConfig(
         name="aarch64-macos-compile-only",
         workernames=["bbw1-mac", "bbw2-mac"],
-        tags=["MacOS", "quick"],
+        tags=["MacOS", "quick", "protected"],
         collapseRequests=True,
         nextBuild=nextBuild,
         factory=get_macos_factory(compile_only=True),


### PR DESCRIPTION
The tag must be added because the builder is used for branch protection
