### PR TITLE
MDBF 653 - Run Connect Tests as part of one builder in buildbot

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -233,8 +233,8 @@ test_type_to_mtr_arg = {
     "debug-ps": "--ps-protocol",
     "debug-emb": "--embedded",
     "debug-emb-ps": "--embedded --ps-protocol",
-    "nm_func_1_2":"--suite=funcs_1,funcs_2,stress,jp --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1",
-    "nm_engines":"--suite=spider,spider/bg,engines/funcs,engines/iuds --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1",
+    "nm_func_1_2": "--suite=funcs_1,funcs_2,stress,jp --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1",
+    "nm_engines": "--suite=spider,spider/bg,engines/funcs,engines/iuds --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1",
 }
 
 # =============================================================================

--- a/constants.py
+++ b/constants.py
@@ -232,6 +232,8 @@ test_type_to_mtr_arg = {
     "debug-ps": "--ps-protocol",
     "debug-emb": "--embedded",
     "debug-emb-ps": "--embedded --ps-protocol",
+    "nm_func_1_2":"--suite=funcs_1,funcs_2,stress,jp --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1",
+    "nm_engines":"--suite=spider,spider/bg,engines/funcs,engines/iuds --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1",
 }
 
 # =============================================================================

--- a/constants.py
+++ b/constants.py
@@ -221,6 +221,7 @@ MTR_ENV = {
 test_type_to_mtr_arg = {
     "nm": "",
     "ps": "--ps-protocol",
+    "connect": "--suite=connect",
     "emb": "--embedded",
     "emb-ps": "--embedded --ps-protocol",
     "view": "--view-protocol",

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -1033,7 +1033,8 @@ full_test_configs = {
     "nm_engines": {},
     "view": {
         "additional_args": "--suite=main"
-    }
+    },
+    "connect": {}
 }
 
 for typ in full_test_configs:

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -984,84 +984,6 @@ f_big_test.addStep(
     )
 )
 
-
-# Define a function to add test steps to a factory
-def add_test_steps(factory, test_types):
-    for test_type in test_types:
-        output_dir = test_type
-        # Common command before customizing per test_type
-        command_base = f"cd mysql-test && MTR_FEEDBACK_PLUGIN=1 perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=2 --max-save-datadir=10 --mem"
-
-        # Custom parts of the command
-        extra_args = ""
-        if test_type == "emb":
-            extra_args = "--embedded-server"
-        elif test_type == "ps":
-            extra_args = "--ps-protocol"
-        elif test_type == "emb-ps":
-            extra_args = "--ps --embedded"
-        elif test_type == "nm_func_1_2":
-            extra_args = "--suite=funcs_1,funcs_2,stress,jp --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1"
-        elif test_type == "nm_engines":
-            extra_args = "--suite=spider,spider/bg,engines/funcs,engines/iuds --big --mysqld=--open-files-limit=0 --mysqld=--log-warnings=1"
-        elif test_type == "view":
-            extra_args = "--view-protocol --suite=main"
-        else:
-            # Default case for 'nm' and any other unspecified types
-            pass
-
-        # Add steps for running MTR, moving logs, and creating archives
-        factory.addStep(
-            steps.MTR(
-                logfiles={"mysqld*": "./buildbot/mysql_logs.html"},
-                name=f"test {test_type}",
-                test_type=test_type,
-                command=[
-                    "sh",
-                    "-c",
-                    util.Interpolate(
-                        f"{command_base} {extra_args} --parallel=$(expr %(kw:jobs)s \* 2)",
-                        jobs=util.Property(
-                            "jobs", default="$(getconf _NPROCESSORS_ONLN)"
-                        ),
-                    ),
-                ],
-                timeout=3600,
-                dbpool=mtrDbPool,
-                parallel=mtrJobsMultiplier,
-                env=MTR_ENV,
-            )
-        )
-        factory.addStep(
-            steps.ShellCommand(
-                name=f"move mysqld log files {test_type}",
-                alwaysRun=True,
-                command=[
-                    "bash",
-                    "-c",
-                    util.Interpolate(
-                        moveMTRLogs(output_dir=output_dir),
-                        jobs=util.Property(
-                            "jobs", default="$(getconf _NPROCESSORS_ONLN)"
-                        ),
-                    ),
-                ],
-            )
-        )
-        factory.addStep(
-            steps.ShellCommand(
-                name=f"create var archive {test_type}",
-                alwaysRun=True,
-                command=[
-                    "bash",
-                    "-c",
-                    util.Interpolate(createVar(output_dir=output_dir)),
-                ],
-                doStepIf=hasFailed,
-            )
-        )
-
-
 ## f_full_test
 f_full_test = util.BuildFactory()
 f_full_test.addStep(printEnv())
@@ -1101,19 +1023,30 @@ f_full_test.addStep(
     )
 )
 
-# List of test configurations: (test_type, output_dir, suite)
-full_test_configs = [
-    "emb",
-    "nm",
-    "ps",
-    "emb-ps",
-    "nm_func_1_2",
-    "nm_engines",
-    "view",
-]
+#MTR steps
+full_test_configs = {
+    "emb": {},
+    "nm": {},
+    "ps": {},
+    "emb-ps":{},
+    "nm_func_1_2": {},
+    "nm_engines": {},
+    "view": {
+        "additional_args": "--suite=main"
+    }
+}
 
-# Refactor the f_full_test factory to use the new function
-add_test_steps(f_full_test, full_test_configs)
+for typ in full_test_configs:
+    addTests(f_full_test,
+            mtr_test_type=typ,
+            mtr_step_db_pool=mtrDbPool,
+            mtr_additional_args=full_test_configs[typ].get('additional_args',""),
+            mtr_feedback_plugin=1,
+            mtr_max_test_fail=10,
+            mtr_step_timeout=3600,
+            mtr_step_auto_create_tables=False
+            )
+
 
 f_full_test.addStep(saveLogs())
 


### PR DESCRIPTION
As part of MDBF-653 we need to run Connect storage engine tests on a Builder.

Testing:
 [amd64-ubuntu-2004-fulltest/18](https://buildbot.dev.mariadb.org/#/builders/183/builds/18)
- see [connect tests](https://buildbot.dev.mariadb.org/#/builders/183/builds/18/steps/27/logs/stdio)
- other tests were compared to a previous run [amd64-ubuntu-2004-fulltest/15 ](https://buildbot.dev.mariadb.org/#/builders/183/builds/15)

Selective regression testing:
- addTests function was modified to be general purpose so I've tested an autogen builder and compared it with a previous run to confirm that tests ran the same way as before.
  - Test:  [aarch64-almalinux-8/16](https://buildbot.dev.mariadb.org/#/builders/124/builds/16)
