### PR TITLE
Dedicated builder for triggering Galera builds

### DIFF
--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -28,6 +28,8 @@ c = BuildmasterConfig = {}
 config = {"private": {}}
 exec(open("../master-private.cfg").read(), config, {})
 
+FQDN = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
+
 ####### PROJECT IDENTITY
 
 # the 'title' string will appear at the top of this buildbot installation's
@@ -89,9 +91,14 @@ schedulerTrigger = schedulers.AnyBranchScheduler(
         repository="https://github.com/MariaDB/galera", branch_fn=upstream_branch_fn
     ),
     treeStableTimer=60,
-    builderNames=builders_galera,
+    builderNames=["trigger-galera-builds"],
 )
+schedulerGaleraBuilders = schedulers.Triggerable(
+    name="s_galera_builders", builderNames=builders_galera
+)
+
 c["schedulers"].append(schedulerTrigger)
+c["schedulers"].append(schedulerGaleraBuilders)
 
 if os.getenv("ENVIRON") == "DEV":
     schedulerTrigger = schedulers.AnyBranchScheduler(
@@ -101,7 +108,7 @@ if os.getenv("ENVIRON") == "DEV":
             branch_fn=upstream_branch_fn,
         ),
         treeStableTimer=60,
-        builderNames=builders_galera,
+        builderNames=["trigger-galera-builds"],
     )
     c["schedulers"].append(schedulerTrigger)
 
@@ -112,13 +119,44 @@ if os.getenv("ENVIRON") == "DEV":
 # worker name and password must be configured on the worker.
 c["workers"] = []
 
+c["workers"].append(
+    worker.DockerLatentWorker(
+        "hz-bbw1-docker-galera-trigger",
+        None,
+        docker_host=config["private"]["docker_workers"]["hz-bbw1-docker"],
+        image=os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12",
+        followStartupLogs=False,
+        autopull=True,
+        alwaysPull=True,
+        masterFQDN=FQDN,
+        hostconfig={"shm_size": "1G"},
+        max_builds=1,
+        build_wait_timeout=0,
+    )
+)
+
+c["workers"].append(
+    worker.DockerLatentWorker(
+        "hz-bbw4-docker-galera-trigger",
+        None,
+        docker_host=config["private"]["docker_workers"]["hz-bbw4-docker"],
+        image=os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12",
+        followStartupLogs=False,
+        autopull=True,
+        alwaysPull=True,
+        masterFQDN=FQDN,
+        hostconfig={"shm_size": "1G"},
+        max_builds=1,
+        build_wait_timeout=0,
+    )
+)
+
 # Docker workers
 GALERA_PACKAGES = os.getenv(
     "GALERA_PACKAGES_DIR", default="/mnt/autofs/galera_packages"
 )
 
 workers = {}
-
 
 def addWorker(
     worker_name_prefix,
@@ -251,6 +289,16 @@ def rpmSave():
 
 
 ####### FACTORY CODE
+
+f_trigger_builds = util.BuildFactory()
+f_trigger_builds.addStep(
+    steps.Trigger(
+        schedulerNames=["s_galera_builders"],
+        waitForFinish=False,
+        updateSourceStamp=False,
+        doStepIf=waitIfStaging,
+    )
+)
 
 ## f_deb_build - create source tarball
 f_deb_build = util.BuildFactory()
@@ -386,6 +434,20 @@ f_rpm_build.addStep(
 
 ####### BUILDERS LIST
 c["builders"] = []
+
+c["builders"].append(
+    util.BuilderConfig(
+        name="trigger-galera-builds",
+        workernames=[
+            "hz-bbw1-docker-galera-trigger",
+            "hz-bbw4-docker-galera-trigger",
+        ],
+        tags=["galera"],
+        collapseRequests=True,
+        nextBuild=nextBuild,
+        factory=f_trigger_builds,
+    )
+)
 
 for os_i in os_info:
     if "install_only" in os_info[os_i] and os_info[os_i]["install_only"]:


### PR DESCRIPTION
 - easy to re-trigger all the builds.
 - when new platforms are introduced one can trigger a build by re-building "trigger-galera-builds" for a particular revision . No need to wait for upstream changes to build on new platforms.

**Tests:**
https://buildbot.dev.mariadb.org/#/builders/435/builds/1
