### PR TITLE
opensuse: missing g++ from build

### DIFF
--- a/ci_build_images/opensuse.Dockerfile
+++ b/ci_build_images/opensuse.Dockerfile
@@ -21,6 +21,7 @@ RUN zypper update -y && \
     createrepo_c \
     curl \
     expect \
+    gcc-c++ \
     git \
     glibc-locale \
     jemalloc-devel \


### PR DESCRIPTION
Not sure how it missed from being a mariadb build dependency.
