### PR TITLE
MDBF-813 - libedit-devel missing from OpenSuse 15.6

### DIFF
--- a/ci_build_images/opensuse.Dockerfile
+++ b/ci_build_images/opensuse.Dockerfile
@@ -42,6 +42,7 @@ RUN zypper update -y \
     libboost_system1_75_0-devel \
     libbz2-devel \
     libcurl-devel \
+    libedit-devel \
     libffi-devel \
     libgnutls-devel \
     liblz4-devel \


### PR DESCRIPTION
```
:~$ docker run --rm -it -u root quay.io/mariadb-foundation/bb-worker:dev_opensuse1505 bash  
 0b0ed4c04573:/home/buildbot # rpm -qa | grep libedit 
libedit0-3.1.snap20150325-2.12.x86_64
libedit-devel-3.1.snap20150325-2.12.x86_64

:~$ docker run --rm -it -u root quay.io/mariadb-foundation/bb-worker:dev_opensuse1506 bash  
 588c54d665b5:/home/buildbot # rpm -qa | grep libedit 
libedit0-3.1.snap20150325-2.12.x86_64
```
Build failure: https://buildbot.dev.mariadb.org/#/builders/418/builds/9

