### PR TITLE
upgrade version - 11.6.0 the prev major_version wasnt 10.11

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -404,8 +404,12 @@ upgrade_test_type() {
       ;;
     "major")
       major=${major_version%.*}
+      # intentionally twice, 11.5.3 has minor of 5.
       minor=${major_version##*.}
-      if ((minor == 0)); then
+      minor=${major_version##*.}
+      # with the earliest supported 11.X version
+      # and make this the upgrade from 10.11
+      if [ "$minor" -le 1 ]; then
         if ((major == 11)); then
           prev_major_version="10.11"
         else


### PR DESCRIPTION
11.0 is end of life so 11.1 has its previous release as 10.11.

because of maths rounding and imprecision 11.6.0 is being treated as 

https://buildbot.mariadb.org/#/builders/601/builds/455/steps/3/logs/stdio
```
+ [[ major == \m\a\j\o\r ]]
++ cut -d . -f1
+ old_branch_digit=10
++ cut -d . -f2
+ old_major_digit=11
++ cut -d . -f1
+ new_branch_digit=11
++ cut -d . -f2
+ new_major_digit=6
+ (( old_branch_digit == 10 ))
+ (( old_major_digit == 11 ))
+ (( new_branch_digit == 11 ))
+ (( new_major_digit != 0 ))
+ bb_log_err 'This does not look like a major upgrade from 10.11 to 11.0:'
+ set +x
ERROR: This does not look like a major upgrade from 10.11 to 11.0:
+ diff -u /tmp/version.old /tmp/version.new
--- /tmp/version.old	2024-07-26 21:15:59.316381612 +0000
+++ /tmp/version.new	2024-07-26 21:16:54.476505014 +0000
@@ -1 +1 @@
-10.11.6
+11.6.0
+ exit 1
```