### PR TITLE
MDBF-826 eco wordpress - retrigger build

### DIFF
--- a/.github/workflows/eco_containers.yml
+++ b/.github/workflows/eco_containers.yml
@@ -49,7 +49,7 @@ jobs:
           extra-args: --ulimit nofile=16384:16384
       - name: Check for registry credentials
         if: >
-          github.ref == 'refs/heads/main' &&
+          github.ref == 'refs/heads/dev' &&
           github.repository == 'MariaDB/buildbot'
         run: |
           missing=()


### PR DESCRIPTION
Trivial commit to get the build green again. Not harmful short term, but per MDBF-826  a different flow is needed.

Change to dev so the schedule (and merging this commit) will regenerate the wordpress container so its tests can pass.

A better long term strategy is in MDBF-826, because ultimately any change via schedule/commit in dev will go to prod.