### PR TITLE
opensuse15: add liburing2-devel and libfmt dependencies

### DIFF
--- a/.github/workflows/bbw_build_container.yml
+++ b/.github/workflows/bbw_build_container.yml
@@ -110,7 +110,7 @@ jobs:
             # s390x)
             # platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
           - dockerfile: opensuse.Dockerfile pip.Dockerfile
-            image: opensuse/leap:15.3
+            image: opensuse/leap:15.5
             tag: opensuse15
             platforms: linux/amd64
           - dockerfile: sles.Dockerfile pip.Dockerfile
@@ -149,6 +149,10 @@ jobs:
           cd ${{ env.WORKDIR }}
           cat ${{ matrix.dockerfile }} qpress.Dockerfile buildbot-worker.Dockerfile >$GITHUB_WORKSPACE/Dockerfile
           cp -r qpress $GITHUB_WORKSPACE
+      - name: opensuse extra
+        if: matrix.tag == 'opensuse15'
+        run: |
+          cp ${{ env.WORKDIR }}/mariadb_zypper_expect $GITHUB_WORKSPACE
       - name: No wsrep on 32 bit platforms
         if: >
           (contains(matrix.platforms, 'linux/386'))

--- a/ci_build_images/mariadb_zypper_expect
+++ b/ci_build_images/mariadb_zypper_expect
@@ -1,0 +1,14 @@
+#!/usr/bin/expect
+spawn zypper si -d mariadb
+
+expect {
+    "Choose from above solutions by number or skip, retry or cancel*" {
+        send "2\r"
+        exp_continue
+    }
+    "Continue?*" {
+        send "y\r"
+        exp_continue
+    }
+}
+

--- a/ci_build_images/opensuse.Dockerfile
+++ b/ci_build_images/opensuse.Dockerfile
@@ -8,43 +8,44 @@ ARG BASE_IMAGE
 FROM "$BASE_IMAGE"
 LABEL maintainer="MariaDB Buildbot maintainers"
 
+COPY --chmod=755 mariadb_zypper_expect /
 # Install updates and required packages
 RUN zypper update -y && \
     zypper install -y -t pattern devel_basis && \
     zypper install -y \
-    boost-devel \
     bzip2 \
     ccache \
     check-devel \
     cmake \
     cracklib-devel \
-    createrepo \
+    createrepo_c \
     curl \
+    expect \
     git \
     glibc-locale \
-    gnutls-devel \
     jemalloc-devel \
-    libboost_filesystem1_66_0-devel \
-    libboost_program_options1_66_0-devel \
-    libboost_system1_66_0-devel \
+    libboost_filesystem1_75_0-devel \
+    libboost_program_options1_75_0-devel \
+    libboost_system1_75_0-devel \
     libbz2-devel \
     libcurl-devel \
     libffi-devel \
+    libfmt8 \
+    libgnutls-devel \
     liblz4-devel \
+    libopenssl-3-devel \
+    liburing2-devel \
     libxml2-devel \
-    openssl-devel \
     perl-Net-SSLeay \
     policycoreutils \
-    python-devel \
-    python-pip \
-    python3-pip \
+    python311-devel \
+    python311-pip \
     rpm-build \
     rpmlint \
-    scons \
     snappy-devel \
     subversion \
     wget \
-    && zypper -n si -d mariadb \
+    && ./mariadb_zypper_expect \
     && zypper clean -a \
     && curl -sLo /usr/local/bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_$(uname -m)" \
     && chmod +x /usr/local/bin/dumb-init


### PR DESCRIPTION
libfmt was added in 10.7 as a dependency. The autofetching mariadb-10.3 dependencies isn't enough. Also liburing was added as 10.6 improvement over libaio so include this.