### PR TITLE
MDBF-749 - support main branch

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -17,6 +17,7 @@ branches_main = [
     "11.6",
     "11.7",
     "11.8",
+    "main",
 ]
 
 # Defines what builders report status to GitHub
@@ -204,6 +205,7 @@ supportedPlatforms["11.5"] = supportedPlatforms["11.4"].copy()
 supportedPlatforms["11.6"] = supportedPlatforms["11.5"].copy()
 supportedPlatforms["11.7"] = supportedPlatforms["11.6"].copy()
 supportedPlatforms["11.8"] = supportedPlatforms["11.7"].copy()
+supportedPlatforms["main"] = supportedPlatforms["11.8"].copy()
 
 # Define environment variables for MTR step
 MTR_ENV = {

--- a/master-web/templates/grid_view/grid.jade
+++ b/master-web/templates/grid_view/grid.jade
@@ -30,6 +30,8 @@
                 a(href="#grid?branch=11.5") 11.5
                 | ,
                 a(href="#grid?branch=11.6") 11.6
+                | ,
+                a(href="#grid?branch=main") main
             label Results:
                 select.form-control(ng-model="C.result", ng-change="C.changeResult(C.result)", ng-options="r.code as r.text for r in C.results")
                     option(value="") (all)

--- a/master-web/templates/home.jade
+++ b/master-web/templates/home.jade
@@ -30,6 +30,8 @@
             a(href="#grid?branch=11.5") 11.5
             | ,
             a(href="#grid?branch=11.6") 11.6
+            | ,
+            a(href="#grid?branch=main") main
             | ) will give you a developer-oriented summary of recent buildbot activity.
           li
             | The 


### PR DESCRIPTION
- added main to branches_main list so builders will be triggered on push
- if main will become 11.7, 11.8 and so on and every minor inherits builders from the previous minor version then main is a copy of supportedPlatform[latest]