### PR TITLE
Enable DEXTRA_DEBUG for amd64-ubuntu-2004-debug

### DIFF
--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -462,7 +462,7 @@ c["builders"].append(
         locks=getLocks,
         properties={
             "build_type": "Debug",
-            "additional_args": "-DWITH_DBUG_TRACE=OFF -DEXTRA_DEBUG ",
+            "additional_args": "-DWITH_DBUG_TRACE=OFF -DEXTRA_DEBUG=ON",
             "mtr_additional_args": '--skip-test="main\.show_analyze_json"',
         },
         factory=getQuickBuildFactory("debug", mtrDbPool),


### PR DESCRIPTION
According to MDBF-715.
Based on: MDBF-654

This is a bug fix only manifesting itself in the Development environment because the changes did not reach Production yet.

