### PR TITLE
MDBF-753 - Conditional paths for Development - windows_msi_env

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -335,8 +335,8 @@ f_windows.addStep(
 ## f_windows_msi
 
 f_windows_msi_env = {
-    "TMP": util.Interpolate("D:\\Buildbot\\%(prop:buildername)s\\build\\tmpdir"),
-    "TEMP": util.Interpolate("D:\\Buildbot\\%(prop:buildername)s\\build\\tmpdir"),
+    "TMP": util.Interpolate("{0}\\%(prop:buildername)s\\build\\tmpdir".format('D:\\DEV\\Buildbot' if os.getenv('ENVIRON') == 'DEV' else 'D:\\Buildbot')),
+    "TEMP": util.Interpolate("{0}\\%(prop:buildername)s\\build\\tmpdir".format('D:\\DEV\\Buildbot' if os.getenv('ENVIRON') == 'DEV' else 'D:\\Buildbot')),
 }
 f_windows_msi_env.update(MTR_ENV)
 


### PR DESCRIPTION
- ENVIRON environment variable is available for Development masters so the condition will evaluate to TRUE and set the correct path for the dev-worker on windows-bbw1 (currently the server hosting windows-packages builds)
