### PR TITLE
Docker Library - account for main branch -ubi fix

### DIFF
--- a/scripts/docker-library-build.sh
+++ b/scripts/docker-library-build.sh
@@ -58,7 +58,7 @@ case "${buildername#*ubuntu-}" in
     ;;
   *-rhel-9-rpm-autobake)
     ubi=-ubi
-    master_branch=${master_branch}-ubi
+    branch=${branch}-ubi
     ;;
   *)
     echo "unknown base buildername $buildername"


### PR DESCRIPTION
main_branch not used after this point.

branch needed the -ubi append.

# Template selection

Please go the the `Preview` tab and select the appropriate sub-template:

* [Adding Worker Machine](?expand=1&template=add_worker.md)
* [Adding a New Build](?expand=1&template=add_build.md)
