### PR TITLE
EOL CentOS Stream 8

### DIFF
--- a/.github/workflows/bbw_build_container.yml
+++ b/.github/workflows/bbw_build_container.yml
@@ -98,10 +98,6 @@ jobs:
           - dockerfile: centos7.Dockerfile pip.Dockerfile
             image: centos:7
             platforms: linux/amd64
-          - dockerfile: centos.Dockerfile
-            image: quay.io/centos/centos:stream8
-            tag: centosstream8
-            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
           - dockerfile: centos.Dockerfile pip.Dockerfile
             image: quay.io/centos/centos:stream9
             tag: centosstream9

--- a/constants.py
+++ b/constants.py
@@ -72,7 +72,6 @@ releaseBranches = ["bb-*-release", "preview-*"]
 # For example, if Debian 10 has MariaDB 10.3 by default, we don't support MariaDB 10.2 on it.
 supportedPlatforms = {}
 supportedPlatforms["10.4"] = [
-    "aarch64-centos-stream8",
     "aarch64-debian-10",
     "aarch64-debian-10-bintar",
     "aarch64-macos",
@@ -82,7 +81,6 @@ supportedPlatforms["10.4"] = [
     "aarch64-ubuntu-2004-debug",
     "amd64-centos-7",
     "amd64-centos-7-bintar",
-    "amd64-centos-stream8",
     "amd64-debian-10",
     "amd64-debian-10-debug-embedded",
     "amd64-debian-10-last-N-failed",
@@ -99,7 +97,6 @@ supportedPlatforms["10.4"] = [
     "amd64-ubuntu-2204-icc",
     "amd64-windows",
     "amd64-windows-packages",
-    "ppc64le-centos-stream8",
     "ppc64le-rhel-8",
     "ppc64le-ubuntu-2004",
     "ppc64le-ubuntu-2004-debug",

--- a/master-config.yaml-sample
+++ b/master-config.yaml-sample
@@ -1,5 +1,4 @@
 builders:
-- aarch64-centos-stream8
 - aarch64-centos-stream9
 - aarch64-debian-10
 - aarch64-debian-11

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -16,13 +16,6 @@ centos-7:
   arch:
     - amd64
   type: rpm
-centos-stream8:
-  version_name: 8
-  arch:
-    - amd64
-    - aarch64
-    - ppc64le
-  type: rpm
 centos-stream9:
   version_name: 9
   arch:


### PR DESCRIPTION
EOL according to https://mariadb.com/kb/en/mariadb-platform-deprecation-policy/.

@fauust VMs also need to be removed