### PR TITLE
Repo needs to be adapted on all RHEL8 based distro

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -463,7 +463,7 @@ name=MariaDB %(prop:branch)s repo (build %(prop:tarbuildnum)s)
 baseurl=%(kw:url)s/%(prop:tarbuildnum)s/%(prop:buildername)s/rpms
 gpgcheck=0
 EOF
-            if [ "%(prop:rpm_type)s" = rhel8 ] || [ "%(prop:rpm_type)s" = centosstream8 ]; then
+            if [ "%(prop:rpm_type)s" = rhel8 ] || [ "%(prop:rpm_type)s" = centosstream8 ] || [ "%(prop:rpm_type)s" = alma8 ] || [ "%(prop:rpm_type)s" = rocky8 ]; then
                 echo "module_hotfixes = 1" >> MariaDB.repo
             fi
         """,

--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -291,7 +291,8 @@ rpm_setup_mariadb_mirror() {
 [mariadb]
 name=MariaDB
 baseurl=$baseurl
-# //TEMP following is probably not needed for all OS
+# //TEMP following is not needed for all OS
+# - rhel8 based OS (almalinux 8, rockylinux 8, centos 8)
 module_hotfixes = 1
 gpgkey=https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1


### PR DESCRIPTION
Error is:
```console
Last metadata expiration check: 0:00:02 ago on Thu 23 May 2024 11:16:33 AM UTC. |All matches were filtered out by modular filtering for argument: MariaDB-devel |  * Maybe you meant: mariadb-devel
All matches were filtered out by modular filtering for argument: MariaDB-server |  * Maybe you meant: mariadb-server
All matches were filtered out by modular filtering for argument: MariaDB-test |  * Maybe you meant: mariadb-test
```

See: https://buildbot.mariadb.org/#/builders/610/builds/1176