### PR TITLE
MDBF-818 Restore rpm-install Columnstore Engine test fixes from old BB

### DIFF
--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -75,7 +75,7 @@ esac
 
 sudo mariadb -e 'drop database if exists test; create database test; use test; create table t(a int primary key) engine=innodb; insert into t values (1); select * from t; drop table t;'
 if echo "$pkg_list" | grep -qi columnstore; then
-  sudo mariadb --verbose -e "create database cs; use cs; create table cs.t_columnstore (a int, b char(8)); insert into cs.t_columnstore select seq, concat('val',seq) from seq_1_to_10; select * from cs.t_columnstore"
+  sudo mariadb --verbose -e "create database cs; use cs; create table cs.t_columnstore (a int, b char(8)) engine=Columnstore; insert into cs.t_columnstore select seq, concat('val',seq) from seq_1_to_10; select * from cs.t_columnstore"
   sudo systemctl restart mariadb
   sudo mariadb --verbose -e "select * from cs.t_columnstore; update cs.t_columnstore set b = 'updated'"
   sudo systemctl restart mariadb-columnstore


### PR DESCRIPTION
The Columnstore Engine option was not specified for the rpm install test and as a result was running with the Innodb default. The issues had been previously fixed in the old BB but the fix was lost during the upgrade to new BB.
