### PR TITLE
validate_master_cfg.sh: do not fail if master-credential-provider exists

### DIFF
--- a/validate_master_cfg.sh
+++ b/validate_master_cfg.sh
@@ -10,7 +10,7 @@ err() {
   exit 1
 }
 
-mkdir master-credential-provider
+mkdir -p master-credential-provider
 [[ -f master-private.cfg ]] ||
   ln -s master-private.cfg-sample master-private.cfg
 [[ -f master-config.yaml ]] ||


### PR DESCRIPTION
Simple fix, to allow running validate_master_cfg.sh multiple times locally.