### PR TITLE
wordpress: always pull latest image

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -641,6 +641,7 @@ f_wordpress.addStep(
             "--pod",
             util.Interpolate("wptest"),
             "--rm",
+            "--pull=always",
             "quay.io/mariadb-foundation/bb-ecosystem:wordpress_phpunit_test_runner",
         ],
     )


### PR DESCRIPTION
Otherwise it keeps whatever is on the local machine.

A pull always if it gets the same manifest will still use the local cached version.