### PR TITLE
SLES/OpenSUSE - build 15.5 and then install/upgrade test to later

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -168,14 +168,16 @@ supportedPlatforms["10.11"] = [
     "amd64-debian-12-debug-embedded",
     "amd64-fedora-40",
     "amd64-fedora-41",
-    "amd64-opensuse-1506",
-    "amd64-sles-1506",
     "amd64-ubuntu-2404",
     "ppc64le-ubuntu-2404",
-    "s390x-sles-1506",
     "s390x-ubuntu-2404",
     "ppc64le-debian-12",
 ]
+# For 10.11 when 1505 goes EOL
+#   "amd64-opensuse-1506",
+#   "amd64-sles-1506",
+#   "s390x-sles-1506",
+
 supportedPlatforms["10.11"] += supportedPlatforms["10.10"]
 
 supportedPlatforms["11.0"] = supportedPlatforms["10.11"].copy()

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -81,6 +81,7 @@ opensuse-1506:
   arch:
     - amd64
   type: rpm
+  install_only: True
 rhel-7:
   version_name: 7
   arch:
@@ -123,7 +124,7 @@ sles-1505:
   version_name: 15.5
   arch:
     - amd64
-# TEMP - currently short on hardware - s390x
+    - s390x
   type: rpm
 sles-1506:
   version_name: 15.6
@@ -131,6 +132,7 @@ sles-1506:
     - amd64
     - s390x
   type: rpm
+  install_only: True
 ubuntu-2004:
   version_name: focal
   arch:

--- a/schedulers_definition.py
+++ b/schedulers_definition.py
@@ -54,32 +54,32 @@ def getBigtestBuilderNames(props):
     return []
 
 
+def getBuilderNames(builderName, builders_list):
+    builders = []
+    for b in builders_list:
+        if builderName in b:
+            builders.append(b)
+            if "rhel" in builderName:
+                builders.append(b.replace("rhel", "almalinux"))
+                builders.append(b.replace("rhel", "rockylinux"))
+            if "sles-1505" in builderName or "opensuse-1505" in builderName:
+                builders.append(b.replace("1505", "1506"))
+            break
+    return builders
+
+
 @util.renderer
 def getInstallBuilderNames(props):
     builderName = str(props.getProperty("parentbuildername"))
 
-    for b in builders_install:
-        if builderName in b:
-            builders = [b]
-            if "rhel" in builderName:
-                builders.append(b.replace("rhel", "almalinux"))
-                builders.append(b.replace("rhel", "rockylinux"))
-            return builders
-    return []
+    return getBuilderNames(builderName, builders_install)
 
 
 @util.renderer
 def getUpgradeBuilderNames(props):
     builderName = str(props.getProperty("parentbuildername"))
 
-    builds = []
-    for b in builders_upgrade:
-        if builderName in b:
-            if "rhel" in builderName:
-                builds.append(b.replace("rhel", "almalinux"))
-                builds.append(b.replace("rhel", "rockylinux"))
-            builds.append(b)
-    return builds
+    return getBuilderNames(builderName, builders_upgrade)
 
 
 @util.renderer


### PR DESCRIPTION
This keep our packages list smaller, less building, and works for 15.5 and 15.6

Factor the generation of lists together as what should be identical implementation. There should be only one match in the list.

# Template selection

Please go the the `Preview` tab and select the appropriate sub-template:

* [Adding Worker Machine](?expand=1&template=add_worker.md)
* [Adding a New Build](?expand=1&template=add_build.md)
