### PR TITLE
MDBF - 645 - windows var.tar on CI

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -234,7 +234,17 @@ def addWinTests(
         cmd = f"..\\mysql-test\\collections\\buildbot_suites.bat && cd .."
     else:
         suites = ",".join(mtr_suites)
-        cmd = f"perl mysql-test-run.pl  --verbose-restart --force  --testcase-timeout=8 --suite-timeout=600  --retry=3 --suites={suites} --parallel=%(kw:jobs)s %(kw:mtr_additional_args)s"
+        cmd = (
+            "perl mysql-test-run.pl"
+            " --verbose-restart"
+            " --force"
+            " --testcase-timeout=8"
+            " --suite-timeout=600"
+            " --retry=3"
+            " --suites={suites}"
+            " --parallel=%(kw:jobs)s"
+            "  %(kw:mtr_additional_args)s"
+        ).format(suites=suites)
 
     if create_scripts:
         factory.addStep(

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -118,6 +118,7 @@ services:
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
+      - /srv/buildbot/packages:/srv/buildbot/packages
     entrypoint:
       - /bin/bash
       - -c

--- a/docker-compose/generate-config.py
+++ b/docker-compose/generate-config.py
@@ -23,6 +23,8 @@ MASTER_DIRECTORIES = [
     "master-bintars",
 ]
 
+VOLUMES = ["./logs:/var/log/buildbot", "./buildbot/:/srv/buildbot/master"]
+
 START_TEMPLATE = """
 ---
 version: "3.7"
@@ -109,9 +111,7 @@ DOCKER_COMPOSE_TEMPLATE = """
     restart: unless-stopped
     container_name: {master_name}
     hostname: {master_name}
-    volumes:
-      - ./logs:/var/log/buildbot
-      - ./buildbot/:/srv/buildbot/master
+    {volumes}
     entrypoint:
       - /bin/bash
       - -c
@@ -150,6 +150,13 @@ networks:
 """
 
 
+# Function to generate volumes section for Docker Compose
+def generate_volumes(volumes, indent_level=2):
+    indent = "   " * indent_level
+    volume_lines = [f"{indent}- {volume}" for volume in volumes]
+    return f"volumes:\n{'\n'.join(volume_lines)}"
+
+
 # Function to construct environment section for Docker Compose
 def construct_env_section(env_vars):
     env_section = "    environment:\n"
@@ -163,6 +170,15 @@ def construct_env_section(env_vars):
 
 
 def main(args):
+    # Load Volumes
+    master_volumes = {
+        key: VOLUMES[:]
+        for key in [element.replace("/", "_") for element in MASTER_DIRECTORIES]
+    }
+    master_volumes["master-nonlatent"].append(
+        "/srv/buildbot/packages:/srv/buildbot/packages"
+    )  # Using FileUpload step
+
     # Capture the current environment variables' keys
     current_env_keys = set(os.environ.keys())
 
@@ -209,6 +225,7 @@ def main(args):
                 master_directory=master_directory,
                 port=port,
                 buildmaster_wg_ip=env_vars["BUILDMASTER_WG_IP"],
+                volumes=generate_volumes(master_volumes[master_name]),
             )
             port += 1
 

--- a/docker-compose/generate-config.py
+++ b/docker-compose/generate-config.py
@@ -154,7 +154,7 @@ networks:
 def generate_volumes(volumes, indent_level=2):
     indent = "   " * indent_level
     volume_lines = [f"{indent}- {volume}" for volume in volumes]
-    return f"volumes:\n{'\n'.join(volume_lines)}"
+    return "volumes:\n{}".format("\n".join(volume_lines))
 
 
 # Function to construct environment section for Docker Compose

--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -266,52 +266,48 @@ f_windows.addStep(
         warningPattern=vsWarningPattern,
     )
 )
+
+windows_tests = {
+    "nm": {
+        "create_scripts": True
+    },
+    "connect": {
+        "suites": ["connect"],
+    },
+}
+
+for typ in windows_tests:
+    addWinTests(f_windows,
+            mtr_test_type=typ,
+            mtr_env=f_windows_env,
+            mtr_additional_args=util.Property("mtr_additional_args", default=""),
+            mtr_step_db_pool=mtrDbPool,
+            mtr_suites=windows_tests[typ].get('suites',["default"]),
+            create_scripts=windows_tests[typ].get('create_scripts',False)
+            )
+
+
 f_windows.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="test nm",
-        test_type="nm",
-        command=[
-            "dojob",
-            '"',
-            util.Interpolate(
-                '"C:\Program Files (x86)\Microsoft Visual Studio\\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=%(kw:arch)s && cd mysql-test && ..\\mysql-test\\collections\\buildbot_suites.bat && cd ..',
-                mtr_additional_args=util.Property("mtr_additional_args", default=""),
-                jobs=util.Property("jobs", default=4),
-                arch=util.Property("arch", default="x64"),
-            ),
-            '"',
-        ],
-        timeout=600,
-        haltOnFailure="true",
-        parallel=mtrJobsMultiplier,
-        dbpool=mtrDbPool,
-        autoCreateTables=True,
-        env=f_windows_env,
-    )
-)
-f_windows.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="extra",
-        test_type="nm",
-        command=[
-            "dojob",
-            '"',
-            util.Interpolate(
-                '"C:\Program Files (x86)\Microsoft Visual Studio\\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=%(kw:arch)s && cd mysql-test && perl mysql-test-run.pl  --verbose-restart --force  --testcase-timeout=8 --suite-timeout=600  --retry=3 --suites=connect --parallel=%(kw:jobs)s %(kw:mtr_additional_args)s',
-                mtr_additional_args=util.Property("mtr_additional_args", default=""),
-                jobs=util.Property("jobs", default=4),
-                arch=util.Property("arch", default="x64"),
-            ),
-            '"',
-        ],
-        timeout=600,
-        haltOnFailure="true",
-        parallel=mtrJobsMultiplier,
-        dbpool=mtrDbPool,
-        autoCreateTables=True,
-        env=f_windows_env,
+    steps.DirectoryUpload(
+        name="save mariadb log files",
+        alwaysRun=True,
+        workersrc="buildbot\\logs\\",
+        masterdest=util.Interpolate(
+            "/srv/buildbot/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/logs/"
+            + "%(prop:buildername)s"
+        ),
+        url=util.Interpolate(
+            f'{os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")}'
+            '/'
+            "%(prop:tarbuildnum)s"
+            '/'
+            'logs'
+            '/'
+            '%(prop:buildername)s'
+            '/'
+        ),
     )
 )
 f_windows.addStep(
@@ -460,52 +456,46 @@ f_windows_msi.addStep(
         warningPattern=vsWarningPattern,
     )
 )
+windows_msi_tests = {
+    "nm": {
+        "create_scripts": True
+    },
+    "connect": {
+        "suites": ["connect"],
+    },
+}
+
+for typ in windows_msi_tests:
+    addWinTests(f_windows_msi,
+            mtr_test_type=typ,
+            mtr_env=f_windows_msi_env,
+            mtr_additional_args=util.Property("mtr_additional_args", default=""),
+            mtr_step_db_pool=mtrDbPool,
+            mtr_suites=windows_msi_tests[typ].get('suites',["default"]),
+            create_scripts=windows_msi_tests[typ].get('create_scripts',False)
+            )
+
 f_windows_msi.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="test nm",
-        test_type="nm",
-        command=[
-            "dojob",
-            '"',
-            util.Interpolate(
-                '"C:\Program Files (x86)\Microsoft Visual Studio\\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=%(kw:arch)s && cd mysql-test && ..\\mysql-test\\collections\\buildbot_suites.bat && cd ..',
-                mtr_additional_args=util.Property("mtr_additional_args", default=""),
-                jobs=util.Property("jobs", default=4),
-                arch=util.Property("arch", default="x64"),
-            ),
-            '"',
-        ],
-        timeout=600,
-        haltOnFailure="true",
-        parallel=mtrJobsMultiplier,
-        dbpool=mtrDbPool,
-        autoCreateTables=True,
-        env=f_windows_msi_env,
-    )
-)
-f_windows_msi.addStep(
-    steps.MTR(
-        addLogs=True,
-        name="test extra",
-        test_type="nm",
-        command=[
-            "dojob",
-            '"',
-            util.Interpolate(
-                '"C:\Program Files (x86)\Microsoft Visual Studio\\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=%(kw:arch)s && cd mysql-test && perl mysql-test-run.pl  --verbose-restart --force  --testcase-timeout=8 --suite-timeout=600  --retry=3 --suites=connect --parallel=%(kw:jobs)s %(kw:mtr_additional_args)s',
-                mtr_additional_args=util.Property("mtr_additional_args", default=""),
-                jobs=util.Property("jobs", default=4),
-                arch=util.Property("arch", default="x64"),
-            ),
-            '"',
-        ],
-        timeout=600,
-        haltOnFailure="true",
-        parallel=mtrJobsMultiplier,
-        dbpool=mtrDbPool,
-        autoCreateTables=True,
-        env=f_windows_msi_env,
+    steps.DirectoryUpload(
+        name="save mariadb log files",
+        alwaysRun=True,
+        workersrc="buildbot\\logs\\",
+        masterdest=util.Interpolate(
+            "/srv/buildbot/packages/"
+            + "%(prop:tarbuildnum)s"
+            + "/logs/"
+            + "%(prop:buildername)s"
+        ),
+        url=util.Interpolate(
+            f'{os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")}'
+            '/'
+            "%(prop:tarbuildnum)s"
+            '/'
+            'logs'
+            '/'
+            '%(prop:buildername)s'
+            '/'
+        ),
     )
 )
 # create package and upload to master
@@ -537,14 +527,13 @@ f_windows_msi.addStep(
         ),
         mode=0o755,
         url=util.Interpolate(
-            """
-            " """
-            + os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
-            + """/"%(prop:tarbuildnum)s"
-            + "/"
-            + "%(prop:buildername)s"
-            + "/"
-        """
+            f'{os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")}'
+            '/'
+            '%(prop:tarbuildnum)s'
+            '/'
+            '%(prop:buildername)s'
+            '/'
+
         ),
         doStepIf=savePackage,
     )
@@ -561,14 +550,12 @@ f_windows_msi.addStep(
         ),
         mode=0o755,
         url=util.Interpolate(
-            """
-            " """
-            + os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
-            + """/"%(prop:tarbuildnum)s"
-            + "/"
-            + "%(prop:buildername)s"
-            + "/"
-        """
+            f'{os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")}'
+            '/'
+            '%(prop:tarbuildnum)s'
+            '/'
+            '%(prop:buildername)s'
+            '/'
         ),
         doStepIf=savePackage,
     )


### PR DESCRIPTION
- windows builders now support uploading mysql.err and var.tar.gz to CI for each MTR run.
- fixed URL's displayed in BB-UI for all File/Directory uploads
- refactored test code, introduced addWinTests function.
- for DEV,  master-nonlatent container has a volume mount on /srv/buildbot/packages (CI Uploads)

Tests:
- [amd64-windows](https://buildbot.dev.mariadb.org/#/builders/9/builds/4)
- [amd64-windows-packages](https://buildbot.dev.mariadb.org/#/builders/17/builds/58)

CI: 
 - logs [windows](https://ci.dev.mariadb.org/13/logs/amd64-windows/) and[ windows-packages](https://ci.dev.mariadb.org/21/logs/amd64-windows-packages/)