### PR TITLE
Manual workflow dispatch

### DIFF
--- a/.github/workflows/bbm_deploy.yml
+++ b/.github/workflows/bbm_deploy.yml
@@ -2,6 +2,7 @@
 name: bbm-deploy
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - ".github/workflows/bbm_deploy.yml"


### PR DESCRIPTION
sometimes it's needed when Development environment it's in a bad state or multiple merges occurred and the workflow does not run in a FIFO manner


