### PR TITLE
Fix for MDBF-746 - quickBuild builders always ran Galera

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -335,8 +335,8 @@ def addGaleraTests(factory, mtrDbPool):
             dbpool=mtrDbPool,
             autoCreateTables=True,
             env=mtrEnv,
-            doStepIf=hasGalera
-            and util.Property("compile_step_completed", default=False),
+            doStepIf=lambda props: hasGalera(props)
+            and props.hasProperty("compile_step_completed"),
         )
     )
     factory.addStep(
@@ -353,8 +353,8 @@ def addGaleraTests(factory, mtrDbPool):
                     jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
                 ),
             ],
-            doStepIf=hasGalera
-            and util.Property("compile_step_completed", default=False),
+            doStepIf=lambda props: hasGalera(props)
+            and props.hasProperty("compile_step_completed"),
         )
     )
     return factory


### PR DESCRIPTION
- by MDBF-736 a bug was introduced so the condition hasGalera and compile_step_completed was always evaluated to True because it will check that hasGalera it's a valid reference (TRUE) instead of calling it
- now doStepIf receives a lambda function that is evaluated at runtime so hasGalera can return True/False based on the builder name if it's in the builders_galera_mtr list

Previous broken runs (with old syntax):
[aarch64-almalinux-8/19 ](https://buildbot.dev.mariadb.org/#/builders/124/builds/19)
[amd64-debian-10/13 ](https://buildbot.dev.mariadb.org/#/builders/116/builds/13)

Here Galera tests are running even if the builders are missing from builders_galera_mtr list.

Fixed (new syntax):
[aarch64-almalinux-8/21 ](https://buildbot.dev.mariadb.org/#/builders/124/builds/21)
[amd64-debian-10/15 ](https://buildbot.dev.mariadb.org/#/builders/116/builds/15)

Builders configured to run Galera tests they run it:
[aarch64-debian-12/13 ](https://buildbot.dev.mariadb.org/#/builders/109/builds/13)

