### PR TITLE
MDBF-774 Add Ubuntu Oracular

### DIFF
--- a/.github/workflows/build-debian-based.yml
+++ b/.github/workflows/build-debian-based.yml
@@ -43,12 +43,12 @@ jobs:
 
           - image: debian:sid
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
-            branch: 10.11
+            branch: 11.4
             nogalera: false
 
           - image: debian:sid
             platforms: linux/386
-            branch: 10.11
+            branch: 11.4
             tag: debiansid-386
             nogalera: false
 

--- a/.github/workflows/build-debian-based.yml
+++ b/.github/workflows/build-debian-based.yml
@@ -68,6 +68,11 @@ jobs:
             nogalera: false
 
 
+          - image: ubuntu:24.10
+            platforms: linux/amd64, linux/arm64/v8
+            branch: 11.4
+            nogalera: true
+
     uses: ./.github/workflows/bbw_build_container_template.yml
     with:
       dockerfile: debian.Dockerfile

--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -95,3 +95,6 @@ RUN . /etc/os-release \
     && apt-get clean
 
 ENV WSREP_PROVIDER=/usr/lib/galera/libgalera_smm.so
+
+# Prevent debian sid runtime error
+ENV CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1

--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -39,7 +39,7 @@ RUN . /etc/os-release \
     && if curl --head --silent "https://ci.mariadb.org/galera/mariadb-4.x-latest-gal-${ARCH}-${ID}-$(echo "$VERSION_ID" | sed 's/\.//').sources" | head -n1 | grep -q 200; then \
       curl -s "https://ci.mariadb.org/galera/mariadb-4.x-latest-gal-${ARCH}-${ID}-$(echo "$VERSION_ID" | sed 's/\.//').sources" >/etc/apt/sources.list.d/galera-4.sources; fi \
     && apt-get update \
-    && curl -skO https://raw.githubusercontent.com/MariaDB/server/44e4b93316be8df130c6d87880da3500d83dbe10/debian/control \
+    && curl -skO "https://raw.githubusercontent.com/MariaDB/server/$MARIADB_BRANCH/debian/control" \
     && mkdir debian \
     && mv control debian/control \
     && touch debian/rules VERSION debian/not-installed \

--- a/constants.py
+++ b/constants.py
@@ -191,7 +191,9 @@ supportedPlatforms["11.3"] = supportedPlatforms["11.2"].copy()
 supportedPlatforms["11.4"] = supportedPlatforms["11.3"].copy()
 supportedPlatforms["11.4"] += [
     "aarch64-debian-sid",
+    "aarch64-ubuntu-2410",
     "amd64-debian-sid",
+    "amd64-ubuntu-2410",
     "ppc64le-debian-sid",
     "x86-debian-sid",
 ]

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -145,3 +145,9 @@ ubuntu-2404:
     - ppc64le
     - s390x
   type: deb
+ubuntu-2410:
+  version_name: oracular
+  arch:
+    - amd64
+    - aarch64
+  type: deb


### PR DESCRIPTION
Set this for 11.4 branch on the hope that
the 11.4 from Debian sid can migrate to there
before release.

Like non-LTS Ubuntu distros only Aarch64/X86_64 architectures due to limited CI hardware.

# Add New Build template

## Checklist

- [X] Make changes os_info.yaml
- [X] Schedule the builder for the appropriate branch in constants.py
- [?] Add builder configuration
