### PR TITLE
MDBF-783 - [GitHub] - Container image build failure for ubi9

### DIFF
--- a/.github/workflows/bbw_build_container_rhel.yml
+++ b/.github/workflows/bbw_build_container_rhel.yml
@@ -42,7 +42,7 @@ jobs:
             tag: rhel8
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
             nogalera: false
-          - dockerfile: rhel.Dockerfile pip.Dockerfile
+          - dockerfile: rhel.Dockerfile
             image: ubi9
             tag: rhel9
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x

--- a/.github/workflows/bbw_build_container_rhel.yml
+++ b/.github/workflows/bbw_build_container_rhel.yml
@@ -195,7 +195,7 @@ jobs:
       - name: ghcr.io - push dev tag
         if: ${{ env.DEPLOY_IMAGES == 'true' && env.MAIN_BRANCH == 'false' }}
         run: |
-          msg="Push docker image to ghcr.io (${{ env.IMG }})"
+          msg="Push docker image to ghcr.io (dev_${{ env.IMG }})"
           line="${msg//?/=}"
           printf "\n${line}\n${msg}\n${line}\n"
           skopeo copy --all --src-tls-verify=0 \
@@ -223,14 +223,14 @@ jobs:
       - name: quay.io - push dev tag
         if: ${{ env.DEPLOY_IMAGES == 'true' && env.MAIN_BRANCH == 'false' }}
         run: |
-          msg="Push docker image to quay.io (${{ env.IMG }})"
+          msg="Push docker image to quay.io (dev_${{ env.IMG }})"
           line="${msg//?/=}"
           printf "\n${line}\n${msg}\n${line}\n"
           skopeo copy --all --src-tls-verify=0 \
           docker://localhost:5000/${{ env.REPO }}:${{ env.IMG }} \
           docker://quay.io/mariadb-foundation/${{ env.REPO }}:dev_${{ env.IMG }}
 
-      - name: quay.io - push dev tag
+      - name: quay.io - move tag to production
         if: ${{ env.DEPLOY_IMAGES == 'true' && env.MAIN_BRANCH == 'true' }}
         run: |
           msg="Update tag (dev_${{ env.IMG }} --> ${{ env.IMG }})"

--- a/ci_build_images/rhel.Dockerfile
+++ b/ci_build_images/rhel.Dockerfile
@@ -21,8 +21,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     && case $BASE_IMAGE in \
     ubi9) \
       v=9; \
-      # no buildbot-worker any more \
-      extra="fmt-devel python3-pip"; \
+      extra="fmt-devel buildbot-worker"; \
       ;; \
     ubi8) \
       v=8; \


### PR DESCRIPTION
@grooverdan  / @vladbogo 

Maybe it's time to switch to EPEL.


See:
```
docker run --rm -it -u root quay.io/mariadb-foundation/bb-worker:rhel9 bash
    [@48969562dc17 buildbot]# uname -p
        x86_64
    [@48969562dc17 buildbot]# dnf list buildbot-worker
        Available Packages
        buildbot-worker.noarch  3.11.7el9 epel

docker run --rm --platform linux/ppc64le -it -u root quay.io/mariadb-foundation/bb-worker:rhel9 bash
    [@331258cd83eb buildbot]# uname -p
        ppc64le
    [@331258cd83eb buildbot]# dnf list buildbot-worker
        Available Packages
        buildbot-worker.noarch  3.11.7-1.el9 epel

docker run --rm --platform linux/arm64 -it -u root quay.io/mariadb-foundation/bb-worker:rhel9 bash
    [@022ae2241c2b buildbot]# uname -p
        aarch64
    [@022ae2241c2b buildbot]# dnf list buildbot-worker
        Available Packages
        buildbot-worker.noarch  3.11.7-1.el9 epel 


docker run --rm --platform linux/s390x -it -u root quay.io/mariadb-foundation/bb-worker:rhel9 bash
[@4815fe007276 buildbot]# uname -p
    s390x
[@4815fe007276 buildbot]# dnf list buildbot-worker
    Available Packages
    buildbot-worker.noarch  3.11.7-1.el9 epel 
```
