### PR TITLE
MDBF-821 - Configure S3 tests

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -61,6 +61,10 @@ builders_galera_mtr = [
     "ppc64le-ubuntu-2204",
     "amd64-freebsd-14",
 ]
+builders_s3_mtr = [
+    "amd64-ubuntu-2004-debug",
+    "s390x-sles-1506",
+]
 
 # Defines branches for which we save packages
 savedPackageBranches = branches_main + [

--- a/utils.py
+++ b/utils.py
@@ -23,6 +23,7 @@ from constants import (
     builders_eco,
     builders_galera_mtr,
     builders_install,
+    builders_s3_mtr,
     builders_upgrade,
     os_info,
     releaseBranches,
@@ -570,6 +571,15 @@ def hasGalera(props):
     builderName = str(props.getProperty("buildername"))
 
     for b in builders_galera_mtr:
+        if builderName in b:
+            return True
+    return False
+
+
+def hasS3(props):
+    builderName = str(props.getProperty("buildername"))
+
+    for b in builders_s3_mtr:
         if builderName in b:
             return True
     return False


### PR DESCRIPTION
- similar logic as in addGaleraTests
- the list is empty now (tests skipped), we should discuss what builders to run S3 tests.
- secrets provided by SecretInAFile provider. Secret file creation done manually on master host.
- mc client already installed on master containers, configured during master start-up (master-private). For PROD needs manual configuration.
