### PR TITLE
Missing dep for galera 4

### DIFF
--- a/ci_build_images/sles.Dockerfile
+++ b/ci_build_images/sles.Dockerfile
@@ -36,6 +36,7 @@ RUN zypper -n update \
     libgnutls-devel \
     liblz4-devel \
     libopenssl-3-devel \
+    libopenssl-devel \
     liburing2-devel \
     pcre2-devel \
     perl-Net-SSLeay \


### PR DESCRIPTION
See: https://buildbot.mariadb.org/#/builders/330/builds/900/steps/3/logs/stdio

Error is:
```
 + /usr/bin/rpmbuild --clean --define '_topdir /home/buildbot/gal-s390x-sles-15/build/scripts/packages/rpm_top_dir' --define 'optflags -O3 -fno-omit-frame-pointer -mtune=core2' --define 'version 26.4.19' --define 'dist .sles15' -bb /home/buildbot/gal-s390x-sles-15/build/scripts/packages/galera.spec | error: Failed build dependencies:
 	openssl-devel is needed by galera-4-26.4.19-1.sle15.s390x

```
# Template selection

Please go the the `Preview` tab and select the appropriate sub-template:

* [Adding Worker Machine](?expand=1&template=add_worker.md)
* [Adding a New Build](?expand=1&template=add_build.md)
