### PR TITLE
MDBF-865 - Nginx cloud-init location

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
       - /srv/buildbot/packages:/srv/buildbot/packages:ro
       - /srv/buildbot/galera_packages:/srv/buildbot/galera_packages:ro
       - /srv/buildbot/helper_files:/srv/buildbot/helper_files:ro
+      - /srv/buildbot/cloud-init:/srv/buildbot/cloud-init:ro
       - ./certbot/www/:/var/www/certbot/:ro
       - ./certbot/ssl/:/etc/nginx/ssl/:ro
     environment:

--- a/docker-compose/generate-config.py
+++ b/docker-compose/generate-config.py
@@ -77,6 +77,7 @@ services:
       - /srv/buildbot/packages:/srv/buildbot/packages:ro
       - /srv/buildbot/galera_packages:/srv/buildbot/galera_packages:ro
       - /srv/buildbot/helper_files:/srv/buildbot/helper_files:ro
+      - /srv/buildbot/cloud-init:/srv/buildbot/cloud-init:ro
       - ./certbot/www/:/var/www/certbot/:ro
       - ./certbot/ssl/:/etc/nginx/ssl/:ro
     environment:

--- a/docker-compose/nginx/templates/ci.conf.template
+++ b/docker-compose/nginx/templates/ci.conf.template
@@ -28,6 +28,12 @@ server {
 	location /galera {
 		alias /srv/buildbot/galera_packages;
 	}
+
+	location /cloud-init {
+		alias /srv/buildbot/cloud-init;
+		autoindex off;
+	}
+
 	location = /favicon.ico {
 		access_log off;
 	}


### PR DESCRIPTION
add /cloud-init location to expose required artifacts for libvirt cloud-init image deployment in Ansible
