### PR TITLE
MDBF-823 - Add check to skip CS tests for Fedora Distrbutions

### DIFF
--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -74,7 +74,9 @@ case "$systemdCapability" in
 esac
 
 sudo mariadb -e 'drop database if exists test; create database test; use test; create table t(a int primary key) engine=innodb; insert into t values (1); select * from t; drop table t;'
-if echo "$pkg_list" | grep -qi columnstore; then
+# Columnstore tests are currently skipped for Fedora (see MCOL-5825) or Columnstore packages were not found
+
+if [[ $ID != "fedora" ]] && ( echo "$pkg_list" | grep -qi "columnstore" ) ; then
   sudo mariadb --verbose -e "create database cs; use cs; create table cs.t_columnstore (a int, b char(8)) engine=Columnstore; insert into cs.t_columnstore select seq, concat('val',seq) from seq_1_to_10; select * from cs.t_columnstore"
   sudo systemctl restart mariadb
   sudo mariadb --verbose -e "select * from cs.t_columnstore; update cs.t_columnstore set b = 'updated'"


### PR DESCRIPTION
After re-adding the Engine=Columnstore option for rpm_install tests (MDBF-818), we started noticing timeouts in BB. This is related to MCOL-5825 and specific only to Fedora. We will exclude Fedora distros from running the CS tests until the timeout issue is solved.