### PR TITLE
MDBF-794 - Link bintar binaries statically with libncurses

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -1322,7 +1322,7 @@ f_bintar.addStep(
             "sh",
             "-c",
             util.Interpolate(
-                'cmake . -DWITH_READLINE=1 -DBUILD_CONFIG=mysql_release -DCMAKE_C_FLAGS="%(kw:gnutls_no_signal)s" -DCMAKE_CXX_FLAGS="%(kw:gnutls_no_signal)s" -DWITH_SSL=bundled -DPLATFORM=linux-systemd && make -j%(kw:jobs)s package',
+                'cmake . -DWITH_READLINE=1 -DCURSES_NEED_NCURSES=1 -DBUILD_CONFIG=mysql_release -DCMAKE_C_FLAGS="%(kw:gnutls_no_signal)s" -DCMAKE_CXX_FLAGS="%(kw:gnutls_no_signal)s" -DWITH_SSL=bundled -DPLATFORM=linux-systemd && make -j%(kw:jobs)s package',
                 perf_schema=util.Property("perf_schema", default="YES"),
                 build_type=util.Property("build_type", default="RelWithDebInfo"),
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),


### PR DESCRIPTION
Clients in our binary taballs are linked dynamically with libncurses, which causes a trouble on systems where it is no longer available As per MDBF-794 only centos7 and debian 10 bintar builders need to link statically with libncurses.

- for debian 10: libncurses.a is already present in /scripts/local/lib/ and -DCURSES_NEED_NCURSES=1 flag is enough to link it statically.
- for centos7: I've rebuilt the image and pushed manually a dev_ tag. libncurses.a was present on the system but not in the library path: /scripts/local/lib/

Tests available at:
- debian10: https://buildbot.dev.mariadb.org/#/builders/187/builds/23
- centos7: https://buildbot.dev.mariadb.org/#/builders/172/builds/292

Reference CMAKE output line:
-- Found Curses: /scripts/local/lib/libncurses.a
