### PR TITLE
Fix scripts generation - always run

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -252,6 +252,7 @@ def addWinTests(
                 util.Interpolate(moveMTRLogs(output_dir="$1")),
                 workerdest="move_logs.sh",
                 name="Create move Logs script",
+                alwaysRun=True,
             )
         )
 
@@ -260,6 +261,7 @@ def addWinTests(
                 util.Interpolate(createVar(output_dir="$1")),
                 workerdest="create_tarball.sh",
                 name="Create tarball script",
+                alwaysRun=True,
             )
         )
 


### PR DESCRIPTION
To solve exception
https://buildbot.mariadb.org/#/builders/234/builds/31674

Scripts will run and do nothing if there is a compilation/packaging error.
