### PR TITLE
Prevent MariaDB hanging process on Windows

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -167,7 +167,7 @@ f_windows = util.BuildFactory()
 f_windows.addStep(
     steps.ShellCommand(
         name="stop_processes",
-        command="taskkill /im mysqltest /f || ver>nul",
+        command="taskkill /im mariadb-test.exe /im mariadbd.exe /f || ver>nul",
         alwaysRun=True,
     )
 )
@@ -340,7 +340,7 @@ f_windows_msi = util.BuildFactory()
 f_windows_msi.addStep(
     steps.ShellCommand(
         name="stop_processes",
-        command="taskkill /im mysqltest /f || ver>nul",
+        command="taskkill /im mariadb-test.exe /im mariadbd.exe /f || ver>nul",
         alwaysRun=True,
     )
 )


### PR DESCRIPTION
During the "Compile step" - create_initial_db.cmake runs a bootstrap as a sanity check to avoid spending time on test runs if the bootstrap fails.

It can happen that some changes on the server may cause a loop during the bootstrap process. Buildbot will terminate the parent process (dojob) when it reaches a timeout, but a MariaDB process will remain up causing new builds to fail. https://buildbot.mariadb.org/#/builders/234/builds/32911

Modified the stop_processes step to handle this.