### PR TITLE
MDBF-768 rhel to Rocky Linux install trigger

### DIFF
--- a/os_info.yaml
+++ b/os_info.yaml
@@ -5,12 +5,14 @@ almalinux-8:
     - amd64
     - aarch64
   type: rpm
+  install_only: True
 almalinux-9:
   version_name: 9
   arch:
     - amd64
     - aarch64
   type: rpm
+  install_only: True
 centos-7:
   version_name: 7
   arch:

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -103,11 +103,13 @@ rockylinux-8:
   arch:
     - amd64
   type: rpm
+  install_only: True
 rockylinux-9:
   version_name: 9
   arch:
     - amd64
   type: rpm
+  install_only: True
 sles-12:
   version_name: 12
   arch:

--- a/schedulers_definition.py
+++ b/schedulers_definition.py
@@ -63,6 +63,7 @@ def getInstallBuilderNames(props):
             builders = [b]
             if "rhel" in builderName:
                 builders.append(b.replace("rhel", "almalinux"))
+                builders.append(b.replace("rhel", "rockylinux"))
             return builders
     return []
 
@@ -76,6 +77,7 @@ def getUpgradeBuilderNames(props):
         if builderName in b:
             if "rhel" in builderName:
                 builds.append(b.replace("rhel", "almalinux"))
+                builds.append(b.replace("rhel", "rockylinux"))
             builds.append(b)
     return builds
 


### PR DESCRIPTION
Rocky to run install/upgrade tests with RHEL packages.

AlmaLinux back to install_only, as we just release RHEL packages.