### PR TITLE
Disable no-unknown-warning-option

### DIFF
--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -331,7 +331,7 @@ f_msan_build.addStep(
             "bash",
             "-xc",
             util.Interpolate(
-                'cmake . -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DCMAKE_C_FLAGS="-O2 -Wno-unused-command-line-argument -fdebug-macro" -DCMAKE_CXX_FLAGS="-stdlib=libc++ -O2 -Wno-unused-command-line-argument -fdebug-macro" -DWITH_EMBEDDED_SERVER=OFF -DWITH_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DWITH_INNODB_{BZIP2,LZ4,LZMA,LZO,SNAPPY}=OFF -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER}=NO -DWITH_SAFEMALLOC=OFF -DWITH_{ZLIB,SSL,PCRE}=bundled -DHAVE_LIBAIO_H=0 -DCMAKE_DISABLE_FIND_PACKAGE_{URING,LIBAIO}=1 -DWITH_MSAN=ON -DWITH_DBUG_TRACE=OFF && make -j%(kw:jobs)s package',
+                'cmake . -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DCMAKE_C_FLAGS="-O2 -Wno-unused-command-line-argument -Wno-unknown-warning-option -fdebug-macro" -DCMAKE_CXX_FLAGS="-stdlib=libc++ -O2 -Wno-unused-command-line-argument -fdebug-macro" -DWITH_EMBEDDED_SERVER=OFF -DWITH_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DWITH_INNODB_{BZIP2,LZ4,LZMA,LZO,SNAPPY}=OFF -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER}=NO -DWITH_SAFEMALLOC=OFF -DWITH_{ZLIB,SSL,PCRE}=bundled -DHAVE_LIBAIO_H=0 -DCMAKE_DISABLE_FIND_PACKAGE_{URING,LIBAIO}=1 -DWITH_MSAN=ON -DWITH_DBUG_TRACE=OFF && make -j%(kw:jobs)s package',
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
                 c_compiler=util.Property("c_compiler", default="clang"),
                 cxx_compiler=util.Property("cxx_compiler", default="clang++"),

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -702,7 +702,7 @@ f_msan_build.addStep(
             "bash",
             "-xc",
             util.Interpolate(
-                'cmake . -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DCMAKE_C_FLAGS="-O2 -Wno-unused-command-line-argument -fdebug-macro" -DCMAKE_CXX_FLAGS="-stdlib=libc++ -O2 -Wno-unused-command-line-argument -fdebug-macro" -DWITH_EMBEDDED_SERVER=OFF -DWITH_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DWITH_INNODB_{BZIP2,LZ4,LZMA,LZO,SNAPPY}=OFF -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER}=NO -DWITH_SAFEMALLOC=OFF -DWITH_{ZLIB,SSL,PCRE}=bundled -DHAVE_LIBAIO_H=0 -DCMAKE_DISABLE_FIND_PACKAGE_{URING,LIBAIO}=1 -DWITH_MSAN=ON -DWITH_DBUG_TRACE=OFF && make -j%(kw:jobs)s package',
+                'cmake . -DCMAKE_C_COMPILER=%(kw:c_compiler)s -DCMAKE_CXX_COMPILER=%(kw:cxx_compiler)s -DCMAKE_C_FLAGS="-O2 -Wno-unused-command-line-argument -Wno-unknown-warning-option -fdebug-macro" -DCMAKE_CXX_FLAGS="-stdlib=libc++ -O2 -Wno-unused-command-line-argument -fdebug-macro" -DWITH_EMBEDDED_SERVER=OFF -DWITH_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DWITH_INNODB_{BZIP2,LZ4,LZMA,LZO,SNAPPY}=OFF -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER}=NO -DWITH_SAFEMALLOC=OFF -DWITH_{ZLIB,SSL,PCRE}=bundled -DHAVE_LIBAIO_H=0 -DCMAKE_DISABLE_FIND_PACKAGE_{URING,LIBAIO}=1 -DWITH_MSAN=ON -DWITH_DBUG_TRACE=OFF && make -j%(kw:jobs)s package',
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
                 c_compiler=util.Property("c_compiler", default="clang"),
                 cxx_compiler=util.Property("cxx_compiler", default="clang++"),


### PR DESCRIPTION
Fixes on 10.6
`assume_role.c:159:32: error: unknown warning group '-Wformat-truncation', ignored [-Werror,-Wunknown-warning-option] #pragma GCC diagnostic ignored "-Wformat-truncation"
`