### PR TITLE
fedora39: backport 3.28.5 CPackeRPM.cmake to build with rpm

### DIFF
--- a/ci_build_images/fedora.Dockerfile
+++ b/ci_build_images/fedora.Dockerfile
@@ -8,7 +8,8 @@ FROM "$BASE_IMAGE"
 LABEL maintainer="MariaDB Buildbot maintainers"
 
 # Install updates and required packages
-RUN dnf -y upgrade \
+RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf \
+    && dnf -y upgrade \
     && dnf -y install 'dnf-command(builddep)' \
     && dnf -y builddep mariadb-server \
     && dnf -y install \

--- a/ci_build_images/fedora.Dockerfile
+++ b/ci_build_images/fedora.Dockerfile
@@ -56,6 +56,7 @@ RUN dnf -y upgrade \
     wget \
     which \
     && source /etc/os-release \
+    && if [ "$VERSION_ID" = 39 ]; then curl -s 'https://gitlab.kitware.com/cmake/cmake/-/raw/v3.28.5/Modules/Internal/CPack/CPackRPM.cmake?ref_type=tags' -o /usr/share/cmake/Modules/Internal/CPack/CPackRPM.cmake ; fi \
     && if [ "$(uname -m)" = "x86_64" ]; then dnf -y install libpmem-devel; fi \
     && dnf clean all
 


### PR DESCRIPTION
Was a cmake/rpm incompatibility that hit Fedora 39 (and 40 has a fixed version):

ref: MDEV-32741
ref: https://gitlab.kitware.com/cmake/cmake/-/issues/25421
Fedora isn't doing a version bump so we work around it: https://bugzilla.redhat.com/show_bug.cgi?id=2268060

