### PR TITLE
[MDBF-800][Postfix] - fix minor upgrade all

### DIFF
--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -73,6 +73,7 @@ RUN . /etc/os-release \
     libeigen3-dev \
     libffi-dev \
     libio-socket-ssl-perl \
+    libmecab-dev \
     libnet-ssleay-perl \
     libssl-dev \
     lsof \

--- a/master-libvirt/master.cfg
+++ b/master-libvirt/master.cfg
@@ -301,7 +301,14 @@ for builder_name in builders_install:
     elif builder_type == "rpm":
         factory_install = f_rpm_install
         factory_upgrade = f_rpm_upgrade
-        build_arch = os_name + os_version + "-" + platform
+        build_arch = os_name + os_info[os_info_name]["version_name"] + "-" + platform
+
+    # FIXME - all RPM's should follow the same conventions!
+    if os_name == "centos" and os_info[os_info_name]["version_name"] >= 9:
+        if platform == "amd64":
+            platform = "x86_64"
+        build_arch = f"centos/{os_info[os_info_name]["version_name"]}/{platform}"
+
 
     c["builders"].append(
         util.BuilderConfig(

--- a/master-libvirt/master.cfg
+++ b/master-libvirt/master.cfg
@@ -301,13 +301,13 @@ for builder_name in builders_install:
     elif builder_type == "rpm":
         factory_install = f_rpm_install
         factory_upgrade = f_rpm_upgrade
-        build_arch = os_name + os_info[os_info_name]["version_name"] + "-" + platform
+        build_arch = os_name + str(os_info[os_info_name]["version_name"]) + "-" + platform
 
     # FIXME - all RPM's should follow the same conventions!
     if os_name == "centos" and os_info[os_info_name]["version_name"] >= 9:
         if platform == "amd64":
             platform = "x86_64"
-        build_arch = f"centos/{os_info[os_info_name]["version_name"]}/{platform}"
+        build_arch = f"centos/{os_info[os_info_name]['version_name']}/{platform}"
 
 
     c["builders"].append(

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -72,12 +72,12 @@ openeuler-2403:
     - aarch64
   type: rpm
 opensuse-1505:
-  version_name: 15.5
+  version_name: 155
   arch:
     - amd64
   type: rpm
 opensuse-1506:
-  version_name: 15.6
+  version_name: 156
   arch:
     - amd64
   type: rpm

--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -577,6 +577,10 @@ check_upgraded_versions() {
     sed -i '/libaio.so/d;liburing.so/d' ./ldd-*.cmp
     sed -i '/lsof/d' ./reqs-*.cmp
 
+    #Account for mariadb-plugin-mroonga diffs in Debian-11
+    sed -i '/liblz4-1/d' ./reqs-*.cmp
+    sed -i '/liblz4.so.1/d' ./ldd-*.cmp
+
     # End of temporary adjustments
 
     set -o pipefail

--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -215,7 +215,6 @@ rpm_repoquery() {
   set +u
   # return full package list from repository
   if [[ $ID_LIKE =~ ^suse* ]]; then
-    sudo zypper --gpg-auto-import-keys packages -r "${repo_name}">/dev/null
     zypper packages -r "${repo_name}" | grep "MariaDB" | awk '{print $4}' #After cache is made, no need for sudo
   else
     repoquery --disablerepo=* --enablerepo="${repo_name}" -a -q |
@@ -315,6 +314,9 @@ module_hotfixes = 1
 gpgkey=https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1
 EOF
+  if [[ $ID_LIKE =~ ^suse* ]]; then
+    sudo zypper --gpg-auto-import-keys refresh mariadb
+  fi
   set +u
 }
 

--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -571,6 +571,12 @@ check_upgraded_versions() {
     # when legitimate changes in dependencies happen between minor versions.
     # The adjustments should be done to .cmp files, and removed after the release
     #
+
+    # Remove after Q4 2024 release
+    sed -i '/libaio.so/d;liburing.so/d' ./reqs-*.cmp
+    sed -i '/libaio.so/d;liburing.so/d' ./ldd-*.cmp
+    sed -i '/lsof/d' ./reqs-*.cmp
+
     # End of temporary adjustments
 
     set -o pipefail

--- a/scripts/deb-upgrade.sh
+++ b/scripts/deb-upgrade.sh
@@ -37,7 +37,7 @@ get_packages_file_mirror() {
   set -u
   if ! wget "$baseurl/$dist_name/dists/$version_name/main/binary-$(deb_arch)/Packages"
   then
-    bb_log_err "Could not find the 'Packages' file for a previous version."
+    bb_log_err "Could not find the 'Packages' file for $dist_name $version_name on deb|archive.mariadb.org."
     exit 1
   fi
   set +u
@@ -50,10 +50,10 @@ case $test_mode in
     if grep -qi columnstore Packages; then
       bb_log_warn "due to MCOL-4120 (Columnstore leaves the server shut down) and other bugs Columnstore upgrade is tested separately"
     fi
-    package_list=$(grep "^Package:" Packages | grep -vE 'galera|spider|columnstore' | awk '{print $2}' | sort | uniq | xargs)
+    package_list=$(grep "^Package:" Packages | grep -vE 'galera|spider|columnstore' | awk '{print $2}' | sort -u | xargs)
     if grep -qi spider Packages; then
       bb_log_warn "due to MDEV-14622 Spider will be installed separately after the server"
-      spider_package_list=$(grep "^Package:" Packages | grep 'spider' | awk '{print $2}' | sort | uniq | xargs)
+      spider_package_list=$(grep "^Package:" Packages | grep 'spider' | awk '{print $2}' | sort -u | xargs)
     fi
     if grep -si tokudb Packages; then
       # For the sake of installing TokuDB, disable hugepages
@@ -75,7 +75,7 @@ case $test_mode in
       bb_log_warn "Columnstore isn't necessarily built on Sid, the test will be skipped"
       exit
     fi
-    package_list="mariadb-server "$(grep "^Package:" Packages | grep 'columnstore' | awk '{print $2}' | sort | uniq | xargs)
+    package_list="mariadb-server "$(grep "^Package:" Packages | grep 'columnstore' | awk '{print $2}' | sort -u | xargs)
     ;;
   *)
     bb_log_err "unknown test mode: $test_mode"
@@ -233,7 +233,7 @@ store_mariadb_server_info new
 # //TEMP what needs to be done here?
 # # Dependency information for new binaries/libraries
 # set +x
-# for i in $(sudo which mysqld | sed -e 's/mysqld$/mysql\*/') $(which mysql | sed -e 's/mysql$/mysql\*/') $(dpkg-query -L $(dpkg -l | grep mariadb | awk '{print $2}' | xargs) | grep -v 'mysql-test' | grep -v '/debug/' | grep '/plugin/' | sed -e 's/[^\/]*$/\*/' | sort | uniq | xargs); do
+# for i in $(sudo which mysqld | sed -e 's/mysqld$/mysql\*/') $(which mysql | sed -e 's/mysql$/mysql\*/') $(dpkg-query -L $(dpkg -l | grep mariadb | awk '{print $2}' | xargs) | grep -v 'mysql-test' | grep -v '/debug/' | grep '/plugin/' | sed -e 's/[^\/]*$/\*/' | sort -u | xargs); do
 #   echo "=== $i"
 #   ldd $i | sort | sed 's/(.*)//'
 # done >/home/buildbot/ldd.new

--- a/scripts/rpm-upgrade.sh
+++ b/scripts/rpm-upgrade.sh
@@ -150,14 +150,14 @@ bb_log_info "Package_list: $package_list"
 # /etc/zypp/repos.d/SUSE_Linux_Enterprise_Server_12_SP3_x86_64:SLES12-SP3-Pool.repo
 if [[ $ID_LIKE =~ ^suse* ]]; then
   sudo "$pkg_cmd" clean --all
-  pkg_cmd_nonint="-n"
+  pkg_cmd_options="-n"
 else
   sudo "$pkg_cmd" clean all
-  pkg_cmd_nonint="-y"
+  pkg_cmd_options="-y"
 fi
 
 # Install previous release
-echo "$package_list" | xargs sudo "$pkg_cmd" "$pkg_cmd_nonint" install ||
+echo "$package_list" | xargs sudo "$pkg_cmd" "$pkg_cmd_options" install ||
   bb_log_err "installation of a previous release failed, see the output above"
 #fi
 
@@ -252,7 +252,7 @@ fi
 if [[ $test_type == "major" ]]; then
   bb_log_info "remove old packages for major upgrade"
   packages_to_remove=$(rpm -qa | grep 'MariaDB-' | awk -F'-' '{print $1"-"$2}')
-  echo "$packages_to_remove" | xargs sudo "$pkg_cmd" "$pkg_cmd_nonint" remove
+  echo "$packages_to_remove" | xargs sudo "$pkg_cmd" "$pkg_cmd_options" remove
   rpm -qa | grep -iE 'maria|mysql' || true
 fi
 
@@ -260,10 +260,10 @@ rpm_setup_bb_galera_artifacts_mirror
 rpm_setup_bb_artifacts_mirror
 if [[ $test_type == "major" ]]; then
   # major upgrade (remove then install)
-  echo "$package_list" | xargs sudo "$pkg_cmd" "$pkg_cmd_nonint" install
+  echo "$package_list" | xargs sudo "$pkg_cmd" "$pkg_cmd_options" install
 else
   # minor upgrade (upgrade works)
-  echo "$package_list" | xargs sudo "$pkg_cmd" "$pkg_cmd_nonint" upgrade
+  echo "$package_list" | xargs sudo "$pkg_cmd" "$pkg_cmd_options" upgrade
 fi
 # set +e
 

--- a/utils.py
+++ b/utils.py
@@ -477,7 +477,15 @@ def hasCompat(step):
     # For s390x and the listed distros there are no compat files
     if any(
         builderName.find(sub) != -1
-        for sub in {"s390x", "fedora", "alma", "rocky", "openeuler", "suse15", "sles15"}
+        for sub in {
+            "s390x",
+            "fedora",
+            "alma",
+            "rocky",
+            "openeuler",
+            "suse-15",
+            "sles-15",
+        }
     ):
         return False
     if "rhel" in builderName or "centos" in builderName:


### PR DESCRIPTION
- [MDBF-803](https://jira.mariadb.org/browse/MDBF-803) - fixed finding mirror packages for previous OpenSuse 15.5/15.6 and CentosStream9
- add libmecab-dev to sort out LDD, REQ differences for `mariadb-plugin-mroonga`
- temporary adjustments for libaio/liburing and lsof to sort out the differences until Q4 release is done
- [Account for mariadb-plugin-mroonga diffs in Debian-11](https://github.com/MariaDB/buildbot/pull/596/commits/9db192c95fa30c9faf97ad560a0d0be92c354d66)
- fix upgrade script for OpenSuse - cache, install command, gpg key
- remove building compat for OpenSuse/SLES 15.x

