### PR TITLE
Add support for openEuler OS (24.03 LTS)

### DIFF
--- a/.github/workflows/build-centos.pip-based.yml
+++ b/.github/workflows/build-centos.pip-based.yml
@@ -43,7 +43,7 @@ jobs:
           - image: docker.io/openeuler/openeuler:24.03-lts
             platforms: linux/amd64, linux/arm64/v8
             tag: oe2403
-            
+
     uses: ./.github/workflows/bbw_build_container_template.yml
     with:
       dockerfile: centos.Dockerfile pip.Dockerfile

--- a/.github/workflows/build-centos.pip-based.yml
+++ b/.github/workflows/build-centos.pip-based.yml
@@ -40,7 +40,7 @@ jobs:
             runner: ubuntu-24.04
             nogalera: false
 
-          - image: openeuler/openeuler:24.03-lts
+          - image: openeuler24.03-lts
             platforms: linux/amd64, linux/arm64/v8
 
     uses: ./.github/workflows/bbw_build_container_template.yml

--- a/.github/workflows/build-centos.pip-based.yml
+++ b/.github/workflows/build-centos.pip-based.yml
@@ -43,6 +43,7 @@ jobs:
           - image: docker.io/openeuler/openeuler:24.03-lts
             platforms: linux/amd64, linux/arm64/v8
             tag: oe2403
+            nogalera: true
 
     uses: ./.github/workflows/bbw_build_container_template.yml
     with:

--- a/.github/workflows/build-centos.pip-based.yml
+++ b/.github/workflows/build-centos.pip-based.yml
@@ -40,6 +40,9 @@ jobs:
             runner: ubuntu-24.04
             nogalera: false
 
+          - image: docker.io/openeuler/openeuler:24.03-lts
+            platforms: linux/amd64, linux/arm64/v8
+
     uses: ./.github/workflows/bbw_build_container_template.yml
     with:
       dockerfile: centos.Dockerfile pip.Dockerfile

--- a/.github/workflows/build-centos.pip-based.yml
+++ b/.github/workflows/build-centos.pip-based.yml
@@ -40,7 +40,7 @@ jobs:
             runner: ubuntu-24.04
             nogalera: false
 
-          - image: docker.io/openeuler/openeuler:24.03-lts
+          - image: openeuler/openeuler:24.03-lts
             platforms: linux/amd64, linux/arm64/v8
 
     uses: ./.github/workflows/bbw_build_container_template.yml

--- a/.github/workflows/build-centos.pip-based.yml
+++ b/.github/workflows/build-centos.pip-based.yml
@@ -40,9 +40,10 @@ jobs:
             runner: ubuntu-24.04
             nogalera: false
 
-          - image: openeuler24.03-lts
+          - image: docker.io/openeuler/openeuler:24.03-lts
             platforms: linux/amd64, linux/arm64/v8
-
+            tag: oe2403
+            
     uses: ./.github/workflows/bbw_build_container_template.yml
     with:
       dockerfile: centos.Dockerfile pip.Dockerfile

--- a/ci_build_images/centos.Dockerfile
+++ b/ci_build_images/centos.Dockerfile
@@ -20,15 +20,24 @@ RUN dnf -y install 'dnf-command(config-manager)' \
           extra="python3-pip"; \
           ;; \
         *) \
-          dnf -y --enablerepo=extras install epel-release; \
-          dnf config-manager --set-enabled powertools; \
-          dnf -y module enable mariadb-devel; \
-          extra="buildbot-worker"; \
+          if [ "$ID" == "openEuler" ]; then \
+            extra="python3-pip"; \
+          else \
+            dnf -y --enablerepo=extras install epel-release; \
+            dnf config-manager --set-enabled powertools; \
+            dnf -y module enable mariadb-devel; \
+            extra="buildbot-worker"; \
+          fi \
           ;; \
     esac \
     && case "$ID" in \
         "centos") \
           ID=centos-stream; \
+          ;; \
+        "openEuler") \
+          ID=openeuler; \
+          # VERSION_ID has leading -, except on centos-stream
+          VERSION_ID=-${VERSION_ID}; \
           ;; \
         "rocky") \
           ID=rockylinux; \
@@ -80,7 +89,7 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     wget \
     which \
     xz-devel \
-    yum-utils \
+    && if [ "$ID" != "openeuler" ]; then dnf -y install yum-utils; fi \
     && if [ "$(uname -m)" = "x86_64" ]; then dnf -y install libpmem-devel; fi \
     && dnf clean all \
     # dumb-init rpm is not available on centos (official repo) \


### PR DESCRIPTION
As requested by @grooverdan at https://mariadb.zulipchat.com/#narrow/stream/451209-MariaDB-in-openEuler/topic/Buildbot.20CI.20image/near/463982676

To run: `buildah bud --build-arg BASE_IMAGE=docker.io/openeuler/openeuler:24.03-lts -f  centos.Dockerfile`

Note: openEuler does not have/need powertools/crb and yum-utils

# Add Worker template

## Checklist

- [ ] Add worker configuration to master-private.cfg on prod
- [ ] Add worker configuration to master-private.cfg on dev
- [ ] Add lock value to locks.py
- [ ] Enable the worker to be used by appropriate workers
