### PR TITLE
Upload git patch when pre-commit fails

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,3 +25,14 @@ jobs:
         run: |
           source .venv/bin/activate
           make pre-commit-run-all
+      - name: Generate git patch
+        if: ${{ failure() }}
+        run: |
+          git diff > pre-commit.patch
+      - name: Upload git patch
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-patch
+          path: pre-commit.patch
+

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -35,4 +35,3 @@ jobs:
         with:
           name: git-patch
           path: pre-commit.patch
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,7 @@ repos:
     hooks:
       - id: black
         name: check python formating (black)
+        args: ["--diff", "--check"]
   # - repo: https://github.com/asottile/pyupgrade
   #   rev: v3.16.0
   #   hooks:
@@ -87,7 +88,7 @@ repos:
     hooks:
       - id: isort
         name: check python imports order (isort)
-        args: ["--profile", "black", "--filter-files"]
+        args: ["--profile", "black", "--filter-files", "--diff", "--check-only"]
   - repo: local
     hooks:
       - id: docker-hadolint

--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,6 @@ import re
 import sys
 from datetime import datetime, timedelta
 
-import docker
 from pyzabbix import ZabbixAPI
 from twisted.internet import defer
 
@@ -28,6 +27,7 @@ from constants import (
     releaseBranches,
     savedPackageBranches,
 )
+import docker
 
 private_config = {"private": {}}
 exec(open("/srv/buildbot/master/master-private.cfg").read(), private_config, {})


### PR DESCRIPTION
When pre-commit modify files but is not verbose about the changes, one case use `git apply pre-commit.patch` (download the patch from GitHub Actions).
