### PR TITLE
 MDBF-702 - remove ubuntu 2310 builders

### DIFF
--- a/.github/workflows/build-debian-based.yml
+++ b/.github/workflows/build-debian-based.yml
@@ -62,11 +62,6 @@ jobs:
             branch: 10.11
             nogalera: false
 
-          - image: ubuntu:23.10
-            platforms: linux/amd64, linux/arm64/v8
-            branch: 10.11
-            nogalera: false
-
           - image: ubuntu:24.04
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
             branch: 10.11

--- a/constants.py
+++ b/constants.py
@@ -171,13 +171,11 @@ supportedPlatforms["10.10"] += supportedPlatforms["10.9"]
 supportedPlatforms["10.11"] = [
     "aarch64-debian-12",
     "aarch64-fedora-40",
-    "aarch64-ubuntu-2310",
     "aarch64-ubuntu-2404",
     "amd64-debian-12",
     "amd64-fedora-40",
     "amd64-opensuse-15",
     "amd64-sles-15",
-    "amd64-ubuntu-2310",
     "amd64-ubuntu-2404",
     "ppc64le-ubuntu-2404",
     "s390x-sles-15",

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -137,12 +137,6 @@ ubuntu-2204:
     - ppc64le
     - s390x
   type: deb
-ubuntu-2310:
-  version_name: mantic
-  arch:
-    - amd64
-    - aarch64
-  type: deb
 ubuntu-2404:
   version_name: noble
   arch:


### PR DESCRIPTION
According to MDBF-702 - ubuntu 23.10 builders removal due to deprecation policy requirements.