### PR TITLE
asan_ubsan: mtr path fix

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -493,7 +493,7 @@ f_asan_ubsan_build.addStep(
             "sh",
             "-c",
             util.Interpolate(
-                'MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=$PWD/mysql-test/lsan.supp" mysql-test/mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=2 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)',
+                'cd mysql-test && MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=$PWD/lsan.supp" ./mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=2 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)',
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
             ),
         ],

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -478,7 +478,7 @@ f_asan_ubsan_build.addStep(
             "sh",
             "-c",
             util.Interpolate(
-                'cmake . -DWITH_ASAN=ON -DWITH_UBSAN=ON -DPLUGIN_PERFSCHEMA=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF && cmake --build . --verbose --parallel %(kw:jobs)s',
+                "cmake . -DWITH_ASAN=ON -DWITH_UBSAN=ON -DPLUGIN_PERFSCHEMA=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF && cmake --build . --verbose --parallel %(kw:jobs)s",
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
             ),
         ],
@@ -581,7 +581,7 @@ f_asan_build.addStep(
             "sh",
             "-c",
             util.Interpolate(
-                'cmake . -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DWITH_ASAN=ON -DPLUGIN_PERFSCHEMA=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF && cmake --build . --verbose --parallel %(kw:jobs)s',
+                "cmake . -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DWITH_ASAN=ON -DPLUGIN_PERFSCHEMA=NO -DPLUGIN_MROONGA=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DWITH_SAFEMALLOC=OFF && cmake --build . --verbose --parallel %(kw:jobs)s",
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
             ),
         ],
@@ -596,7 +596,27 @@ f_asan_build.addStep(
             "sh",
             "-c",
             util.Interpolate(
-                'cd mysql-test; MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=$PWD/lsan.supp" perl mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=2 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr %(kw:jobs)s \* 2)',
+                ";".join(
+                    [
+                        "cd mysql-test",
+                        " ".join(
+                            [
+                                "MTR_FEEDBACK_PLUGIN=1",
+                                'ASAN_OPTIONS="abort_on_error=1"',
+                                'LSAN_OPTIONS="print_suppressions=0,suppressions=$PWD/lsan.supp"',
+                                "perl mysql-test-run.pl",
+                                "--verbose-restart",
+                                "--force",
+                                "--retry=3",
+                                "--max-save-core=2",
+                                "--max-save-datadir=10",
+                                "--max-test-fail=20",
+                                "--mem",
+                                "--parallel=$(expr %(kw:jobs)s \* 2)",
+                            ]
+                        ),
+                    ]
+                ),
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
             ),
         ],
@@ -1023,30 +1043,29 @@ f_full_test.addStep(
     )
 )
 
-#MTR steps
+# MTR steps
 full_test_configs = {
     "emb": {},
     "nm": {},
     "ps": {},
-    "emb-ps":{},
+    "emb-ps": {},
     "nm_func_1_2": {},
     "nm_engines": {},
-    "view": {
-        "additional_args": "--suite=main"
-    },
-    "connect": {}
+    "view": {"additional_args": "--suite=main"},
+    "connect": {},
 }
 
 for typ in full_test_configs:
-    addTests(f_full_test,
-            mtr_test_type=typ,
-            mtr_step_db_pool=mtrDbPool,
-            mtr_additional_args=full_test_configs[typ].get('additional_args',""),
-            mtr_feedback_plugin=1,
-            mtr_max_test_fail=10,
-            mtr_step_timeout=3600,
-            mtr_step_auto_create_tables=False
-            )
+    addTests(
+        f_full_test,
+        mtr_test_type=typ,
+        mtr_step_db_pool=mtrDbPool,
+        mtr_additional_args=full_test_configs[typ].get("additional_args", ""),
+        mtr_feedback_plugin=1,
+        mtr_max_test_fail=10,
+        mtr_step_timeout=3600,
+        mtr_step_auto_create_tables=False,
+    )
 
 
 f_full_test.addStep(saveLogs())


### PR DESCRIPTION
As this isn't an out of tree build, the mtr must be run from the mysql-test directory otherwise:

sh -c 'MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=$PWD/mysql-test/lsan.supp" mysql-test/mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=2 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr 20 \* 2)'
 in dir /home/buildbot/amd64-debian-12-asan-ubsan/build (timeout 950 secs)
 watching logfiles {'syslog': '/var/log/syslog'}
 argv: [b'sh', b'-c', b'MTR_FEEDBACK_PLUGIN=1 ASAN_OPTIONS="abort_on_error=1" LSAN_OPTIONS="print_suppressions=0,suppressions=$PWD/mysql-test/lsan.supp" mysql-test/mysql-test-run.pl --verbose-restart --force --retry=3 --max-save-core=2 --max-save-datadir=10 --max-test-fail=20 --mem --parallel=$(expr 20 \\* 2)']
 environment:
  BUILDMASTER=100.64.100.1
  BUILDMASTER_PORT=9992
  CARGO_NET_GIT_FETCH_WITH_CLI=true
  HOME=/home/buildbot
  HOSTNAME=2d2d22f108aa
  LC_CTYPE=C.UTF-8
  MTR_PRINT_CORE=detailed
  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
  PWD=/home/buildbot/amd64-debian-12-asan-ubsan/build
  WORKERNAME=hz-bbw2-docker-debian-12
  WSREP_PROVIDER=/usr/lib/galera/libgalera_smm.so
 using PTY: False
**** ERROR **** You must start mysql-test-run from the mysql-test/ directory program finished with exit code 1

ref: https://buildbot.mariadb.org/#/builders/588/builds/7217