### PR TITLE
Revert part of #589 - cursor protocol tests on Last-N

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -475,13 +475,12 @@ def getLastNFailedBuildsFactory(test_type, mtrDbPool):
     config = {
         "nm": {
             "args": ("RelWithDebInfo", "-DWITH_EMBEDDED_SERVER=ON"),
-            "steps": ("nm", "cursor", "ps", "emb", "emb-ps", "view"),
+            "steps": ("nm", "ps", "emb", "emb-ps", "view"),
         },
         "debug": {
             "args": ("Debug", "-DWITH_EMBEDDED_SERVER=ON"),
             "steps": (
                 "debug",
-                "debug-cursor",
                 "debug-ps",
                 "debug-emb",
                 "debug-emb-ps",


### PR DESCRIPTION
We need to merge #585 to Production, which will enable the cursor tests on x86-debian-12-fulltest After the cursor tests are Stable we can enable them on the protected branches builder last-N-failed.