### PR TITLE
docker library: trigger operator with mariadb_version

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -773,15 +773,18 @@ f_dockerlibrary.addStep(
     steps.ShellCommand(
         name="test operator with image",
         command=[
-            'bash',
-            '-xc',
+            "bash",
+            "-xc",
             util.Interpolate(
-                'gh workflow run %s --repo mariadb-operator/mariadb-operator -f mariadb_image=quay.io/mariadb-foundation/mariadb-devel@%s',
-                util.Property('GH_WORKFLOW', default='test-image.yml'),
-		        util.Property('lastsha'),
+                "gh workflow run %s --repo mariadb-operator/mariadb-operator -f mariadb_image=quay.io/mariadb-foundation/mariadb-devel@%s -f mariadb_version=%s",
+                util.Property("GH_WORKFLOW", default="test-image.yml"),
+                util.Property("lastsha"),
+                util.Property("master_branch"),
             ),
         ],
-        doStepIf=lambda step: (str(step.getProperty("lastsha")) != "null" and step.hasProperty("lastsha")),
+        doStepIf=lambda step: (
+            str(step.getProperty("lastsha")) != "null" and step.hasProperty("lastsha")
+        ),
     )
 )
 


### PR DESCRIPTION
Without the MariaDB version specified, the operator was depending on a tag to identify the version. As we trigger by sha this needs to be specified.

Depends on https://github.com/mariadb-operator/mariadb-operator/pull/1048