### PR TITLE
MDBF-779 SLES/OpenSUSE 15.5 bb config

### DIFF
--- a/.github/workflows/build-opensuse.pip-based.yml
+++ b/.github/workflows/build-opensuse.pip-based.yml
@@ -29,7 +29,7 @@ jobs:
         include:
           - image: opensuse/leap:15.5
             platforms: linux/amd64
-            tag: opensuse15.5
+            tag: opensuse1505
             nogalera: true
 
           - image: opensuse/leap:15.6

--- a/.github/workflows/build-opensuse.pip-based.yml
+++ b/.github/workflows/build-opensuse.pip-based.yml
@@ -34,7 +34,7 @@ jobs:
 
           - image: opensuse/leap:15.6
             platforms: linux/amd64
-            tag: opensuse15
+            tag: opensuse1506
             nogalera: false
 
     uses: ./.github/workflows/bbw_build_container_template.yml

--- a/.github/workflows/build-sles.pip-based.yml
+++ b/.github/workflows/build-sles.pip-based.yml
@@ -35,7 +35,7 @@ jobs:
 
           - image: registry.suse.com/bci/bci-base:15.6
             platforms: linux/amd64, linux/s390x
-            tag: sles15
+            tag: sles1506
             nogalera: false
 
     uses: ./.github/workflows/bbw_build_container_template.yml

--- a/.github/workflows/build-sles.pip-based.yml
+++ b/.github/workflows/build-sles.pip-based.yml
@@ -30,7 +30,7 @@ jobs:
         include:
           - image: registry.suse.com/bci/bci-base:15.5
             platforms: linux/amd64, linux/s390x
-            tag: sles15.5
+            tag: sles1505
             nogalera: true
 
           - image: registry.suse.com/bci/bci-base:15.6

--- a/constants.py
+++ b/constants.py
@@ -144,9 +144,12 @@ supportedPlatforms["10.5"] += [
 
 supportedPlatforms["10.6"] += [
     "aarch64-ubuntu-2204",
+    "amd64-opensuse-1505",
+    "amd64-sles-1505",
     "amd64-ubuntu-2204",
     "ppc64le-ubuntu-2204",
     "s390x-ubuntu-2204",
+    "s390x-sles-1505",
     "x86-debian-12",
 ]
 

--- a/constants.py
+++ b/constants.py
@@ -167,7 +167,7 @@ supportedPlatforms["10.11"] = [
     "amd64-debian-12",
     "amd64-debian-12-debug-embedded",
     "amd64-fedora-40",
-    "amd64-opensuse-15",
+    "amd64-opensuse-1506",
     "amd64-sles-15",
     "amd64-ubuntu-2404",
     "ppc64le-ubuntu-2404",

--- a/master.cfg
+++ b/master.cfg
@@ -394,6 +394,7 @@ for builder in master_config["builders"]:
         "aarch64-debian-sid",
         "ppc64le-debian-sid",
         "amd64-opensuse-1505",
+        "amd64-opensuse-1506",
         "amd64-sles-1505",
         "s390x-sles-1505",
     ]:

--- a/master.cfg
+++ b/master.cfg
@@ -393,9 +393,9 @@ for builder in master_config["builders"]:
         "amd64-debian-sid",
         "aarch64-debian-sid",
         "ppc64le-debian-sid",
-        "amd64-opensuse-15.5",
-        "amd64-sles-15.5",
-        "s390x-sles-15.5",
+        "amd64-opensuse-1505",
+        "amd64-sles-1505",
+        "s390x-sles-1505",
     ]:
         tags += ["release_packages"]
     c["builders"].append(

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -117,7 +117,7 @@ sles-1505:
   version_name: 15.5
   arch:
     - amd64
-    - s390x
+# TEMP - currently short on hardware - s390x
   type: rpm
 sles-15:
   version_name: 15

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -65,9 +65,13 @@ openeuler-2403:
   arch:
     - amd64
     - aarch64
+opensuse-1505:
+  version_name: 1505
+  arch:
+    - amd64
   type: rpm
-opensuse-15:
-  version_name: 15
+opensuse-1506:
+  version_name: 1506
   arch:
     - amd64
   type: rpm
@@ -107,6 +111,12 @@ rockylinux-9:
 sles-12:
   version_name: 12
   arch:
+    - s390x
+  type: rpm
+sles-1505:
+  version_name: 15.5
+  arch:
+    - amd64
     - s390x
   type: rpm
 sles-15:

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -66,12 +66,12 @@ openeuler-2403:
     - amd64
     - aarch64
 opensuse-1505:
-  version_name: 1505
+  version_name: 15.5
   arch:
     - amd64
   type: rpm
 opensuse-1506:
-  version_name: 1506
+  version_name: 15.6
   arch:
     - amd64
   type: rpm

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -119,8 +119,8 @@ sles-1505:
     - amd64
 # TEMP - currently short on hardware - s390x
   type: rpm
-sles-15:
-  version_name: 15
+sles-1506:
+  version_name: 15.6
   arch:
     - amd64
     - s390x


### PR DESCRIPTION
15.5 needed as incompatibilities in 15.6 including a different supported MariaDB version.

```
$ podman run --rm -ti  opensuse/leap:15.5 bash
a6d80ad49eed:/ # zypper info mariadb
Loading repository data...
Reading installed packages...


Information for package mariadb:
--------------------------------
Repository     : Update repository with updates from SUSE Linux Enterprise 15
Name           : mariadb
Version        : 10.6.18-150400.3.33.1
```