### PR TITLE
build almalinux on aarch64

### DIFF
--- a/.github/workflows/bbw_build_container.yml
+++ b/.github/workflows/bbw_build_container.yml
@@ -26,10 +26,10 @@ jobs:
         include:
           - dockerfile: centos.Dockerfile
             image: almalinux:8
-            platforms: linux/amd64
+            platforms: linux/amd64, linux/arm64/v8
           - dockerfile: centos.Dockerfile pip.Dockerfile
             image: almalinux:9
-            platforms: linux/amd64
+            platforms: linux/amd64, linux/arm64/v8
           - dockerfile: debian.Dockerfile
             image: debian:11
             branch: 10.11


### PR DESCRIPTION
According to [MDBF-706] added aarch64 for almalinux 8 & 9.

