### PR TITLE
Add s390x-bbw workers for Ubuntu 20.04 debug builds

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -402,6 +402,24 @@ addWorker(
     save_packages=False,
 )
 
+addWorker(
+    "s390x-bbw",
+    2,
+    "-ubuntu-2004-debug",
+    "quay.io/mariadb-foundation/bb-worker:ubuntu20.04",
+    jobs=7,
+    save_packages=False,
+)
+
+addWorker(
+    "s390x-bbw",
+    3,
+    "-ubuntu-2004-debug",
+    "quay.io/mariadb-foundation/bb-worker:ubuntu20.04",
+    jobs=7,
+    save_packages=False,
+)
+
 ## hz-bbw2-docker
 c["workers"].append(
     worker.DockerLatentWorker(


### PR DESCRIPTION
MDBF-708
