### PR TITLE
MDBF-806 - Exclude LDD for mariadb-test packages

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -635,7 +635,7 @@ collect_dependencies() {
   old_or_new=$1
   pkgtype=$2
   bb_log_info "Collecting dependencies for the ${old_or_new} server"
-#  set +x
+ set +x
   for p in ${package_list} ${spider_package_list} ; do
     if [[ "$p" =~ columnstore ]] ; then
       suffix="columnstore"
@@ -650,7 +650,7 @@ collect_dependencies() {
     else
       # We need sudo here for the apt-cache command, not for redirection
       # shellcheck disable=SC2024
-      sudo apt-cache depends "$p" --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances | sort >> "./reqs-${suffix}.${old_or_new}"  
+      sudo apt-cache depends "$p" --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances | sort >> "./reqs-${suffix}.${old_or_new}"
     fi
 
     # Collect LDD output for files installed by the package on the system
@@ -673,5 +673,5 @@ collect_dependencies() {
       done
     fi
   done
-#  set -x
+ set -x
 }

--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -654,7 +654,7 @@ collect_dependencies() {
     fi
 
     # Collect LDD output for files installed by the package on the system
-    if [[ ${p} != "mariadb-test"* ]]; then
+    if [[ ${p,,} != "mariadb-test"* ]]; then
       if [ "$pkgtype" == "rpm" ] ; then
         filelist=$(rpm -ql "$p" | sort)
       else


### PR DESCRIPTION
Improving build time by excluding the too many files of mariadb-test package from the ldd check when dependencies are collected.

[Disable previously enabled command logging in](https://github.com/MariaDB/buildbot/commit/0606a4e47ad843061895f90cfedab8833a772e57) https://github.com/MariaDB/buildbot/pull/582