### PR TITLE
MDBF-780 - CentOS Stream 9 - ppc - Image Build Failure

### DIFF
--- a/ci_build_images/centos.Dockerfile
+++ b/ci_build_images/centos.Dockerfile
@@ -94,6 +94,7 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     && dnf clean all \
     # dumb-init rpm is not available on centos (official repo) \
     && curl -sL "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_$(uname -m)" >/usr/local/bin/dumb-init \
-    && chmod +x /usr/local/bin/dumb-init
+    && chmod +x /usr/local/bin/dumb-init \
+    && if [ "$ARCH" = "ppc64le" ] && [ "$ID" = "centos-stream" ] && [ "$PLATFORM_ID" = "platform:el9" ]; then pip3 install --no-cache-dir setuptools==69.5.1; fi
 
 ENV WSREP_PROVIDER=/usr/lib64/galera-4/libgalera_smm.so


### PR DESCRIPTION
This is a temporary workaround to address the installation issue of the zope.interface package on the ppc64le architecture. I haven’t identified why the build succeeds on other architectures. Based on my observations, the installation fails with any version of setuptools greater than 70.*.

The latest release of setuptools in the 69.* series appears to work correctly, as most packages require a version greater than 61.*.

We need a more robust method for pinning package versions and managing updates in the future. Details of the failure can be found here: https://github.com/MariaDB/buildbot/actions/runs/10505629895/job/29103561343

@vladbogo  , @grooverdan  if you have better ideas how to handle this, please let me know.
