### PR TITLE
rpm-install script - create my.cnf.d

### DIFF
--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -56,6 +56,7 @@ else
 fi
 set -u
 
+sudo mkdir -p /etc/my.cnf.d
 sh -c 'g=/usr/lib*/galera*/libgalera_smm.so; echo -e "[galera]\nwsrep_provider=$g"' | sudo tee /etc/my.cnf.d/galera.cnf
 case "$systemdCapability" in
   yes)


### PR DESCRIPTION
Prevent:

+ set -u
+ sh -c 'g=/usr/lib*/galera*/libgalera_smm.so; echo -e "[galera]\nwsrep_provider=$g"'
+ sudo tee /etc/my.cnf.d/galera.cnf tee: /etc/my.cnf.d/galera.cnf: No such file or directory [galera]
wsrep_provider=/usr/lib*/galera*/libgalera_smm.so
program finished with exit code 1

e.g.: https://buildbot.mariadb.org/#/builders/697/builds/316