### PR TITLE
MDEV-35452 debug-view causing too many failures throughout spider

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -484,8 +484,8 @@ def getLastNFailedBuildsFactory(test_type, mtrDbPool):
                 "debug-ps",
                 "debug-emb",
                 "debug-emb-ps",
-                "debug-view",
             ),
+            # TODO MDEV-35452 - "debug-view",
         },
     }
 


### PR DESCRIPTION
lots of failures across too many branches.

Some:
* crashes
* wrong result - needing 'select complicate_exp() as simplename`
* others general log requiring a view disable.