### PR TITLE
MDBF-813 - Use unixODBC

### DIFF
--- a/ci_build_images/opensuse.Dockerfile
+++ b/ci_build_images/opensuse.Dockerfile
@@ -45,7 +45,6 @@ RUN zypper update -y \
     libffi-devel \
     libgnutls-devel \
     liblz4-devel \
-    libodbc2 \
     libopenssl-3-devel \
     liburing2-devel \
     libxml2-devel \
@@ -63,6 +62,8 @@ RUN zypper update -y \
     snappy-devel \
     subversion \
     systemd-devel \
+    unixODBC \
+    unixODBC-devel \
     wget \
     && ./mariadb_zypper_expect \
     && zypper clean -a \


### PR DESCRIPTION
use unixODBC

https://buildbot.dev.mariadb.org/#/builders/418/builds/8

in LDD comparison for a minor upgrade test:
`-	libodbc.so.2 => /usr/lib64/libodbc.so.2 `