### PR TITLE
MDBF-632 Fedora 39 received cmake update

### DIFF
--- a/ci_build_images/fedora.Dockerfile
+++ b/ci_build_images/fedora.Dockerfile
@@ -62,7 +62,6 @@ RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf \
     unixODBC-devel \
     wget \
     which \
-    && if [ "$VERSION_ID" = 39 ]; then curl -s 'https://gitlab.kitware.com/cmake/cmake/-/raw/v3.28.5/Modules/Internal/CPack/CPackRPM.cmake?ref_type=tags' -o /usr/share/cmake/Modules/Internal/CPack/CPackRPM.cmake ; fi \
     && if [ "$(uname -m)" = "x86_64" ]; then dnf -y install libpmem-devel; fi \
     && if [ "$INSTALL_VALGRIND" = "true" ]; then dnf -y install valgrind; fi \
     && dnf clean all


### PR DESCRIPTION
The version bump https://bodhi.fedoraproject.org/updates/FEDORA-2024-1991ac9b3e

raised version to cmake-3.30.5-1.fc39 hence the cmake patch of cpack_rpm is out of date.