### PR TITLE
bbw_builder: use buildah to build worker containers

### DIFF
--- a/.github/workflows/bbw_build_container.yml
+++ b/.github/workflows/bbw_build_container.yml
@@ -166,49 +166,31 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-      - name: Make sure that time is in sync
-        run: |
-          # RHEL subscription needs that time and date
-          # is correct and is syncing with an NTP-server
-          # https://access.redhat.com/discussions/672313#comment-2360508
-          sudo chronyc -a makestep
-      - name: Build image
-        run: |
-          podman manifest create ${{ env.REPO }}:${{ env.IMG }}
-          for arch in $(echo ${{ matrix.platforms }} | sed 's/,/ /g'); do
-            msg="Build $arch:"
-            line="${msg//?/=}"
-            printf "\n${line}\n${msg}\n${line}\n"
-            podman buildx build --tag ${{ env.REPO }}:${{ env.IMG }}-${arch//\//-} \
-              --platform $arch \
-              --manifest ${{ env.REPO }}:${{ env.IMG }} \
-              -f $GITHUB_WORKSPACE/Dockerfile \
-              --build-arg BASE_IMAGE=${{ matrix.image }} \
-              --build-arg CLANG_VERSION=${{ matrix.clang_version }} \
-              --build-arg MARIADB_BRANCH=${{ matrix.branch }}
-          done
-          podman images
-      - name: Push images to local registry
-        run: |
-          podman manifest push --tls-verify=0 \
-            --all ${{ env.REPO }}:${{ env.IMG }} \
-            docker://localhost:5000/${{ env.REPO }}:${{ env.IMG }}
+      - name: Build with Buildah
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.REPO }}
+          tags: ${{ env.IMG }}
+          build-args:
+            - BASE_IMAGE=${{ matrix.image }}
+            - CLANG_VERSION=${{ matrix.clang_version }}
+            - MARIADB_BRANCH=${{ matrix.branch }}
+          containerfiles: \
+            Dockerfile
+          context: ${{ env.WORKDIR }}
+          archs: ${{ matrix.archs }}
+          oci: true
+          extra-args: --ulimit nofile=16384:16384
       - name: Check multi-arch container
         run: |
-          # make some space on the runner
-          if [[ -d $HOME/.local/share/containers ]]; then
-            sudo rm -rf $HOME/.local/share/containers
-          fi
+          image="${{ env.REPO }}:${{ env.IMG }}"
           for p in ${{ matrix.platforms }}; do
             platform="${p/,/}"
-            image="localhost:5000/bb-worker:${{ env.IMG }}"
-            msg="Testing docker image $image on platform $platform"
-            line="${msg//?/=}"
-            printf "\n${line}\n${msg}\n${line}\n"
-            docker pull -q --platform "$platform" "$image"
-            docker run -i "$image" buildbot-worker --version
-            docker run -i "$image" dumb-init twistd --pidfile= -y /home/buildbot/buildbot.tac
-            docker run -u root -i "$image" bash -c "touch /tmp/foo && qpress -r /tmp /root/qpress.qp"
+            echo "Testing docker image $image on platform $platform"
+            docker run --platform=$platform --rm -i "$image" buildbot-worker --version
+            docker run --platform=$platform --rm -i "$image" dumb-init twistd --pidfile= -y /home/buildbot/buildbot.tac
+            docker run --platform=$platform --rm -u root -i "$image" bash -c "touch /tmp/foo && qpress -r /tmp /root/qpress.qp"
           done
       - name: Check for registry credentials
         run: |
@@ -223,35 +205,38 @@ jobs:
           else
             echo "Not pushing images to registry"
           fi
-      - name: Login to ghcr.io
-        if: ${{ env.DEPLOY_IMAGES == 'true' }}
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push images to ghcr.io
         if: ${{ env.DEPLOY_IMAGES == 'true' }}
-        run: |
-          msg="Push docker image to ghcr.io (${{ env.IMG }})"
-          line="${msg//?/=}"
-          printf "\n${line}\n${msg}\n${line}\n"
-          skopeo copy --all --src-tls-verify=0 \
-            docker://localhost:5000/${{ env.REPO }}:${{ env.IMG }} \
-            docker://ghcr.io/${GITHUB_REPOSITORY,,}/${{ env.REPO }}:${{ env.IMG }}
-      - name: Login to registry
-        if: ${{ env.DEPLOY_IMAGES == 'true' }}
-        uses: docker/login-action@v2
+        uses: redhat-actions/push-to-registry@v2
         with:
-          registry: quay.io
+          image: ${{ env.REPO }}
+          tags: ${{ env.IMG }}
+          registry: ghcr.io/${GITHUB_REPOSITORY,,}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for registry credentials
+        if: >
+          github.ref == 'refs/heads/main' &&
+          github.repository == 'MariaDB/buildbot'
+        run: |
+          missing=()
+          [[ -n "${{ secrets.QUAY_USER }}" ]] || missing+=(QUAY_USER)
+          [[ -n "${{ secrets.QUAY_TOKEN }}" ]] || missing+=(QUAY_TOKEN)
+          for i in "${missing[@]}"; do
+            echo "Missing github secret: $i"
+          done
+          if (( ${#missing[@]} == 0 )); then
+            echo "DEPLOY_IMAGES=true" >> $GITHUB_ENV
+          else
+            echo "Not pushing images to registry"
+          fi
+      - name: Push To quay.io
+        id: push-to-quay
+        if: ${{ env.DEPLOY_IMAGES == 'true' }}
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ env.REPO }}
+          tags: ${{ env.IMG }}
+          registry: quay.io/mariadb-foundation
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
-      - name: Push images to quay.io
-        if: ${{ env.DEPLOY_IMAGES == 'true' }}
-        run: |
-          msg="Push docker image to quay.io (${{ env.IMG }})"
-          line="${msg//?/=}"
-          printf "\n${line}\n${msg}\n${line}\n"
-          skopeo copy --all --src-tls-verify=0 \
-          docker://localhost:5000/${{ env.REPO }}:${{ env.IMG }} \
-          docker://quay.io/mariadb-foundation/${{ env.REPO }}:${{ env.IMG }}


### PR DESCRIPTION
This is an attempt to speed up the build.

As RHEL has been moved to separate workflow the timesync isn't needed.

Attempted to match as much as possible.

Used podman run --rm to remove the container after use.

# Template selection

Please go the the `Preview` tab and select the appropriate sub-template:

* [Adding Worker Machine](?expand=1&template=add_worker.md)
* [Adding a New Build](?expand=1&template=add_build.md)
