### PR TITLE
Fix for MDBF-768 - rocky / alma are still triggered

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -148,13 +148,7 @@ supportedPlatforms["10.5"] += [
 ]
 
 supportedPlatforms["10.6"] += [
-    "aarch64-almalinux-8",
-    "aarch64-almalinux-9",
     "aarch64-ubuntu-2204",
-    "amd64-almalinux-8",
-    "amd64-almalinux-9",
-    "amd64-rockylinux-8",
-    "amd64-rockylinux-9",
     "amd64-ubuntu-2204",
     "ppc64le-ubuntu-2204",
     "s390x-ubuntu-2204",


### PR DESCRIPTION
Previously rocky/alma were switched to INSTALL_ONLY. Supported branches determines the triggering of these builders via the upstream scheduler.

fyi @grooverdan 