### PR TITLE
Add missing Galera dependencies - rhel - last-N-failed

### DIFF
--- a/ci_build_images/rhel.Dockerfile
+++ b/ci_build_images/rhel.Dockerfile
@@ -71,6 +71,7 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     liburing-devel \
     libxml2-devel \
     libzstd-devel \
+    lsof \
     lzo-devel \
     lz4-devel \
     ncurses-devel \
@@ -85,8 +86,10 @@ RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
     python3-devel \
     readline-devel \
     rpmlint \
+    rsync \
     ruby \
     snappy-devel \
+    socat \
     subversion \
     systemd-devel \
     systemtap-sdt-devel \


### PR DESCRIPTION
Galera tests failing with WSREP_SST: [ERROR] 'rsync' not found in path (20240916 03:25:57.651)

See:
https://buildbot.mariadb.org/#/builders/728/builds/113/steps/8/logs/stdio
