### PR TITLE
hasAutobake/hasBigtest - exact match

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -553,7 +553,7 @@ def waitIfStaging(step):
 def hasAutobake(props):
     builderName = props.getProperty("buildername")
     for b in builders_autobake:
-        if builderName in b:
+        if builderName == b:
             return True
     return False
 
@@ -580,7 +580,7 @@ def hasBigtest(props):
     builderName = str(props.getProperty("buildername"))
 
     for b in builders_big:
-        if builderName in b:
+        if builderName == b:
             return True
     return False
 


### PR DESCRIPTION
While the current matches are exact, there was risk in "in" as a comparison matching those builder names with suffixes.

As this pattern was copied to other build conditions, lets keep a good pattern to copy.

like https://github.com/MariaDB/buildbot/pull/492#issuecomment-2553056796 and another fix.