### PR TITLE
debian-sid: base branch 11.4 + env for run error

### DIFF
--- a/.github/workflows/build-debian-based.yml
+++ b/.github/workflows/build-debian-based.yml
@@ -40,11 +40,11 @@ jobs:
 
           - image: debian:sid
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
-            branch: 10.11
+            branch: 11.4
 
           - image: debian:sid
             platforms: linux/386
-            branch: 10.11
+            branch: 11.4
             tag: debiansid-386
 
           - image: ubuntu:20.04

--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -98,3 +98,6 @@ RUN . /etc/os-release \
     && apt-get clean
 
 ENV WSREP_PROVIDER=/usr/lib/galera/libgalera_smm.so
+
+# Prevent debian sid runtime error
+ENV CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1

--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -40,7 +40,7 @@ RUN . /etc/os-release \
       curl -s "https://ci.mariadb.org/galera/mariadb-4.x-latest-gal-${ARCH}-${ID}-$(echo "$VERSION_ID" | sed 's/\.//').sources" >/etc/apt/sources.list.d/galera-4.sources; \
     fi \
     && apt-get update \
-    && curl -skO https://raw.githubusercontent.com/MariaDB/server/44e4b93316be8df130c6d87880da3500d83dbe10/debian/control \
+    && curl -skO "https://raw.githubusercontent.com/MariaDB/server/$MARIADB_BRANCH/debian/control" \
     && mkdir debian \
     && mv control debian/control \
     && touch debian/rules VERSION debian/not-installed \


### PR DESCRIPTION
Debian sid now has 11.4 as its version so match that.

Runtime on sid fails with:

builtins.RuntimeError: OpenSSL 3.0's legacy provider failed to load. This is a fatal error by default, but cryptography supports running without legacy algorithms by setting the environment variable CRYPTOGRAPHY_OPENSSL_NO_LEGACY. If you did not expect this error, you have likely made a mistake with your OpenSSL configuration.

Failed to load application: OpenSSL 3.0's legacy provider failed to load. This is a fatal error by default, but cryptography supports running without legacy algorithms by setting the environment variable CRYPTOGRAPHY_OPENSSL_NO_LEGACY. If you did not expect this error, you have likely made a mistake with your OpenSSL configuration.


ref: https://github.com/MariaDB/buildbot/actions/runs/10380468155/job/28740349730?pr=541

On the assumption we don't use legacy crypto we've set the environment variable.