### PR TITLE
deb: DEBIAN_FRONTEND=noninteractive is ENV not ARG

### DIFF
--- a/ci_build_images/debian-release.Dockerfile
+++ b/ci_build_images/debian-release.Dockerfile
@@ -8,7 +8,7 @@ FROM "$BASE_IMAGE"
 LABEL maintainer="MariaDB Buildbot maintainers"
 
 # This will make apt-get install without question
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install updates and required packages
 RUN . /etc/os-release; \

--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="MariaDB Buildbot maintainers"
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 # This will make apt-get install without question
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Enable apt sources
 RUN . /etc/os-release \


### PR DESCRIPTION
It needs to be an ENV to be passed though to apt-get commands.

Probably worked due to lack of tty.