### PR TITLE
mdbf-800 - SUSE fixes

### DIFF
--- a/ci_build_images/opensuse.Dockerfile
+++ b/ci_build_images/opensuse.Dockerfile
@@ -34,6 +34,8 @@ RUN zypper update -y \
     git \
     glibc-locale \
     jemalloc-devel \
+    judy-devel \
+    krb5-devel \
     libaio-devel \
     libboost_filesystem1_75_0-devel \
     libboost_program_options1_75_0-devel \
@@ -46,6 +48,7 @@ RUN zypper update -y \
     libopenssl-3-devel \
     liburing2-devel \
     libxml2-devel \
+    lzo-devel \
     pam-devel \
     pcre2-devel \
     perl-Net-SSLeay \

--- a/scripts/rpm-upgrade.sh
+++ b/scripts/rpm-upgrade.sh
@@ -148,13 +148,19 @@ bb_log_info "Package_list: $package_list"
 # sudo rm -rf
 # /etc/zypp/repos.d/SUSE_Linux_Enterprise_Server_12_SP3_x86_64:SLES12-SP3-Updates.repo
 # /etc/zypp/repos.d/SUSE_Linux_Enterprise_Server_12_SP3_x86_64:SLES12-SP3-Pool.repo
+
+# ID_LIKE may not exist
+set +u
 if [[ $ID_LIKE =~ ^suse* ]]; then
   sudo "$pkg_cmd" clean --all
   pkg_cmd_options="-n"
+  pkg_cmd_upgrade="update"
 else
   sudo "$pkg_cmd" clean all
   pkg_cmd_options="-y"
+  pkg_cmd_upgrade="upgrade"
 fi
+set -u
 
 # Install previous release
 echo "$package_list" | xargs sudo "$pkg_cmd" "$pkg_cmd_options" install ||
@@ -263,7 +269,7 @@ if [[ $test_type == "major" ]]; then
   echo "$package_list" | xargs sudo "$pkg_cmd" "$pkg_cmd_options" install
 else
   # minor upgrade (upgrade works)
-  echo "$package_list" | xargs sudo "$pkg_cmd" "$pkg_cmd_options" upgrade
+  echo "$package_list" | xargs sudo "$pkg_cmd" "$pkg_cmd_options" "$pkg_cmd_upgrade"
 fi
 # set +e
 


### PR DESCRIPTION
- ID_LIKE may not exist
- upgrade command does not exist for zypper
- set delimiter for zypper packages -r output
- suppress libmecab diffs to account for old/new bb env diffs
- add krb5/judy/lzo to opensuse images to allow creating rpm packages for  lzo, oqgraph, and gssapi

