### PR TITLE
MDBF-847 Add centos stream 10 as bb worker

### DIFF
--- a/.github/workflows/build-centos.pip-based.yml
+++ b/.github/workflows/build-centos.pip-based.yml
@@ -27,6 +27,12 @@ jobs:
       matrix:
         include:
 
+          - image: quay.io/centos/centos:stream10
+            platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
+            tag: centosstream10
+            runner: ubuntu-24.04
+            nogalera: true
+
           - image: quay.io/centos/centos:stream9
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
             tag: centosstream9

--- a/ci_build_images/centos.Dockerfile
+++ b/ci_build_images/centos.Dockerfile
@@ -13,6 +13,8 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     && source /etc/os-release \
     && ARCH=$(rpm --query --queryformat='%{ARCH}' rpm) \
     && case "$PLATFORM_ID" in \
+        "platform:el10") \
+           ;& \
         "platform:el9") \
           # centosstream9/almalinux9/rockylinux9 \
           dnf -y install epel-release; \
@@ -59,7 +61,6 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     # not sure if needed \
     # perl \
     ${extra} \
-    asio-devel \
     bzip2 \
     bzip2-devel \
     ccache \
@@ -70,9 +71,6 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     eigen3-devel \
     flex \
     galera-4 \
-    java-1.8.0-openjdk-devel \
-    java-1.8.0-openjdk \
-    jemalloc-devel \
     libcurl-devel \
     libevent-devel \
     libffi-devel \
@@ -91,6 +89,16 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     wget \
     which \
     xz-devel \
+    && if [ "$PLATFORM_ID" = "platform:el10" ]; then \
+         dnf -y install liburing-devel \
+           java-21-openjdk-devel \
+           java-21-openjdk ; \
+       else \
+         dnf -y install asio-devel \
+           java-1.8.0-openjdk-devel \
+           java-1.8.0-openjdk \
+           jemalloc-devel; \
+       fi \
     && if [ "$ID" != "openeuler" ]; then dnf -y install yum-utils; fi \
     && if [ "$(uname -m)" = "x86_64" ]; then dnf -y install libpmem-devel; fi \
     && dnf clean all \

--- a/constants.py
+++ b/constants.py
@@ -159,10 +159,12 @@ supportedPlatforms["10.10"] = [
 supportedPlatforms["10.10"] += supportedPlatforms["10.9"]
 
 supportedPlatforms["10.11"] = [
+    "aarch64-centos-stream10",
     "aarch64-debian-12",
     "aarch64-fedora-40",
     "aarch64-fedora-41",
     "aarch64-ubuntu-2404",
+    "amd64-centos-stream10",
     "amd64-debian-12",
     "amd64-debian-12-debug-embedded",
     "amd64-fedora-40",
@@ -170,6 +172,7 @@ supportedPlatforms["10.11"] = [
     "amd64-opensuse-1506",
     "amd64-sles-1506",
     "amd64-ubuntu-2404",
+    "ppc64le-centos-stream10",
     "ppc64le-ubuntu-2404",
     "s390x-sles-1506",
     "s390x-ubuntu-2404",

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -20,6 +20,13 @@ centos-stream9:
     - aarch64
     - ppc64le
   type: rpm
+centos-stream10:
+  version_name: 10
+  arch:
+    - amd64
+    - aarch64
+    - ppc64le
+  type: rpm
 debian-11:
   version_name: bullseye
   arch:


### PR DESCRIPTION
Bump java version.

It wasn't clear that setup python was a problem. Lets see if CI fails on ppc64le (d9a25df6ebb211ea2bf8e921df73095e5ce9e98e / MDBF-780)

asio (used in galera) isn't currently in EPEL 10
https://src.fedoraproject.org/rpms/asio - might need to request it? Or check Codership on their plans for its continued used?

# Add New Build template

## Checklist

- [X] Make changes os_info.yaml
- [X] Schedule the builder for the appropriate branch in constants.py
- [?] Add builder configuration - already there in master-libvirt/master.cfg?