### PR TITLE
[Mdev 31050][Post-Fix] - Enable cursor test on x86-debian-12-fulltest

### DIFF
--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -679,6 +679,7 @@ f_full_test.addStep(
 
 # List of test configurations: (test_type, output_dir, suite)
 full_test_configs = [
+    "cursor",
     "emb",
     "nm",
     "ps",


### PR DESCRIPTION
Fixes https://github.com/MariaDB/buildbot/pull/585