### PR TITLE
MDBF-786 - Make build output verbose, as a rule

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -201,7 +201,7 @@ def getBuildFactoryPreTest(build_type="RelWithDebInfo", additional_args=""):
                         "additional_args", default=f"{additional_args}"
                     ),
                     create_package=util.Property("create_package", default="package"),
-                    verbose_build=util.Property("verbose_build", default=""),
+                    verbose_build=util.Property("verbose_build", default="VERBOSE=1"),
                 ),
             ],
             env={"CCACHE_DIR": "/mnt/ccache"},


### PR DESCRIPTION
Enabled VERBOSE=1 for quick builders as per request in MDBF-786.
