### PR TITLE
MDBF-800 Extend package minor upgrade tests to ensure transition from…

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -655,6 +655,8 @@ collect_dependencies() {
     fi
     echo "====== Package $p" >> "./ldd-${suffix}.${old_or_new}"
     for f in $filelist ; do
+      # We do want to match literally here, not as regex
+      # shellcheck disable=SC2076
       if [[ "$f" =~ "/.build-id/" ]] ; then
         continue
       fi


### PR DESCRIPTION
… old bb

- .build-id files may also be present on old systems where --noartifact does not work
- package dependencies need to be sorted for comparison
- dependency collection hangs frequently in buildbot, enabled logging temporarily to get more output for the issue

