### PR TITLE
MDBF-777 - Fixes for UBI #511

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -646,6 +646,8 @@ Repository available with: curl %(kw:url)s/%(prop:tarbuildnum)s/%(prop:builderna
                 "mariadb_version": Property("mariadb_version"),
                 "master_branch": Property("master_branch"),
                 "parentbuildername": Property("buildername"),
+                "ubi": "ubi",
+                "GH_WORKFLOW": "test-image-ent.yml",
             },
             doStepIf=lambda step: hasDockerLibrary(step),
         )

--- a/common_factories.py
+++ b/common_factories.py
@@ -646,7 +646,7 @@ Repository available with: curl %(kw:url)s/%(prop:tarbuildnum)s/%(prop:builderna
                 "mariadb_version": Property("mariadb_version"),
                 "master_branch": Property("master_branch"),
                 "parentbuildername": Property("buildername"),
-                "ubi": "ubi",
+                "ubi": "-ubi",
                 "GH_WORKFLOW": "test-image-ent.yml",
             },
             doStepIf=lambda step: hasDockerLibrary(step),

--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -614,7 +614,7 @@ f_wordpress.addStep(
             "--health-interval=4s",
             "--rm",
             util.Interpolate(
-                "mariadb-%(prop:tarbuildnum)s-amd64-wordpress%(prop:ubi)s"
+                "mariadb-%(prop:tarbuildnum)s-amd64%(prop:ubi)s-wordpress"
             ),
         ],
     )
@@ -659,7 +659,7 @@ f_wordpress.addStep(
             "podman",
             "untag",
             util.Interpolate(
-                "mariadb-%(prop:tarbuildnum)s-amd64-wordpress%(prop:ubi)s"
+                "mariadb-%(prop:tarbuildnum)s-amd64%(prop:ubi)s-wordpress"
             ),
         ],
         alwaysRun=True,
@@ -717,9 +717,7 @@ f_dockerlibrary.addStep(
         updateSourceStamp=False,
         set_properties={
             "tarbuildnum": Property("tarbuildnum"),
-            "ubi": lambda step: (
-                "-ubi" if "rhel" in str(step.getProperty("parentbuildername")) else ""
-            ),
+            "ubi": Property("ubi"),
         },
         doStepIf=lambda step: str(step.getProperty("parentbuildername")).startswith(
             "amd64"
@@ -741,7 +739,7 @@ f_dockerlibrary.addStep(
 f_dockerlibrary.addStep(
     steps.SetPropertyFromCommand(
         name="Extract the last tag created",
-        command=["cat", "last_tag"],
+	command=['bash','-c','if [ -f "last_tag" ]; then cat "last_tag"; else echo ""; fi'],
         property="lasttag",
     )
 )
@@ -749,13 +747,14 @@ f_dockerlibrary.addStep(
     steps.SetPropertyFromCommand(
         name="Determine sha for the last tag",
         command=[
-            "bash",
+           "bash",
             "-xc",
             util.Interpolate(
-                "curl -s https://quay.io/api/v1/repository/mariadb-foundation/mariadb-devel/tag/?filter_tag_name=eq:%(prop:lasttag)s&onlyActiveTags=true | jq -r .tags[0].manifest_digest"
+                'curl -s "https://quay.io/api/v1/repository/mariadb-foundation/mariadb-devel/tag/?filter_tag_name=eq:%(prop:lasttag)s&onlyActiveTags=true" | jq -r .tags[0].manifest_digest'
             ),
         ],
         property="lastsha",
+        doStepIf=lambda step: (str(step.getProperty("lasttag")) != "")
     )
 )
 f_dockerlibrary.addStep(
@@ -766,25 +765,23 @@ f_dockerlibrary.addStep(
             "-xc",
             "gh auth login --with-token < ~/gh_auth",
         ],
-        doStepIf=lambda step: (str(step.getProperty("lastsha")) != ""),
+        doStepIf=lambda step: (str(step.getProperty("lastsha")) != "null" and step.hasProperty("lastsha")),
     )
 )
+
 f_dockerlibrary.addStep(
     steps.ShellCommand(
         name="test operator with image",
         command=[
-            "bash",
-            "-xc",
+            'bash',
+            '-xc',
             util.Interpolate(
-                "gh workflow run %(kw:testname)s --repo mariadb-operator/mariadb-operator -f mariadb_image=quay.io/mariadb-foundation/mariadb-devel@%(prop:lastsha)s",
-                testname=lambda step: (
-                    "test-image-ent.yml"
-                    if "rhel" in str(step.getProperty("parentbuildername"))
-                    else "test-image.yml"
-                ),
+                'gh workflow run %s --repo mariadb-operator/mariadb-operator -f mariadb_image=quay.io/mariadb-foundation/mariadb-devel@%s',
+                util.Property('GH_WORKFLOW', default='test-image.yml'),
+		        util.Property('lastsha'),
             ),
         ],
-        doStepIf=lambda step: (str(step.getProperty("lastsha")) != ""),
+        doStepIf=lambda step: (str(step.getProperty("lastsha")) != "null" and step.hasProperty("lastsha")),
     )
 )
 

--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -739,7 +739,7 @@ f_dockerlibrary.addStep(
 f_dockerlibrary.addStep(
     steps.SetPropertyFromCommand(
         name="Extract the last tag created",
-	command=['bash','-c','if [ -f "last_tag" ]; then cat "last_tag"; else echo ""; fi'],
+	command=['bash','-c','if [ -f last_tag ]; then cat last_tag; else echo ""; fi'],
         property="lasttag",
     )
 )


### PR DESCRIPTION
- rpm_autobake should provide UBI and GH_WORKFLOW properties. Default defined for Debian
- resulting wordpress image ends in ubi-wordpress
- extract last tag step should handle the file absence
- determine sha step should handle empty << tag >> array and should NOT run if lasttag file is not present
- gh credentials should not run if lastsha is empty or not defined
- test operator (GH workflow) should not run if lastsha is empty or not defined

The steps related to GH will be skipped when there is NO push to QUAY (last_tag file created == images were pushed to QUAY).
