### PR TITLE
MDBF 135 - Don't run S3 for 10.5 / Use non-protected builders / Use SSL verification

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -454,6 +454,11 @@ def addGaleraTests(factory, mtrDbPool):
 
 
 def addS3Tests(factory, mtrDbPool):
+    runS3 = (
+        lambda props: hasS3(props)
+        and props.hasProperty("compile_step_completed")
+        and "10.5" not in str(props.getProperty("master_branch"))
+    )
     factory.addStep(
         steps.MasterShellCommand(
             name="Create minio S3 bucket",
@@ -463,8 +468,7 @@ def addS3Tests(factory, mtrDbPool):
                 "mb",
                 util.Interpolate("minio/%(prop:buildername)s-%(prop:buildnumber)s"),
             ],
-            doStepIf=lambda props: hasS3(props)
-            and props.hasProperty("compile_step_completed"),
+            doStepIf=runS3,
         )
     )
     factory.addStep(
@@ -502,8 +506,7 @@ def addS3Tests(factory, mtrDbPool):
                 "S3_USE_HTTP": "OFF",
                 "S3_SSL_NO_VERIFY": "ON",
             },
-            doStepIf=lambda props: hasS3(props)
-            and props.hasProperty("compile_step_completed"),
+            doStepIf=runS3,
         )
     )
 
@@ -517,8 +520,7 @@ def addS3Tests(factory, mtrDbPool):
                 "--force",
                 util.Interpolate("minio/%(prop:buildername)s-%(prop:buildnumber)s"),
             ],
-            doStepIf=lambda props: hasS3(props)
-            and props.hasProperty("compile_step_completed"),
+            doStepIf=runS3,
         )
     )
 
@@ -534,8 +536,7 @@ def addS3Tests(factory, mtrDbPool):
                     jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
                 ),
             ],
-            doStepIf=lambda props: hasS3(props)
-            and props.hasProperty("compile_step_completed"),
+            doStepIf=runS3,
         )
     )
     return factory

--- a/common_factories.py
+++ b/common_factories.py
@@ -457,6 +457,7 @@ def addS3Tests(factory, mtrDbPool):
     factory.addStep(
         steps.MasterShellCommand(
             name="Create minio S3 bucket",
+            alwaysRun=True,
             command=[
                 "mc",
                 "mb",

--- a/common_factories.py
+++ b/common_factories.py
@@ -496,7 +496,7 @@ def addS3Tests(factory, mtrDbPool):
             dbpool=mtrDbPool,
             autoCreateTables=True,
             env={
-                "S3_HOST_NAME": "135.181.42.57",
+                "S3_HOST_NAME": "minio.mariadb.org",
                 "S3_PORT": "443",
                 "S3_ACCESS_KEY": util.Interpolate("%(secret:minio_access_key)s"),
                 "S3_SECRET_KEY": util.Interpolate("%(secret:minio_secret_key)s"),
@@ -504,7 +504,7 @@ def addS3Tests(factory, mtrDbPool):
                     "%(prop:buildername)s-%(prop:buildnumber)s"
                 ),
                 "S3_USE_HTTP": "OFF",
-                "S3_SSL_NO_VERIFY": "ON",
+                "S3_PROTOCOL_VERSION": "Path",
             },
             doStepIf=runS3,
         )

--- a/constants.py
+++ b/constants.py
@@ -61,10 +61,7 @@ builders_galera_mtr = [
     "ppc64le-ubuntu-2204",
     "amd64-freebsd-14",
 ]
-builders_s3_mtr = [
-    "amd64-ubuntu-2004-debug",
-    "s390x-sles-1506",
-]
+builders_s3_mtr = []
 
 # Defines branches for which we save packages
 savedPackageBranches = branches_main + [

--- a/constants.py
+++ b/constants.py
@@ -61,7 +61,10 @@ builders_galera_mtr = [
     "ppc64le-ubuntu-2204",
     "amd64-freebsd-14",
 ]
-builders_s3_mtr = []
+builders_s3_mtr = [
+    "aarch64-ubuntu-2004-debug",
+    "s390x-sles-1506",
+]
 
 # Defines branches for which we save packages
 savedPackageBranches = branches_main + [


### PR DESCRIPTION
S3 tests don't work for 10.5 (SSL No verify option is not present).
https://buildbot.mariadb.org/#/builders/369/builds/26765/steps/13/logs/stdio

Added `alwaysRun` option on `create bucket step` for the situation in which the previous test suite fails.

I've manually disabled these tests on PROD also until further notice.
I suggest we do the buildbot migration and then come back on this subject.