### PR TITLE
MDBF-829 - Update MariaDB Server cnf

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -3,7 +3,7 @@
 ---
 services:
   mariadb:
-    image: mariadb:10.11
+    image: mariadb:10.11.10
     restart: unless-stopped
     container_name: mariadb
     hostname: mariadb
@@ -15,10 +15,10 @@ services:
       - MARIADB_AUTO_UPGRADE=1
     network_mode: host
     healthcheck:
-      test: ['CMD', "mariadb-admin", "--password=password", "--protocol", "tcp", "ping"]
+      test: ['CMD', "healthcheck.sh", "--connect", "--innodb_initialized"]
     volumes:
-      - ./mariadb:/var/lib/mysql:rw
-      - ./mariadb.cnf:/etc/mysql/conf.d/mariadb.cnf:ro
+      - /srv/mariadb:/var/lib/mysql:rw
+      - ./mariadb-config/dev/mariadb.cnf:/etc/mysql/conf.d/mariadb.cnf:ro
     logging:
       driver: journald
       options:

--- a/docker-compose/generate-config.py
+++ b/docker-compose/generate-config.py
@@ -29,7 +29,7 @@ START_TEMPLATE = """
 ---
 services:
   mariadb:
-    image: mariadb:10.11
+    image: mariadb:10.11.10
     restart: unless-stopped
     container_name: mariadb
     hostname: mariadb
@@ -41,10 +41,10 @@ services:
       - MARIADB_AUTO_UPGRADE=1
     network_mode: host
     healthcheck:
-      test: ['CMD', "mariadb-admin", "--password=password", "--protocol", "tcp", "ping"]
+      test: ['CMD', "healthcheck.sh", "--connect", "--innodb_initialized"]
     volumes:
-      - ./mariadb:/var/lib/mysql:rw
-      - ./mariadb.cnf:/etc/mysql/conf.d/mariadb.cnf:ro
+      - /srv/mariadb:/var/lib/mysql:rw
+      - ./mariadb-config/{config_path}/mariadb.cnf:/etc/mysql/conf.d/mariadb.cnf:ro
     logging:
       driver: journald
       options:
@@ -194,6 +194,7 @@ def main(args):
             start_template.format(
                 port=master_web_port,
                 environment="" if args.env == "prod" else "dev_",
+                config_path=args.env,
             )
         )
         port = starting_port

--- a/docker-compose/mariadb-config/dev/mariadb.cnf
+++ b/docker-compose/mariadb-config/dev/mariadb.cnf
@@ -1,0 +1,17 @@
+[mariadb]
+
+# InnoDB
+innodb_buffer_pool_size = 4G
+innodb_log_file_size    = 4G
+innodb_io_capacity      = 2000
+
+# Logging
+slow_query_log
+log_slow_query_file    = mariadb-slow.log
+log_slow_verbosity     = full
+log_slow_query_time     = 2
+
+# Character sets
+character-set-server = utf8mb4
+collation-server     = utf8mb4_uca1400_ai_ci
+old_mode = ''

--- a/docker-compose/mariadb-config/prod/mariadb.cnf
+++ b/docker-compose/mariadb-config/prod/mariadb.cnf
@@ -1,0 +1,44 @@
+[mariadb]
+
+# Fine tuning
+max_connections         = 300
+wait_timeout            = 600
+max_allowed_packet      = 32M
+thread_cache_size       = 128
+sort_buffer_size        = 128M
+bulk_insert_buffer_size = 128M
+tmp_table_size          = 32M
+max_heap_table_size     = 32M
+innodb_log_file_size    = 2G
+
+# Logging
+# warning log-basename is defined later for replication
+# some log option may be ignored.
+# see: https://mariadb.com/kb/en/mysqld-options/#-log-basename
+# log_error = /var/log/mysql/error.log
+log_slow_query
+log_slow_query_file    = mariadb-slow.log
+log_slow_query_time    = 2
+log_slow_verbosity     = full
+
+# Character sets
+character-set-server = utf8mb4
+collation-server     = utf8mb4_uca1400_ai_ci
+old_mode = ''
+
+# InnoDB
+# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
+# Read the manual for more InnoDB related options. There are many!
+innodb_buffer_pool_size = 40G
+
+# Replication
+server-id = 1
+log-basename = mariadb
+
+log_bin
+expire_logs_days = 5
+max_binlog_size = 100M
+binlog_format = MIXED
+# the following permits to simplify the process of moving a replica to a
+# primary node role by ensuring that replication is not started on primary node
+

--- a/docker-compose/mariadb.cnf
+++ b/docker-compose/mariadb.cnf
@@ -1,8 +1,0 @@
-[mariadb]
-
-slow_query_log
-log_slow_verbosity      = query_plan,explain,engine
-log_slow_query_time     = 0.5
-innodb_buffer_pool_size = 4G # FIXME: find a solution for DEV and PROD not being ISO
-innodb_log_file_size    = 4G # FIXME: find a solution for DEV and PROD not being ISO
-innodb_io_capacity      = 2000

--- a/rsync.exclude
+++ b/rsync.exclude
@@ -6,7 +6,6 @@ autogen
 ci_build_images
 docker-compose/logs
 docker-compose/certbot
-docker-compose/mariadb
 docker-compose/nginx/conf.d/bb.conf
 docker-compose/nginx/conf.d/ci.conf
 master-libvirt/id_ed25519


### PR DESCRIPTION
**Main feature**: [MDBF-791](https://jira.mariadb.org/browse/MDBF-791) - Run Production BuildBot services in docker containers

**In this Pull Request:**
- separate configs for PROD and DEV. 
- Updated docker-compose to choose the right one based on environment. 
- TODO: maybe a templating engine in the future to de-duplicate configuration settings.

**Q:**
 ->  @fauust how Restic backup will work for containers?
 -> @grooverdan Couldn't find anything for slow query log in containers --> stdout (to be inspected with `docker logs `via `journald` driver). Anything like that possible? I've mounted a volume for these logs.

**Source of Truth:**
@fauust / @grooverdan For PROD configuration, well, my source of truth was hz-bbm1.
Here's the current prod layout, if you have any suggestions or I missed something, please let me know.

```
:/etc/mysql$ tree
.
├── conf.d
│   ├── mysql.cnf -> this is empty
│   └── mysqldump.cnf -> Settings described in [A]
├── debian.cnf -> I guess we dont need it: "THIS FILE IS OBSOLETE. STOP USING IT IF POSSIBLE"
├── debian-start -> Same as above
├── mariadb.cnf -> Settings described in [B]
├── mariadb.conf.d
│   ├── 50-client.cnf -> Nothing set here
│   ├── 50-mysql-clients.cnf -> Nothing set here
│   ├── 50-mysqld_safe.cnf ->  Settings described in [C], not included.
│   ├── 50-server.cnf -> Setting described in [D], not included.
│   ├── 60-galera.cnf -> Nothing set here
│   └── 99-enable-encryption.cnf.preset
│       └── enable_encryption.preset -> Not used
├── my.cnf -> mariadb.cnf
└── my.cnf.fallback -> Guess this is a backup file, only contains !includedir /etc/mysql/conf.d/
```
```
 [A] - Duplicate of [B]
    [mysqldump]
    quick
    quote-names
    max_allowed_packet	= 16M

[B]
    # Ansible managed

    [mariadb]

    # Basic settings
    user                  = mysql
    pid-file              = /run/mysqld/mysqld.pid
    socket                = /run/mysqld/mysqld.sock
    basedir               = /usr
    datadir               = /var/lib/mysql
    tmpdir                = /tmp
    lc-messages-dir       = /usr/share/mysql
    lc_messages           = en_US
    skip-external-locking
    port                  = 3306
    bind-address          = 0.0.0.0

    # Fine tuning
    max_connections         = 300
    connect_timeout         = 5
    wait_timeout            = 600
    max_allowed_packet      = 32M
    thread_cache_size       = 128
    sort_buffer_size        = 128M
    bulk_insert_buffer_size = 128M
    tmp_table_size          = 32M
    max_heap_table_size     = 32M
    skip-name-resolve       = 1
    innodb_log_file_size    = 2G

    # Logging
    # warning log-basename is defined later for replication
    # some log option may be ignored.
    # see: https://mariadb.com/kb/en/mysqld-options/#-log-basename
    # log_error = /var/log/mysql/error.log
    slow_query_log
    slow_query_log_file    = /var/log/mysql/mariadb-slow.log
    long_query_time        = 2
    log_slow_verbosity     = query_plan,explain
    log_error              = /var/log/mysql/mariadb.err.log

    # Query cache
    query_cache_size        = 16M

    # Character sets
    character-set-server = utf8mb4
    collation-server     = utf8mb4_general_ci

    # InnoDB
    # InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
    # Read the manual for more InnoDB related options. There are many!
    innodb_buffer_pool_size = 40G

    # Replication
    server-id = 1
    log-basename = mariadb

    log_bin
    expire_logs_days = 5
    max_binlog_size = 100M
    binlog_format = MIXED
    # the following permits to simplify the process of moving a replica to a
    # primary node role by ensuring that replication is not started on primary node
    skip-slave-start

    [mysqldump]
    quick
    quote-names
    max_allowed_packet = 16M

[C]:
    [mysqld_safe]
    nice = 0
    skip_log_error
    syslog

[D]: Duplicate of [B] except expire_logs_days value
    pid-file                = /run/mysqld/mysqld.pid
    basedir                 = /usr
    expire_logs_days        = 10
    character-set-server  = utf8mb4
    collation-server      = utf8mb4_general_ci
```