```
CPackRPM:Debug:    - /buildtheveryveryveryveryveryveryveryverlongpathforrpmbuild/_CPack_Packages/Linux/RPM/rpmbuildMariaDB-backup.out
CPackRPM:Debug: *** Building target platforms: x86_64
Building for target x86_64
setting SOURCE_DATE_EPOCH=1278201600
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.hrwwED
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.qIjJ8B
find-debuginfo: starting
Extracting debug info from 2 files
DWARF-compressing 2 files
sepdebugcrcfix: Updated 2 CRC32s, 0 CRC32s did match.
Creating .debug symlinks for symlinks to ELF files
find-debuginfo: done
Processing files: MariaDB-backup-10.11.9-1.fc39.x86_64
Finding  Provides: /bin/sh -c " /usr/bin/grep -v  '\.\(test\|result\|h\|cc\|c\|inc\|opt\|ic\|cnf\|rdiff\|cpp\)$' | while read FILE; do echo "${FILE}" | /usr/lib/rpm/rpmdeps -P; done | /bin/sort -u  | /usr/bin/sed -e '/perl(\(mtr\|My::\)/d'"
Finding  Requires(interp): 
Finding  Requires(rpmlib): 
Finding  Requires(verify): 
Finding  Requires(pre): 
Finding  Requires(post): 
Finding  Requires(preun): 
Finding  Requires(postun): 
Finding  Requires(pretrans): 
Finding  Requires(posttrans): 
Finding  Requires(preuntrans): 
Finding  Requires(postuntrans): 
Finding  Requires: /bin/sh -c " /usr/bin/grep -v  '\.\(test\|result\|h\|cc\|c\|inc\|opt\|ic\|cnf\|rdiff\|cpp\)$' |  while read FILE; do echo "${FILE}" | /usr/lib/rpm/rpmdeps -R; done | /bin/sort -u  | /usr/bin/sed -e '/\(perl(\(.*mtr\|My::\|.*HandlerSocket\|Mysql\)\)/d'"
Finding  Conflicts: 
Finding  Obsoletes: 
Finding  Recommends: 
Finding  Suggests: 
Finding  Supplements: 
Finding  Enhances: 
Finding  OrderWithRequires: 
Provides: MariaDB-backup = 10.11.9-1.fc39 MariaDB-backup(x86-64) = 10.11.9-1.fc39
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires: ld-linux-x86-64.so.2()(64bit) ld-linux-x86-64.so.2(GLIBC_2.3)(64bit) libc.so.6()(64bit) libc.so.6(GLIBC_2.10)(64bit) libc.so.6(GLIBC_2.14)(64bit) libc.so.6(GLIBC_2.15)(64bit) libc.so.6(GLIBC_2.16)(64bit) libc.so.6(GLIBC_2.17)(64bit) libc.so.6(GLIBC_2.2.5)(64bit) libc.so.6(GLIBC_2.27)(64bit) libc.so.6(GLIBC_2.28)(64bit) libc.so.6(GLIBC_2.3)(64bit) libc.so.6(GLIBC_2.3.2)(64bit) libc.so.6(GLIBC_2.3.4)(64bit) libc.so.6(GLIBC_2.32)(64bit) libc.so.6(GLIBC_2.33)(64bit) libc.so.6(GLIBC_2.34)(64bit) libc.so.6(GLIBC_2.38)(64bit) libc.so.6(GLIBC_2.4)(64bit) libc.so.6(GLIBC_2.6)(64bit) libc.so.6(GLIBC_2.7)(64bit) libc.so.6(GLIBC_2.8)(64bit) libcrypt.so.2()(64bit) libcrypt.so.2(XCRYPT_2.0)(64bit) libcrypto.so.3()(64bit) libcrypto.so.3(OPENSSL_3.0.0)(64bit) libgcc_s.so.1()(64bit) libgcc_s.so.1(GCC_3.0)(64bit) libm.so.6()(64bit) libm.so.6(GLIBC_2.2.5)(64bit) libm.so.6(GLIBC_2.29)(64bit) libm.so.6(GLIBC_2.38)(64bit) libpcre2-8.so.0()(64bit) libssl.so.3()(64bit) libssl.so.3(OPENSSL_3.0.0)(64bit) libstdc++.so.6()(64bit) libstdc++.so.6(CXXABI_1.3)(64bit) libstdc++.so.6(CXXABI_1.3.5)(64bit) libstdc++.so.6(CXXABI_1.3.8)(64bit) libstdc++.so.6(GLIBCXX_3.4)(64bit) libstdc++.so.6(GLIBCXX_3.4.11)(64bit) libstdc++.so.6(GLIBCXX_3.4.14)(64bit) libstdc++.so.6(GLIBCXX_3.4.15)(64bit) libstdc++.so.6(GLIBCXX_3.4.17)(64bit) libstdc++.so.6(GLIBCXX_3.4.18)(64bit) libstdc++.so.6(GLIBCXX_3.4.19)(64bit) libstdc++.so.6(GLIBCXX_3.4.20)(64bit) libstdc++.so.6(GLIBCXX_3.4.21)(64bit) libstdc++.so.6(GLIBCXX_3.4.22)(64bit) libstdc++.so.6(GLIBCXX_3.4.26)(64bit) libstdc++.so.6(GLIBCXX_3.4.29)(64bit) libstdc++.so.6(GLIBCXX_3.4.30)(64bit) libstdc++.so.6(GLIBCXX_3.4.32)(64bit) libstdc++.so.6(GLIBCXX_3.4.9)(64bit) libsystemd.so.0()(64bit) libsystemd.so.0(LIBSYSTEMD_227)(64bit) liburing.so.2()(64bit) liburing.so.2(LIBURING_2.0)(64bit) liburing.so.2(LIBURING_2.1)(64bit) libz.so.1()(64bit) libz.so.1(ZLIB_1.2.0)(64bit) rtld(GNU_HASH)
Processing files: MariaDB-backup-debuginfo-10.11.9-1.fc39.x86_64
Provides: MariaDB-backup-debuginfo = 10.11.9-1.fc39 MariaDB-backup-debuginfo(x86-64) = 10.11.9-1.fc39
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Checking for unpackaged file(s): /usr/lib/rpm/check-files /buildtheveryveryveryveryveryveryveryverlongpathforrpmbuild/_CPack_Packages/Linux/RPM/mariadb-10.11.9-linux-x86_64/backup
Wrote: /buildtheveryveryveryveryveryveryveryverlongpathforrpmbuild/_CPack_Packages/Linux/RPM/RPMS/x86_64/MariaDB-backup-10.11.9-1.fc39.x86_64.rpm
Wrote: /buildtheveryveryveryveryveryveryveryverlongpathforrpmbuild/_CPack_Packages/Linux/RPM/RPMS/x86_64/MariaDB-backup-debuginfo-10.11.9-1.fc39.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.gVJsdD
Executing(rmbuild): /bin/sh -e /var/tmp/rpm-tmp.zqAlNo

```