### PR TITLE
Switch to SLE BCI 15 SP6 as base container for SLE15

### DIFF
--- a/dockerfiles/s390x-sles-15.dockerfile
+++ b/dockerfiles/s390x-sles-15.dockerfile
@@ -3,7 +3,7 @@
 # Provides a base OpenSUSE image with latest buildbot worker installed
 # and MariaDB build dependencies
 
-FROM registry.suse.com/suse/sle15:15.2
+FROM registry.suse.com/bci/bci-base:15.6
 LABEL maintainer="MariaDB Buildbot maintainers"
 
 ADD http://lxslsmt.marist.edu/smt.crt /etc/pki/trust/anchors/smt.crt

--- a/dockerfiles/sles-15.dockerfile
+++ b/dockerfiles/sles-15.dockerfile
@@ -3,7 +3,7 @@
 # Provides a base OpenSUSE image with latest buildbot worker installed
 # and MariaDB build dependencies
 
-FROM registry.suse.com/suse/sle15:15.2
+FROM registry.suse.com/suse/bci/bci-base:15.6
 LABEL maintainer="MariaDB Buildbot maintainers"
 
 ENV ADDITIONAL_MODULES sle-module-development-tools,PackageHub


### PR DESCRIPTION
This is a fully compatible SLES15 container (actually the same like /suse/sle15:15.6). 15.2 is end of life, using the latest SP instead

# Template selection

Please go the the `Preview` tab and select the appropriate sub-template:

* [Adding Worker Machine](?expand=1&template=add_worker.md)
* [Adding a New Build](?expand=1&template=add_build.md)
