### PR TITLE
MDBF-850 - Backup PROD master tag

### DIFF
--- a/.github/workflows/bbm_build_container.yml
+++ b/.github/workflows/bbm_build_container.yml
@@ -16,6 +16,8 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     name: build
+    env:
+      MAIN_BRANCH: false
     services:
       registry:
         image: registry:2
@@ -24,34 +26,49 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Check Dockerfile with hadolint
-        run: |
-          docker run -i -v $(pwd):/mnt -w /mnt ghcr.io/hadolint/hadolint:latest hadolint /mnt/Dockerfile
+
+      - name: Enable Production release - no rebuild
+        run: echo "MAIN_BRANCH=true" >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/main'
+
       - name: Set up env vars
         run: |
           echo "REPO=bb-master" >>$GITHUB_ENV
+
+      - name: Check Dockerfile with hadolint
+        if: ${{ env.MAIN_BRANCH == 'false' }}
+        run: |
+          docker run -i -v $(pwd):/mnt -w /mnt ghcr.io/hadolint/hadolint:latest hadolint /mnt/Dockerfile
+
       - name: Build master image
+        if: ${{ env.MAIN_BRANCH == 'false' }}
         run: |
           podman build . --tag ${{ env.REPO }}:master
+
       - name: Build master-web image
+        if: ${{ env.MAIN_BRANCH == 'false' }}
         run: |
           podman build . --tag ${{ env.REPO }}:master-web \
             --build-arg master_type=master-web
+
       - name: Push images to local registry
+        if: ${{ env.MAIN_BRANCH == 'false' }}
         run: |
           for img in master master-web; do
             podman push --tls-verify=0 \
               ${{ env.REPO }}:$img \
               docker://localhost:5000/${{ env.REPO }}:$img
           done
+
       - name: Check images
+        if: ${{ env.MAIN_BRANCH == 'false' }}
         run: |
           docker run -i localhost:5000/${{ env.REPO }}:master buildbot --version
           #//TEMP there is probably a better way for master-web here
           docker run -i localhost:5000/${{ env.REPO }}:master-web buildbot --version
+
       - name: Check for registry credentials
         if: >
-          github.ref == 'refs/heads/dev' &&
           github.repository == 'MariaDB/buildbot'
         run: |
           missing=()
@@ -65,6 +82,7 @@ jobs:
           else
             echo "Not pushing images to registry"
           fi
+
       - name: Login to ghcr.io
         if: ${{ env.DEPLOY_IMAGES == 'true' }}
         uses: docker/login-action@v2
@@ -72,17 +90,33 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push images to ghcr.io
-        if: ${{ env.DEPLOY_IMAGES == 'true' }}
+
+      - name: Push DEV images to ghcr.io
+        if: ${{ env.DEPLOY_IMAGES == 'true' && env.MAIN_BRANCH == 'false' }}
         run: |
-          msg="Push docker images to ghcr.io"
-          line="${msg//?/=}"
-          printf "\n${line}\n${msg}\n${line}\n"
           for image in master master-web; do
+            msg="Push docker image to ghcr.io (${image})"
+            line="${msg//?/=}"
+            printf "\n${line}\n${msg}\n${line}\n"
+
             skopeo copy --all --src-tls-verify=0 \
             docker://localhost:5000/${{ env.REPO }}:${image} \
             docker://ghcr.io/mariadb/buildbot:dev_${image}
           done
+
+      - name: ghcr.io - backup Production tag
+        if: ${{ env.DEPLOY_IMAGES == 'true' && env.MAIN_BRANCH =='true' }}
+        run:
+          for image in master master-web; do
+            msg="Create backup for ${image} on ghcr.io"
+            line="${msg//?/=}"
+            printf "\n${line}\n${msg}\n${line}\n"
+
+            skopeo copy --all --src-tls-verify=0 \
+              docker://ghcr.io/mariadb/buildbot:${image} \
+              docker://ghcr.io/mariadb/buildbot:previous_${image}
+          done
+
       - name: Login to quay.io
         if: ${{ env.DEPLOY_IMAGES == 'true' }}
         uses: docker/login-action@v2
@@ -90,14 +124,29 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
-      - name: Push images to quay.io
-        if: ${{ env.DEPLOY_IMAGES == 'true' }}
+
+      - name: Push DEV images to quay.io
+        if: ${{ env.DEPLOY_IMAGES == 'true' && env.MAIN_BRANCH == 'false' }}
         run: |
-          msg="Push docker images to quay.io"
-          line="${msg//?/=}"
-          printf "\n${line}\n${msg}\n${line}\n"
           for image in master master-web; do
+            msg="Push docker image to quay.io (${image})"
+            line="${msg//?/=}"
+            printf "\n${line}\n${msg}\n${line}\n"
+
             skopeo copy --all --src-tls-verify=0 \
-            docker://localhost:5000/${{ env.REPO }}:${image} \
-            docker://quay.io/mariadb-foundation/${{ env.REPO }}:dev_${image}
+              docker://localhost:5000/${{ env.REPO }}:${image} \
+              docker://quay.io/mariadb-foundation/${{ env.REPO }}:dev_${image}
+          done
+
+      - name: quay.io - backup Production tag
+        if: ${{ env.DEPLOY_IMAGES == 'true' && env.MAIN_BRANCH =='true' }}
+        run:
+          for image in master master-web; do
+            msg="Create backup for ${image} on quay.io"
+            line="${msg//?/=}"
+            printf "\n${line}\n${msg}\n${line}\n"
+
+            skopeo copy --all --src-tls-verify=0 \
+              docker://quay.io/mariadb-foundation/${{ env.REPO }}:${image} \
+              docker://quay.io/mariadb-foundation/${{ env.REPO }}:previous_${image}
           done


### PR DESCRIPTION
Main feature: [MDBF-791](https://jira.mariadb.org/browse/MDBF-791) - Run Production BuildBot services in docker containers

**Background:**
- when the branch is Main, create a copy of the Production tag {previous_master, previous_master-web}.
- in the future after the backup step, a "Move Tag" step will be added. For the moment we move dev_ tag to production manually.

**In this patch:**
- add MAIN_BRANCH environment variable. If branch is not main, no build, no backup creation.

@fauust @vladbogo let me know if that's a suitable approach.
Do you want backup on GHCR also?

Thanks.