### PR TITLE
MDBF-763 - rhel8 and rhel9 builders don't have lzo

### DIFF
--- a/ci_build_images/rhel.Dockerfile
+++ b/ci_build_images/rhel.Dockerfile
@@ -72,6 +72,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     liburing-devel \
     libxml2-devel \
     libzstd-devel \
+    lzo-devel \
     lz4-devel \
     ncurses-devel \
     openssl-devel \


### PR DESCRIPTION
added lzo-devel
