### PR TITLE
MDBF-857 - Volume mounts for File/Upload steps

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -426,6 +426,7 @@ services:
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
+      - /srv/buildbot/packages:/srv/buildbot/packages
     entrypoint:
       - /bin/bash
       - -c
@@ -540,6 +541,7 @@ services:
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
+      - /srv/buildbot/packages:/srv/buildbot/packages
     entrypoint:
       - /bin/bash
       - -c

--- a/docker-compose/generate-config.py
+++ b/docker-compose/generate-config.py
@@ -150,10 +150,14 @@ def main(args):
         key: VOLUMES[:]
         for key in [element.replace("/", "_") for element in MASTER_DIRECTORIES]
     }
-    for master in ["master-nonlatent", "master-docker-nonstandard", "master-docker-nonstandard-2"]:
-      master_volumes[master].append(
-          "/srv/buildbot/packages:/srv/buildbot/packages"
-      )  # Using FileUpload step
+    for master in [
+        "master-nonlatent",
+        "master-docker-nonstandard",
+        "master-docker-nonstandard-2",
+    ]:
+        master_volumes[master].append(
+            "/srv/buildbot/packages:/srv/buildbot/packages"
+        )  # Using FileUpload step
 
     # Capture the current environment variables' keys
     current_env_keys = set(os.environ.keys())

--- a/docker-compose/generate-config.py
+++ b/docker-compose/generate-config.py
@@ -150,9 +150,10 @@ def main(args):
         key: VOLUMES[:]
         for key in [element.replace("/", "_") for element in MASTER_DIRECTORIES]
     }
-    master_volumes["master-nonlatent"].append(
-        "/srv/buildbot/packages:/srv/buildbot/packages"
-    )  # Using FileUpload step
+    for master in ["master-nonlatent", "master-docker-nonstandard", "master-docker-nonstandard-2"]:
+      master_volumes[master].append(
+          "/srv/buildbot/packages:/srv/buildbot/packages"
+      )  # Using FileUpload step
 
     # Capture the current environment variables' keys
     current_env_keys = set(os.environ.keys())


### PR DESCRIPTION
Some factories are using the File/Directory upload steps to move files from the worker to CI. The data is transferred to the master which is then in charge of writing the files to destination on the host, meaning hz-bbm[1,2].

In order for this to work, the paths (from hz-bbm) should be mounted inside the container.

So far the following factories were identified:
-> f_asan_ubsan_build
-> f_big_test
-> f_asan_ubsan_build
-> f_valgrind_build
-> f_windows
-> f_windows_msi

Windows is defined by non-latent master which has already the path mounted. The rest of the factories are defined in master-docker-nonstandard 1 and 2.

For Linux builders is it possible to use a network file share but we will not cover this for the migration but taking a note for future refactoring.
