### PR TITLE
MDBF-782 Quick builders don't need "make package", default "make all"…

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -200,7 +200,7 @@ def getBuildFactoryPreTest(build_type="RelWithDebInfo", additional_args=""):
                     additional_args=util.Property(
                         "additional_args", default=f"{additional_args}"
                     ),
-                    create_package=util.Property("create_package", default="package"),
+                    create_package=util.Property("create_package", default="all"),
                     verbose_build=util.Property("verbose_build", default=""),
                 ),
             ],

--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -496,7 +496,7 @@ c["builders"].append(
         properties={
             "build_type": "Debug",
             "additional_args": "-DWITH_DBUG_TRACE=OFF",
-            "create_package": " ",
+            "create_package": "all",
             "mtr_additional_args": '--skip-test="main\.show_analyze_json"',
         },
         factory=getQuickBuildFactory("debug-ps", mtrDbPool),


### PR DESCRIPTION
… sufficient

Quick builders aren't saving packages or using them for tests.

As such there doesn't need to be a tarball created.

The build default, target "all" is sufficient for the artifacts used in MTR tests to be generated.

Test cases:

Deb and rpm autobakes have different steps. The bintar builder also have unique steps.

Standard quick builders, (distro without {rpm,deb}_autobake) should have a compile step that doesn't finish with creating a tarball like: 
```
CPack: Create package using TGZ
CPack: Install projects
CPack: - Run preinstall target for: MySQL
CPack: - Install project: MySQL []
CPack: Create package
CPack: - package: /home/buildbot/aarch64-debian-11/build/mariadb-10.11.10-linux-aarch64.tar.gz generated.
program finished with exit code 0
```