### PR TITLE
Jepsen fixes

### DIFF
--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -752,37 +752,19 @@ f_jepsen_mysql.addStep(
     )
 )
 # get the source tarball and extract it
-f_jepsen_mysql.addStep(
-    steps.FileDownload(
-        mastersrc=util.Interpolate(
-            "/srv/buildbot/packages/"
-            + "%(prop:tarbuildnum)s"
-            + "/"
-            + "%(prop:mariadb_version)s"
-            + ".tar.gz"
-        ),
-        workerdest=util.Interpolate("%(prop:mariadb_version)s" + ".tar.gz"),
-    )
-)
-f_jepsen_mysql.addStep(
-    steps.ShellCommand(
-        command=util.Interpolate(
-            "tar -xzf " + "%(prop:mariadb_version)s" + ".tar.gz --strip-components=1"
-        )
-    )
-)
+f_jepsen_mysql.addStep(getSourceTarball())
 # build steps
 f_jepsen_mysql.addStep(
     steps.Compile(
         command=[
-            "sh",
+            "bash",
             "-c",
             util.Interpolate(
                 "export PATH=/usr/lib/ccache:/usr/lib64/ccache:$PATH && cmake . -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER,SPHINX,COLUMNSTORE,PERFSCHEMA,XPAND}=NO -DWITH_SAFEMALLOC=OFF -DCMAKE_BUILD_TYPE=RelWithDebinfo -DCMAKE_INSTALL_PREFIX=$PREFIX && make -j%(kw:jobs)s install",
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
             ),
         ],
-        env={"CCACHE_DIR": "/mnt/ccache"},
+        env={"CCACHE_DIR": "/mnt/ccache", "PREFIX": "/home/buildbot/mariadb-bin"},
     )
 )
 f_jepsen_mysql.addStep(

--- a/script_templates/jepsen_mysql.sh
+++ b/script_templates/jepsen_mysql.sh
@@ -9,15 +9,18 @@ err() {
 
 NPROC="%(prop:jobs)s"
 
-LEIN_OPTIONS="run test \
-  --db maria-docker \
-  --nodes localhost \
-  --concurrency ${NPROC} \
-  --rate 1000 \
-  --time-limit 60 \
-  --key-count 40 \
-  --no-ssh=true \
-  --innodb-strict-isolation=true"
+LEIN_OPTIONS=(
+  "run"
+  "test"
+  "--db" "maria-docker"
+  "--nodes" "localhost"
+  "--concurrency ${NPROC}"
+  "--rate" "1000"
+  "--time-limit" "60"
+  "--key-count" "40"
+  "--no-ssh=true"
+  "--innodb-strict-isolation=true"
+)
 
 cd ../jepsen-mariadb ||
   err "cd ../jepsen-mariadb"
@@ -28,25 +31,25 @@ log_lines() {
   echo -e "\n${line}\n${msg}\n${line}\n"
 }
 log_lines "Append serializable"
-../lein "$LEIN_OPTIONS" -w append -i serializable
+../lein "${LEIN_OPTIONS[@]}" -w append -i serializable
 
 log_lines "Append repeatable-read"
-../lein "$LEIN_OPTIONS" -w append -i repeatable-read
+../lein "${LEIN_OPTIONS[@]}" -w append -i repeatable-read
 
 log_lines "Append read-committed"
-../lein "$LEIN_OPTIONS" -w append -i read-committed
+../lein "${LEIN_OPTIONS[@]}" -w append -i read-committed
 
 log_lines "Append read-uncommitted"
-../lein "$LEIN_OPTIONS" -w append -i read-uncommitted
+../lein "${LEIN_OPTIONS[@]}" -w append -i read-uncommitted
 
 log_lines "Non-repeatable read serializable"
-../lein "$LEIN_OPTIONS" -w nonrepeatable-read -i serializable
+../lein "${LEIN_OPTIONS[@]}" -w nonrepeatable-read -i serializable
 
 log_lines "Non-repeatable repeatable-read"
-../lein "$LEIN_OPTIONS" -w nonrepeatable-read -i repeatable-read
+../lein "${LEIN_OPTIONS[@]}" -w nonrepeatable-read -i repeatable-read
 
 log_lines "mav serializable"
-../lein "$LEIN_OPTIONS" -w mav -i serializable
+../lein "${LEIN_OPTIONS[@]}" -w mav -i serializable
 
 log_lines "mav repeatable-read"
-../lein "$LEIN_OPTIONS" -w mav -i repeatable-read
+../lein "${LEIN_OPTIONS[@]}" -w mav -i repeatable-read


### PR DESCRIPTION
- download step
- add env vars
- solve bash issue that makes lein interpret "$LEIN_OPTIONS" as a single argument

# Template selection

Please go the the `Preview` tab and select the appropriate sub-template:

* [Adding Worker Machine](?expand=1&template=add_worker.md)
* [Adding a New Build](?expand=1&template=add_build.md)
