### PR TITLE
MDBF-842 / MDBF-841 - Streaming NGINX logs to standard streams / evaluate .env files values

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -1,14 +1,15 @@
 TITLE="MariaDB CI"
 TITLE_URL=https://github.com/MariaDB/server
 BUILDMASTER_URL=https://buildbot.mariadb.org/
-CR_HOST_WG_ADDR="hz-bbw5=100.64.100.20"
-MQ_ROUTER_URL=ws://localhost:8085/ws
+BUILDMASTER_WG_IP=100.64.100.1
+MQ_ROUTER_URL=ws://127.0.0.1:8080/ws
 MASTER_PACKAGES_DIR="/mnt/autofs/master_packages"
 MASTER_CREDENTIALS_DIR="/srv/buildbot/master/master-credential-provider"
 GALERA_PACKAGES_DIR="/mnt/autofs/galera_packages"
 ARTIFACTS_URL="https://ci.mariadb.org"
 NGINX_ARTIFACTS_VHOST="ci.mariadb.org"
 NGINX_BUILDBOT_VHOST="buildbot.mariadb.org"
+NGINX_CR_HOST_WG_ADDR="100.64.100.20:8080"
 ENVIRON="PROD"
 BRANCH="main"
 MASTER_NONLATENT_DOCKERLIBRARY_WORKER="bb-rhel8-docker"

--- a/docker-compose/.env.dev
+++ b/docker-compose/.env.dev
@@ -1,7 +1,6 @@
 TITLE="MariaDB CI (DEV)"
 TITLE_URL=https://github.com/MariaDB/server
 BUILDMASTER_URL=https://buildbot.dev.mariadb.org/
-CR_HOST_WG_ADDR="hz-bbw5=127.0.0.1"
 BUILDMASTER_WG_IP=100.64.101.1
 MQ_ROUTER_URL=ws://127.0.0.1:8080/ws
 MASTER_PACKAGES_DIR="/mnt/autofs/master_dev_packages"
@@ -10,6 +9,7 @@ GALERA_PACKAGES_DIR="/mnt/autofs/galera_dev_packages"
 ARTIFACTS_URL="https://ci.dev.mariadb.org"
 NGINX_ARTIFACTS_VHOST="ci.dev.mariadb.org"
 NGINX_BUILDBOT_VHOST="buildbot.dev.mariadb.org"
+NGINX_CR_HOST_WG_ADDR="127.0.0.1:8081"
 ENVIRON="DEV"
 BRANCH="dev"
 MASTER_NONLATENT_DOCKERLIBRARY_WORKER="bb-rhel9-docker"

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -47,12 +47,12 @@ services:
       - /srv/buildbot/packages:/srv/buildbot/packages:ro
       - /srv/buildbot/galera_packages:/srv/buildbot/galera_packages:ro
       - /srv/buildbot/helper_files:/srv/buildbot/helper_files:ro
-      - ./logs/nginx:/var/log/nginx
       - ./certbot/www/:/var/www/certbot/:ro
       - ./certbot/ssl/:/etc/nginx/ssl/:ro
     environment:
       - NGINX_ARTIFACTS_VHOST
       - NGINX_BUILDBOT_VHOST
+      - NGINX_CR_HOST_WG_ADDR
     network_mode: host
     logging:
       driver: journald
@@ -69,7 +69,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -105,7 +104,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -145,7 +143,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -184,7 +181,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -223,7 +219,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -262,7 +257,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -301,7 +295,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -340,7 +333,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -379,7 +371,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -418,7 +409,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -457,7 +447,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -496,7 +485,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -535,7 +523,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR
@@ -574,7 +561,6 @@ services:
       - BUILDMASTER_URL
       - BUILDMASTER_WG_IP
       - CONTAINER_REGISTRY_URL
-      - CR_HOST_WG_ADDR
       - ENVIRON
       - GALERA_PACKAGES_DIR
       - MASTER_CREDENTIALS_DIR

--- a/docker-compose/generate-config.py
+++ b/docker-compose/generate-config.py
@@ -73,12 +73,12 @@ services:
       - /srv/buildbot/packages:/srv/buildbot/packages:ro
       - /srv/buildbot/galera_packages:/srv/buildbot/galera_packages:ro
       - /srv/buildbot/helper_files:/srv/buildbot/helper_files:ro
-      - ./logs/nginx:/var/log/nginx
       - ./certbot/www/:/var/www/certbot/:ro
       - ./certbot/ssl/:/etc/nginx/ssl/:ro
     environment:
       - NGINX_ARTIFACTS_VHOST
       - NGINX_BUILDBOT_VHOST
+      - NGINX_CR_HOST_WG_ADDR
     network_mode: host
     logging:
       driver: journald
@@ -193,7 +193,6 @@ def main(args):
         file.write(
             start_template.format(
                 port=master_web_port,
-                cr_host_wg_addr=env_vars["CR_HOST_WG_ADDR"],
                 environment="" if args.env == "prod" else "dev_",
             )
         )

--- a/docker-compose/nginx/templates/bb.conf.template
+++ b/docker-compose/nginx/templates/bb.conf.template
@@ -61,9 +61,9 @@ server {
 		alias   /srv/cr/static;
 	}
 
-	# logging
-	access_log /var/log/nginx/${NGINX_BUILDBOT_VHOST}.access.log;
-	error_log /var/log/nginx/${NGINX_BUILDBOT_VHOST}.error.log;
+	location /cr/ {
+		proxy_pass http://${NGINX_CR_HOST_WG_ADDR};
+	}
 
 	# disable logging for wsgi_dashboards/styles.css since it's generated
 	# somewhere and mess with fail2ban //TEMP find the root cause!

--- a/docker-compose/nginx/templates/ci.conf.template
+++ b/docker-compose/nginx/templates/ci.conf.template
@@ -48,8 +48,4 @@ server {
 	autoindex on;
 
 	error_page 404 /older_builds$request_uri;
-
-	# logging
-	access_log /var/log/nginx/${NGINX_ARTIFACTS_VHOST}.access.log;
-	error_log /var/log/nginx/${NGINX_ARTIFACTS_VHOST}.error.log;
 }


### PR DESCRIPTION
**Main feature**: [MDBF-791](https://jira.mariadb.org/browse/MDBF-791) - Run Production BuildBot services in docker containers

- **MQ_ROUTER_URL** for PROD will be the same as DEV, on 8080
- define **NGINX_CR_HOST_WG_ADDR** . For PROD is `hz-bbw5 on 8080`. For **DEV** we should deploy CR on `hz-dev-bbm` and choose another port (**8081**) because 8080 is already in use by CrossBar (MQ_ROUTER_URL)
- enable proxy pass to CrossReference in NGINX `bb.conf.template` and define ENV variable in docker-compose.
- by removing the logs mount, and custom logging in configs, NGINX container will now stream the default access / error logs to the standard out/err streams.
- having logging driver: `journald` will enable us to collect the logs via **journalctl** using the container tag **bb-nginx**.