### PR TITLE
MDBF-769: FreeBSD clang

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -1066,6 +1066,8 @@ c["builders"].append(
         collapseRequests=True,
         properties={
             "additional_args": "-DPLUGIN_ROCKSDB=NO",
+            "c_compiler": "clang",
+            "cxx_compiler": "clang++",
             "mtr_env": {
                 "WSREP_PROVIDER": "/usr/local/lib/libgalera_smm.so",
                 }


### PR DESCRIPTION
Use clang for the build because that's the FreeBSD default.

We use clang here to make it easy for FreeBSD ports maintainers.