### PR TITLE
Rollback MDBF-740 clang usage on asan-ubsan

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -478,7 +478,7 @@ f_asan_ubsan_build.addStep(
             "sh",
             "-c",
             util.Interpolate(
-                'cmake . -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DWITH_ASAN=ON -DWITH_UBSAN=ON -DPLUGIN_PERFSCHEMA=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF && cmake --build . --verbose --parallel %(kw:jobs)s',
+                'cmake . -DWITH_ASAN=ON -DWITH_UBSAN=ON -DPLUGIN_PERFSCHEMA=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF && cmake --build . --verbose --parallel %(kw:jobs)s',
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
             ),
         ],


### PR DESCRIPTION
- this change needs to be rollbacked until reported bugs on MDBF-741 are cleared up.
