### PR TITLE
MDBF-776 - Automat 24.8.0 breaks with Twisted 23.8.0

### DIFF
--- a/dockerfiles/eco-mysqljs-nodejs15-buster.dockerfile
+++ b/dockerfiles/eco-mysqljs-nodejs15-buster.dockerfile
@@ -29,7 +29,8 @@ WORKDIR /buildbot
 
 # Upgrade pip and install packages
 RUN pip3 install -U pip virtualenv
-RUN pip3 install buildbot-worker && \
+RUN pip3 install automat==22.10 && \
+    pip3 install buildbot-worker && \
     pip3 --no-cache-dir install 'twisted[tls]'
 
 # Test runs produce a great quantity of dead grandchild processes.  In a

--- a/dockerfiles/eco-php-ubuntu-2004.dockerfile
+++ b/dockerfiles/eco-php-ubuntu-2004.dockerfile
@@ -61,7 +61,8 @@ WORKDIR /buildbot
 
 # Upgrade pip and install packages
 RUN pip3 install -U pip virtualenv
-RUN pip3 install buildbot-worker && \
+RUN pip3 install automat==22.10 && \
+    pip3 install buildbot-worker && \
     pip3 --no-cache-dir install 'twisted[tls]'
 
 # Test runs produce a great quantity of dead grandchild processes.  In a

--- a/dockerfiles/eco-pymysql-python-3-9-slim-buster.dockerfile
+++ b/dockerfiles/eco-pymysql-python-3-9-slim-buster.dockerfile
@@ -32,7 +32,8 @@ WORKDIR /buildbot
 
 # Upgrade pip and install packages
 RUN pip3 install -U pip virtualenv
-RUN pip3 install buildbot-worker && \
+RUN pip3 install automat==22.10 && \
+    pip3 install buildbot-worker && \
     pip3 --no-cache-dir install 'twisted[tls]' \
     cryptography \
     'PyNaCl>=1.4.0' \


### PR DESCRIPTION
- recent release (24.8.0) of automat package, installed from PIP, breaks twisted when starting buildbot-worker.
- 22.10 was tested locally that it solves the issue. Twisted is not enforcing an upper limit but requires automat >= 0.8.0