### PR TITLE
MDBF-135 Use exact match for builderName comparison in has S3

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -571,7 +571,7 @@ def hasS3(props):
     builderName = str(props.getProperty("buildername"))
 
     for b in builders_s3_mtr:
-        if builderName in b:
+        if builderName == b:
             return True
     return False
 


### PR DESCRIPTION
Otherwise aarch64-ubuntu-2004 will run S3 tests because the string is in aarch64-ubuntu-2004-debug
