### PR TITLE
MDBF-824 - Switch to Debian 11 for the protected branches docker containers

### DIFF
--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -112,10 +112,10 @@ MASTER_PACKAGES = os.getenv(
 ## hz-bbw2-docker
 c["workers"].append(
     worker.DockerLatentWorker(
-        "hz-bbw1-docker-tarball-debian-10",
+        "hz-bbw1-docker-tarball-debian-11",
         None,
         docker_host=config["private"]["docker_workers"]["hz-bbw1-docker"],
-        image=os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian10",
+        image=os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian11",
         followStartupLogs=False,
         autopull=True,
         alwaysPull=True,
@@ -130,10 +130,10 @@ c["workers"].append(
 
 c["workers"].append(
     worker.DockerLatentWorker(
-        "hz-bbw4-docker-tarball-debian-10",
+        "hz-bbw4-docker-tarball-debian-11",
         None,
         docker_host=config["private"]["docker_workers"]["hz-bbw4-docker"],
-        image=os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian10",
+        image=os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian11",
         followStartupLogs=False,
         autopull=True,
         alwaysPull=True,
@@ -440,8 +440,8 @@ c["builders"].append(
     util.BuilderConfig(
         name="tarball-docker",
         workernames=[
-            "hz-bbw1-docker-tarball-debian-10",
-            "hz-bbw4-docker-tarball-debian-10",
+            "hz-bbw1-docker-tarball-debian-11",
+            "hz-bbw4-docker-tarball-debian-11",
         ],
         tags=["tar", "bake"],
         collapseRequests=True,


### PR DESCRIPTION
Debian 10 has reached the end-of-life support in July 2024 and no longer receives security upgrades. This change will switch the container version to Debian 11 for the protected branches workers.
