### PR TITLE
MDBF-796 - openeuler doesn't have compat rpm

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -475,7 +475,10 @@ def hasCompat(step):
     builderName = str(step.getProperty("buildername"))
 
     # For s390x and the listed distros there are no compat files
-    if any(builderName.find(sub) != -1 for sub in {"s390x", "fedora", "alma", "rocky"}):
+    if any(
+        builderName.find(sub) != -1
+        for sub in {"s390x", "fedora", "alma", "rocky", "openeuler"}
+    ):
         return False
     if "rhel" in builderName or "centos" in builderName:
         return step.getProperty("rpm_type")[-1] in ["7", "8"]


### PR DESCRIPTION
As per https://github.com/MariaDB/server/blob/8478a06cdbb7281e1cc2d507f18c985c736c2ffc/cmake/cpack_rpm.cmake#L374

MariaDB-compat won't be built for OpenEuler.
