### PR TITLE
Decrease parallel for x86-debian-12-fulltest

### DIFF
--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -142,7 +142,7 @@ addWorker(
     1,
     "-debian-12-32-bit",
     os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12-386",
-    jobs=20,
+    jobs=10,
     save_packages=False,
     shm_size="30G",
 )
@@ -152,7 +152,7 @@ addWorker(
     2,
     "-debian-12-32-bit",
     os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12-386",
-    jobs=20,
+    jobs=10,
     save_packages=False,
     shm_size="30G",
 )
@@ -162,8 +162,9 @@ addWorker(
     3,
     "-debian-12-32-bit",
     os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12-386",
-    jobs=20,
+    jobs=10,
     save_packages=False,
+    shm_size="30G",
 )
 
 addWorker(


### PR DESCRIPTION
The build runs --big-test which puts a lot of memory pressure on the machine, so adjusting the parallel to mitigate this.