### PR TITLE
MDBF-876 - Remove BuildBot configuration code needed for systemd setup

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -648,7 +648,7 @@ def getRpmAutobakeFactory(mtrDbPool):
                 util.Interpolate(
                     'wget --no-check-certificate -cO ../MariaDB-shared-5.3.%(kw:arch)s.rpm "%(kw:url)s/helper_files/mariadb-shared-5.3-%(kw:arch)s.rpm" && wget -cO ../MariaDB-shared-10.1.%(kw:arch)s.rpm "%(kw:url)s/helper_files/mariadb-shared-10.1-kvm-rpm-%(kw:rpm_type)s-%(kw:arch)s.rpm"',
                     arch=getArch,
-                    url=os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org"),
+                    url=os.environ["ARTIFACTS_URL"],
                     rpm_type=util.Property("rpm_type"),
                 ),
             ],
@@ -736,7 +736,7 @@ EOF
                 echo "module_hotfixes = 1" >> MariaDB.repo
             fi
         """,
-                    url=os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org"),
+                    url=os.environ["ARTIFACTS_URL"],
                 ),
             ]
         )
@@ -761,7 +761,7 @@ EOF
             descriptionDone=util.Interpolate(
                 """
 Repository available with: curl %(kw:url)s/%(prop:tarbuildnum)s/%(prop:buildername)s/MariaDB.repo -o /etc/yum.repos.d/MariaDB.repo""",
-                url=os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org"),
+                url=os.environ["ARTIFACTS_URL"],
             ),
         )
     )

--- a/constants.py
+++ b/constants.py
@@ -45,7 +45,7 @@ BUILDERS_ECO = [
     "amd64-ubuntu-2004-eco-php",
 ]
 
-if os.getenv("ENVIRON") == "DEV":
+if os.environ["ENVIRON"] == "DEV":
     BUILDERS_WORDPRESS = ["amd64-rhel9-wordpress"]
     BUILDERS_DOCKERLIBRARY = ["amd64-rhel9-dockerlibrary"]
 else:

--- a/define_masters.py
+++ b/define_masters.py
@@ -27,7 +27,6 @@ for os_name in OS_INFO:
 if os.path.exists(BASE_PATH):
     shutil.rmtree(BASE_PATH)
 
-IDX = 0
 for arch in platforms:
     # Create the directory for the architecture that is handled by each master
     # If for a given architecture there are more than "max_builds" builds,
@@ -47,13 +46,6 @@ for arch in platforms:
         master_config["workers"] = config["private"]["master-variables"]["workers"][
             arch
         ]
-
-        starting_port = int(
-            os.getenv(
-                "PORT", default=config["private"]["master-variables"]["starting_port"]
-            )
-        )
-        master_config["port"] = starting_port + IDX
         master_config["log_name"] = (
             "master-docker-" + arch + "-" + str(master_id) + ".log"
         )
@@ -69,5 +61,4 @@ for arch in platforms:
         )
         with open(dir_path + "/buildbot.tac", mode="w", encoding="utf-8") as f:
             f.write(buildbot_tac)
-        IDX += 1
     print(arch, len(master_config["builders"]))

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -1,29 +1,19 @@
-TITLE="MariaDB CI"
-TITLE_URL=https://github.com/MariaDB/server
-BUILDMASTER_URL=https://buildbot.mariadb.org/
-BUILDMASTER_WG_IP=100.64.100.1
-MQ_ROUTER_URL=ws://127.0.0.1:8080/ws
-MASTER_PACKAGES_DIR="/mnt/autofs/master_packages"
-MASTER_CREDENTIALS_DIR="/srv/buildbot/master/master-credential-provider"
-GALERA_PACKAGES_DIR="/mnt/autofs/galera_packages"
-ARTIFACTS_URL="https://ci.mariadb.org"
-NGINX_ARTIFACTS_VHOST="ci.mariadb.org"
-NGINX_BUILDBOT_VHOST="buildbot.mariadb.org"
-NGINX_CR_HOST_WG_ADDR="100.64.100.20:8080"
-ENVIRON="PROD"
-BRANCH="main"
-MASTER_NONLATENT_DOCKERLIBRARY_WORKER="bb-rhel8-docker"
-MASTER_NONLATENT_BINTARS_WORKERS = '
-    {
-    "ro-apexis-bbw03-x64": {
-        "max_builds": 2,
-        "jobs": 12
-        },
-    "bg-bbw1-x64": {
-        "max_builds": 1,
-        "jobs": 12
-        }
-    }'
-MASTER_NONLATENT_BINTARS_VM_PORT="10000"
-MASTER_NONLATENT_BINTARS_WORKER_PORT="10007"
-CONTAINER_REGISTRY_URL="quay.io/mariadb-foundation/bb-worker:"
+TITLE='MariaDB CI'
+TITLE_URL='https://github.com/MariaDB/server'
+BUILDMASTER_URL='https://buildbot.mariadb.org/'
+BUILDMASTER_WG_IP='100.64.100.1'
+MQ_ROUTER_URL='ws://127.0.0.1:8080/ws'
+MASTER_PACKAGES_DIR='/mnt/autofs/master_packages'
+MASTER_CREDENTIALS_DIR='/srv/buildbot/master/master-credential-provider'
+GALERA_PACKAGES_DIR='/mnt/autofs/galera_packages'
+ARTIFACTS_URL='https://ci.mariadb.org'
+NGINX_ARTIFACTS_VHOST='ci.mariadb.org'
+NGINX_BUILDBOT_VHOST='buildbot.mariadb.org'
+NGINX_CR_HOST_WG_ADDR='100.64.100.20:8080'
+ENVIRON='PROD'
+BRANCH='main'
+MASTER_NONLATENT_DOCKERLIBRARY_WORKER='bb-rhel8-docker'
+MASTER_NONLATENT_BINTARS_WORKERS='{ "ro-apexis-bbw03-x64": { "max_builds": 2, "jobs": 12 }, "bg-bbw1-x64": { "max_builds": 1, "jobs": 12 } }'
+MASTER_NONLATENT_BINTARS_VM_PORT='10000'
+MASTER_NONLATENT_BINTARS_WORKER_PORT='10007'
+CONTAINER_REGISTRY_URL='quay.io/mariadb-foundation/bb-worker:'

--- a/docker-compose/.env.dev
+++ b/docker-compose/.env.dev
@@ -1,26 +1,19 @@
-TITLE="MariaDB CI (DEV)"
-TITLE_URL=https://github.com/MariaDB/server
-BUILDMASTER_URL=https://buildbot.dev.mariadb.org/
-BUILDMASTER_WG_IP=100.64.101.1
-MQ_ROUTER_URL=ws://127.0.0.1:8080/ws
-MASTER_PACKAGES_DIR="/mnt/autofs/master_dev_packages"
-MASTER_CREDENTIALS_DIR="/srv/buildbot/master/master-credential-provider"
-GALERA_PACKAGES_DIR="/mnt/autofs/galera_dev_packages"
-ARTIFACTS_URL="https://ci.dev.mariadb.org"
-NGINX_ARTIFACTS_VHOST="ci.dev.mariadb.org"
-NGINX_BUILDBOT_VHOST="buildbot.dev.mariadb.org"
-NGINX_CR_HOST_WG_ADDR="127.0.0.1:8081"
-ENVIRON="DEV"
-BRANCH="dev"
-MASTER_NONLATENT_DOCKERLIBRARY_WORKER="bb-rhel9-docker"
-# MASTER_NONLATENT_BINTARS_WORKERS='["bg-bbw1"]'
-MASTER_NONLATENT_BINTARS_WORKERS = '
-    {
-    "bg-bbw1-x64": {
-        "max_builds": 1,
-        "jobs": 12
-        }
-    }'
-MASTER_NONLATENT_BINTARS_VM_PORT="20000"
-MASTER_NONLATENT_BINTARS_WORKER_PORT="10007"
-CONTAINER_REGISTRY_URL="quay.io/mariadb-foundation/bb-worker:dev_"
+TITLE='MariaDB CI (DEV)'
+TITLE_URL='https://github.com/MariaDB/server'
+BUILDMASTER_URL='https://buildbot.dev.mariadb.org/'
+BUILDMASTER_WG_IP='100.64.101.1'
+MQ_ROUTER_URL='ws://127.0.0.1:8080/ws'
+MASTER_PACKAGES_DIR='/mnt/autofs/master_dev_packages'
+MASTER_CREDENTIALS_DIR='/srv/buildbot/master/master-credential-provider'
+GALERA_PACKAGES_DIR='/mnt/autofs/galera_dev_packages'
+ARTIFACTS_URL='https://ci.dev.mariadb.org'
+NGINX_ARTIFACTS_VHOST='ci.dev.mariadb.org'
+NGINX_BUILDBOT_VHOST='buildbot.dev.mariadb.org'
+NGINX_CR_HOST_WG_ADDR='127.0.0.1:8081'
+ENVIRON='DEV'
+BRANCH='dev'
+MASTER_NONLATENT_DOCKERLIBRARY_WORKER='bb-rhel9-docker'
+MASTER_NONLATENT_BINTARS_WORKERS='{ "bg-bbw1-x64": { "max_builds": 1, "jobs": 12 } }'
+MASTER_NONLATENT_BINTARS_VM_PORT='20000'
+MASTER_NONLATENT_BINTARS_WORKER_PORT='10007'
+CONTAINER_REGISTRY_URL='quay.io/mariadb-foundation/bb-worker:dev_'

--- a/master-bintars/master.cfg
+++ b/master-bintars/master.cfg
@@ -24,7 +24,7 @@ from locks import *
 from schedulers_definition import SCHEDULERS
 from utils import *
 
-FQDN = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
+FQDN = os.environ["BUILDMASTER_WG_IP"]
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
@@ -55,10 +55,7 @@ gs = reporters.GitHubStatusPush(
 c["services"].append(gs)
 c["secretsProviders"] = [
     secrets.SecretInAFile(
-        dirname=os.getenv(
-            "MASTER_CREDENTIALS_DIR",
-            default="/srv/buildbot/master/master-credential-provider",
-        )
+        dirname=os.environ["MASTER_CREDENTIALS_DIR"]
     )
 ]
 
@@ -66,21 +63,21 @@ c["secretsProviders"] = [
 
 # the 'title' string will appear at the top of this buildbot installation's
 # home pages (linked to the 'titleURL').
-c["title"] = os.getenv("TITLE", default="MariaDB CI")
-c["titleURL"] = os.getenv("TITLE_URL", default="https://github.com/MariaDB/server")
+c["title"] = os.environ["TITLE"]
+c["titleURL"] = os.environ["TITLE_URL"]
 
 # the 'buildbotURL' string should point to the location where the buildbot's
 # internal web server is visible. This typically uses the port number set in
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
-c["buildbotURL"] = os.getenv("BUILDMASTER_URL", default="https://buildbot.mariadb.org/")
+c["buildbotURL"] = os.environ["BUILDMASTER_URL"]
 
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers. You must define at least 'port' option that workers
 # could connect to your master with this protocol.
 # 'port' must match the value configured into the workers (with their
 # --master option)
-port = int(os.getenv("MASTER_NONLATENT_BINTARS_WORKER_PORT", default="10002"))
+port = int(os.environ["MASTER_NONLATENT_BINTARS_WORKER_PORT"])
 c["protocols"] = {"pb": {"port": port}}
 
 ####### DB URL
@@ -117,22 +114,8 @@ def mkWorker(name, **kwargs):
 # a Worker object, specifying a unique worker name and password.  The same
 # worker name and password must be configured on the worker.
 
-# default_workers_bintar exists because master-bintar in production
-# is a standolone service, not a container sourcing .env
-default_workers_bintar = """
-{
-    "ro-apexis-bbw03-x64": {
-        "max_builds": 2,
-        "jobs": 12
-    },
-    "bg-bbw1-x64": {
-        "max_builds": 1,
-        "jobs": 12
-    }
-}
-"""
 workers_bintar = json.loads(
-    os.getenv("MASTER_NONLATENT_BINTARS_WORKERS", default=default_workers_bintar)
+    os.environ["MASTER_NONLATENT_BINTARS_WORKERS"]
 )
 
 c["workers"] = []
@@ -356,7 +339,7 @@ builder_definitions = {
     "centos-6": "centos6",
 }
 
-current_port = int(os.getenv("MASTER_NONLATENT_BINTARS_VM_PORT", default=10000))
+current_port = int(os.environ["MASTER_NONLATENT_BINTARS_VM_PORT"])
 
 for b in builder_definitions:
     for arch in ["amd64", "i386"]:
@@ -388,7 +371,7 @@ c["multiMaster"] = True
 
 c["mq"] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     "type": "wamp",
-    "router_url": os.getenv("MQ_ROUTER_URL", default="ws://localhost:8085/ws"),
+    "router_url": os.environ["MQ_ROUTER_URL"],
     "realm": "realm1",
     # valid are: none, critical, error, warn, info, debug, trace
     "wamp_debug_level": "info",

--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -23,7 +23,7 @@ from locks import *
 from schedulers_definition import SCHEDULERS
 from utils import *
 
-FQDN = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
+FQDN = os.environ["BUILDMASTER_WG_IP"]
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
@@ -54,31 +54,28 @@ gs = reporters.GitHubStatusPush(
 c["services"].append(gs)
 c["secretsProviders"] = [
     secrets.SecretInAFile(
-        dirname=os.getenv(
-            "MASTER_CREDENTIALS_DIR",
-            default="/srv/buildbot/master/master-credential-provider",
-        )
+        dirname=os.environ["MASTER_CREDENTIALS_DIR"]
     )
 ]
 ####### PROJECT IDENTITY
 
 # the 'title' string will appear at the top of this buildbot installation's
 # home pages (linked to the 'titleURL').
-c["title"] = os.getenv("TITLE", default="MariaDB CI")
-c["titleURL"] = os.getenv("TITLE_URL", default="https://github.com/MariaDB/server")
+c["title"] = os.environ["TITLE"]
+c["titleURL"] = os.environ["TITLE_URL"]
 
 # the 'buildbotURL' string should point to the location where the buildbot's
 # internal web server is visible. This typically uses the port number set in
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
-c["buildbotURL"] = os.getenv("BUILDMASTER_URL", default="https://buildbot.mariadb.org/")
+c["buildbotURL"] = os.environ["BUILDMASTER_URL"]
 
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers. You must define at least 'port' option that workers
 # could connect to your master with this protocol.
 # 'port' must match the value configured into the workers (with their
 # --master option)
-port = int(os.getenv("PORT", default="10001"))
+port = int(os.environ["PORT"])
 c["protocols"] = {"pb": {"port": port}}
 
 ####### DB URL
@@ -142,13 +139,13 @@ def addWorker(
 
 
 # Docker workers
-fqdn = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
+fqdn = os.environ["BUILDMASTER_WG_IP"]
 
 addWorker(
     "amd-bbw",
     1,
     "-debian-12-32-bit",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "debian12-386",
     jobs=10,
     save_packages=False,
@@ -159,7 +156,7 @@ addWorker(
     "amd-bbw",
     2,
     "-debian-12-32-bit",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "debian12-386",
     jobs=10,
     save_packages=False,
@@ -170,7 +167,7 @@ addWorker(
     "apexis-bbw",
     3,
     "-debian-12-32-bit",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "debian12-386",
     jobs=10,
     save_packages=False,
@@ -181,7 +178,7 @@ addWorker(
     "apexis-bbw",
     3,
     "-msan-clang-debian-11",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "debian11-msan",
     jobs=20,
     save_packages=False,
@@ -191,7 +188,7 @@ addWorker(
     "apexis-bbw",
     3,
     "-ubuntu-2204-jepsen-mariadb",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "ubuntu22.04-jepsen-mariadb",
     jobs=5,
     save_packages=False,
@@ -805,7 +802,7 @@ f_eco_php.addStep(
         command=[
             "/buildbot/installdb.sh",
             util.Interpolate(
-                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                os.environ["ARTIFACTS_URL"]
                 + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
             ),
             "--plugin-load-add=auth_pam",
@@ -862,7 +859,7 @@ f_eco_pymysql.addStep(
         command=[
             "/buildbot/installdb.sh",
             util.Interpolate(
-                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                os.environ["ARTIFACTS_URL"]
                 + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
             ),
         ],
@@ -908,7 +905,7 @@ f_eco_mysqljs.addStep(
         command=[
             "/buildbot/installdb.sh",
             util.Interpolate(
-                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                os.environ["ARTIFACTS_URL"]
                 + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
             ),
         ],
@@ -1167,7 +1164,7 @@ c["multiMaster"] = True
 
 c["mq"] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     "type": "wamp",
-    "router_url": os.getenv("MQ_ROUTER_URL", default="ws://localhost:8085/ws"),
+    "router_url": os.environ["MQ_ROUTER_URL"],
     "realm": "realm1",
     # valid are: none, critical, error, warn, info, debug, trace
     "wamp_debug_level": "info",

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -23,7 +23,7 @@ from locks import *
 from schedulers_definition import SCHEDULERS
 from utils import *
 
-FQDN = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
+FQDN = os.environ["BUILDMASTER_WG_IP"]
 
 # This is the dictionary that the buildmaster pays attention to. We also use
 # a shorter alias to save typing.
@@ -54,31 +54,28 @@ gs = reporters.GitHubStatusPush(
 c["services"].append(gs)
 c["secretsProviders"] = [
     secrets.SecretInAFile(
-        dirname=os.getenv(
-            "MASTER_CREDENTIALS_DIR",
-            default="/srv/buildbot/master/master-credential-provider",
-        )
+        dirname=os.environ["MASTER_CREDENTIALS_DIR"]
     )
 ]
 ####### PROJECT IDENTITY
 
 # the 'title' string will appear at the top of this buildbot installation's
 # home pages (linked to the 'titleURL').
-c["title"] = os.getenv("TITLE", default="MariaDB CI")
-c["titleURL"] = os.getenv("TITLE_URL", default="https://github.com/MariaDB/server")
+c["title"] = os.environ["TITLE"]
+c["titleURL"] = os.environ["TITLE_URL"]
 
 # the 'buildbotURL' string should point to the location where the buildbot's
 # internal web server is visible. This typically uses the port number set in
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
-c["buildbotURL"] = os.getenv("BUILDMASTER_URL", default="https://buildbot.mariadb.org/")
+c["buildbotURL"] = os.environ["BUILDMASTER_URL"]
 
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers. You must define at least 'port' option that workers
 # could connect to your master with this protocol.
 # 'port' must match the value configured into the workers (with their
 # --master option)
-port = int(os.getenv("PORT", default="9992"))
+port = int(os.environ["PORT"])
 c["protocols"] = {"pb": {"port": port}}
 
 ####### DB URL
@@ -142,7 +139,7 @@ def addWorker(
 
 
 # Docker workers
-fqdn = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
+fqdn = os.environ["BUILDMASTER_WG_IP"]
 
 ## hz-bbw2-docker
 c["workers"].append(
@@ -211,17 +208,13 @@ c["workers"].append(
 )
 
 ## bm-bbw1-docker
-MASTER_PACKAGES = os.getenv(
-    "MASTER_PACKAGES_DIR", default="/mnt/autofs/master_packages"
-)
+MASTER_PACKAGES = os.environ["MASTER_PACKAGES_DIR"]
 c["workers"].append(
     worker.DockerLatentWorker(
         "bm-bbw1-docker-ubuntu-2004",
         None,
         docker_host=config["private"]["docker_workers"]["bm-bbw1-docker"],
-        image=os.getenv(
-            "CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:"
-        )
+        image=os.environ["CONTAINER_REGISTRY_URL"]
         + "ubuntu20.04",
         followStartupLogs=False,
         autopull=True,
@@ -243,7 +236,7 @@ addWorker(
     "hz-bbw",
     6,
     "-bigtest-ubuntu-2004",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "ubuntu20.04",
     jobs=20,
     save_packages=False,
@@ -255,9 +248,7 @@ for w_name in ["ppc64le-osuosl-bbw"]:
         w_name,
         1,
         "-ubuntu-2004",
-        os.getenv(
-            "CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:"
-        )
+        os.environ["CONTAINER_REGISTRY_URL"]
         + "ubuntu20.04",
         jobs=7,
         save_packages=True,
@@ -267,9 +258,7 @@ for w_name in ["ppc64le-osuosl-bbw"]:
         w_name,
         1,
         "-ubuntu-2004-debug",
-        os.getenv(
-            "CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:"
-        )
+        os.environ["CONTAINER_REGISTRY_URL"]
         + "ubuntu20.04",
         jobs=30,
         save_packages=True,
@@ -287,10 +276,7 @@ for w_name in ["ns-x64-bbw", "apexis-bbw"]:
             w_name,
             i,
             "-aocc-debian-11",
-            os.getenv(
-                "CONTAINER_REGISTRY_URL",
-                default="quay.io/mariadb-foundation/bb-worker:",
-            )
+            os.environ["CONTAINER_REGISTRY_URL"]
             + "debian11-aocc",
             jobs=jobs,
             save_packages=False,
@@ -299,10 +285,7 @@ for w_name in ["ns-x64-bbw", "apexis-bbw"]:
             w_name,
             i,
             "-asan-ubuntu-2404",
-            os.getenv(
-                "CONTAINER_REGISTRY_URL",
-                default="quay.io/mariadb-foundation/bb-worker:",
-            )
+            os.environ["CONTAINER_REGISTRY_URL"]
             + "ubuntu24.04",
             jobs=jobs,
             save_packages=False,
@@ -311,10 +294,7 @@ for w_name in ["ns-x64-bbw", "apexis-bbw"]:
             w_name,
             i,
             "-icc-ubuntu-2204",
-            os.getenv(
-                "CONTAINER_REGISTRY_URL",
-                default="quay.io/mariadb-foundation/bb-worker:",
-            )
+            os.environ["CONTAINER_REGISTRY_URL"]
             + "ubuntu22.04-icc",
             jobs=jobs,
             save_packages=False,
@@ -323,10 +303,7 @@ for w_name in ["ns-x64-bbw", "apexis-bbw"]:
             w_name,
             i,
             "-ubuntu-2004",
-            os.getenv(
-                "CONTAINER_REGISTRY_URL",
-                default="quay.io/mariadb-foundation/bb-worker:",
-            )
+            os.environ["CONTAINER_REGISTRY_URL"]
             + "ubuntu20.04",
             jobs=jobs,
             save_packages=True,
@@ -337,7 +314,7 @@ addWorker(
     "amd-bbw",
     1,
     "-valgrind-fedora-40",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "fedora40-valgrind",
     jobs=20,
     save_packages=False,
@@ -346,7 +323,7 @@ addWorker(
     "amd-bbw",
     2,
     "-valgrind-fedora-40",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "fedora40-valgrind",
     jobs=20,
     save_packages=False,
@@ -355,7 +332,7 @@ addWorker(
     "hz-bbw",
     6,
     "-valgrind-fedora-40",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "fedora40-valgrind",
     jobs=20,
     save_packages=False,
@@ -365,7 +342,7 @@ addWorker(
     "hz-bbw",
     1,
     "-msan-clang-16-debian-11",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "debian11-msan-clang-16",
     jobs=20,
     save_packages=False,
@@ -374,7 +351,7 @@ addWorker(
     "hz-bbw",
     4,
     "-msan-clang-16-debian-11",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "debian11-msan-clang-16",
     jobs=20,
     save_packages=False,
@@ -383,7 +360,7 @@ addWorker(
     "hz-bbw",
     5,
     "-msan-clang-16-debian-11",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "debian11-msan-clang-16",
     jobs=30,
     save_packages=False,
@@ -393,7 +370,7 @@ addWorker(
     "hz-bbw",
     2,
     "-debian-12",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "debian12",
     jobs=20,
     save_packages=False,
@@ -402,7 +379,7 @@ addWorker(
     "hz-bbw",
     5,
     "-debian-12",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "debian12",
     jobs=20,
     save_packages=False,
@@ -412,7 +389,7 @@ addWorker(
     "aarch64-bbw",
     6,
     "-ubuntu-2004-debug",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "ubuntu20.04",
     jobs=10,
     save_packages=True,
@@ -421,7 +398,7 @@ addWorker(
     "aarch64-bbw",
     6,
     "-debian-10-bintar",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "debian10-bintar",
     jobs=10,
     save_packages=True,
@@ -431,7 +408,7 @@ addWorker(
     "hz-bbw",
     5,
     "-centos-7-bintar",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "centos7-bintar",
     jobs=10,
     save_packages=True,
@@ -441,7 +418,7 @@ addWorker(
     "s390x-bbw",
     1,
     "-ubuntu-2004-debug",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "ubuntu20.04",
     jobs=7,
     save_packages=False,
@@ -451,7 +428,7 @@ addWorker(
     "s390x-bbw",
     2,
     "-ubuntu-2004-debug",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "ubuntu20.04",
     jobs=7,
     save_packages=False,
@@ -461,7 +438,7 @@ addWorker(
     "s390x-bbw",
     3,
     "-ubuntu-2004-debug",
-    os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:")
+    os.environ["CONTAINER_REGISTRY_URL"]
     + "ubuntu20.04",
     jobs=7,
     save_packages=False,
@@ -473,9 +450,7 @@ c["workers"].append(
         "release-prep-docker",
         None,
         docker_host=config["private"]["docker_workers"]["release-prep-docker"],
-        image=os.getenv(
-            "CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:"
-        )
+        image=os.environ["CONTAINER_REGISTRY_URL"]
         + "debian12-release",
         followStartupLogs=False,
         autopull=True,
@@ -1220,7 +1195,7 @@ f_eco_php.addStep(
         command=[
             "/buildbot/installdb.sh",
             util.Interpolate(
-                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                os.environ["ARTIFACTS_URL"]
                 + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
             ),
             "--plugin-load-add=auth_pam",
@@ -1277,7 +1252,7 @@ f_eco_pymysql.addStep(
         command=[
             "/buildbot/installdb.sh",
             util.Interpolate(
-                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                os.environ["ARTIFACTS_URL"]
                 + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
             ),
         ],
@@ -1323,7 +1298,7 @@ f_eco_mysqljs.addStep(
         command=[
             "/buildbot/installdb.sh",
             util.Interpolate(
-                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                os.environ["ARTIFACTS_URL"]
                 + "/%(prop:tarbuildnum)s/%(prop:parentbuildername)s/%(prop:mariadb_binary)s"
             ),
         ],
@@ -1816,7 +1791,7 @@ c["multiMaster"] = True
 
 c["mq"] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     "type": "wamp",
-    "router_url": os.getenv("MQ_ROUTER_URL", default="ws://localhost:8085/ws"),
+    "router_url": os.environ["MQ_ROUTER_URL"],
     "realm": "realm1",
     # valid are: none, critical, error, warn, info, debug, trace
     "wamp_debug_level": "info",

--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -28,27 +28,27 @@ c = BuildmasterConfig = {}
 config = {"private": {}}
 exec(open("../master-private.cfg").read(), config, {})
 
-FQDN = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
+FQDN = os.environ["BUILDMASTER_WG_IP"]
 
 ####### PROJECT IDENTITY
 
 # the 'title' string will appear at the top of this buildbot installation's
 # home pages (linked to the 'titleURL').
-c["title"] = os.getenv("TITLE", default="MariaDB CI")
-c["titleURL"] = os.getenv("TITLE_URL", default="https://github.com/MariaDB/server")
+c["title"] = os.environ["TITLE"]
+c["titleURL"] = os.environ["TITLE_URL"]
 
 # the 'buildbotURL' string should point to the location where the buildbot's
 # internal web server is visible. This typically uses the port number set in
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
-c["buildbotURL"] = os.getenv("BUILDMASTER_URL", default="https://buildbot.mariadb.org/")
+c["buildbotURL"] = os.environ["BUILDMASTER_URL"]
 
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers. You must define at least 'port' option that workers
 # could connect to your master with this protocol.
 # 'port' must match the value configured into the workers (with their
 # --master option)
-port = int(os.getenv("PORT", default="9991"))
+port = int(os.environ["PORT"])
 c["protocols"] = {"pb": {"port": port}}
 
 ####### DB URL
@@ -100,7 +100,7 @@ schedulerGaleraBuilders = schedulers.Triggerable(
 c["schedulers"].append(schedulerTrigger)
 c["schedulers"].append(schedulerGaleraBuilders)
 
-if os.getenv("ENVIRON") == "DEV":
+if os.environ["ENVIRON"] == "DEV":
     schedulerTrigger = schedulers.AnyBranchScheduler(
         name="s_upstream_galera_vlad",
         change_filter=util.ChangeFilter(
@@ -124,7 +124,7 @@ c["workers"].append(
         "hz-bbw1-docker-galera-trigger",
         None,
         docker_host=config["private"]["docker_workers"]["hz-bbw1-docker"],
-        image=os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12",
+        image=os.environ["CONTAINER_REGISTRY_URL"] + "debian12",
         followStartupLogs=False,
         autopull=True,
         alwaysPull=True,
@@ -140,7 +140,7 @@ c["workers"].append(
         "hz-bbw4-docker-galera-trigger",
         None,
         docker_host=config["private"]["docker_workers"]["hz-bbw4-docker"],
-        image=os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12",
+        image=os.environ["CONTAINER_REGISTRY_URL"] + "debian12",
         followStartupLogs=False,
         autopull=True,
         alwaysPull=True,
@@ -152,9 +152,7 @@ c["workers"].append(
 )
 
 # Docker workers
-GALERA_PACKAGES = os.getenv(
-    "GALERA_PACKAGES_DIR", default="/mnt/autofs/galera_packages"
-)
+GALERA_PACKAGES = os.environ["GALERA_PACKAGES_DIR"]
 
 workers = {}
 
@@ -226,7 +224,7 @@ for platform in ALL_PLATFORMS:
                 ):
                     continue
                 if platform in OS_INFO[os_str]["arch"]:
-                    quay_name = os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "".join(
+                    quay_name = os.environ["CONTAINER_REGISTRY_URL"] + "".join(
                         os_str.split("-")
                     )
                     os_name = os_str
@@ -368,7 +366,7 @@ EOF
         ln -sf %(prop:branch)s/%(prop:revision)s/%(prop:buildername)s/galera.sources /packages/%(prop:branch)s-latest-%(prop:buildername)s.sources \
         && sync /packages/%(prop:branch)s/%(prop:revision)s
 """,
-            url=os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org"),
+            url=os.environ["ARTIFACTS_URL"],
         ),
         doStepIf=(lambda step:
                   savePackageIfBranchMatch(step,
@@ -427,7 +425,7 @@ EOF
         && ln -sf %(prop:branch)s/%(prop:revision)s/%(prop:buildername)s/galera.repo /packages/%(prop:branch)s-latest-%(prop:buildername)s.repo \
         && sync /packages/%(prop:branch)s/%(prop:revision)s
 """,
-            url=os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org"),
+            url=os.environ["ARTIFACTS_URL"],
         ),
         doStepIf=(lambda step:
                   savePackageIfBranchMatch(step,
@@ -499,7 +497,7 @@ c["multiMaster"] = True
 
 c["mq"] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     "type": "wamp",
-    "router_url": os.getenv("MQ_ROUTER_URL", default="ws://localhost:8085/ws"),
+    "router_url": os.environ["MQ_ROUTER_URL"],
     "realm": "realm1",
     # valid are: none, critical, error, warn, info, debug, trace
     "wamp_debug_level": "info",

--- a/master-libvirt/master.cfg
+++ b/master-libvirt/master.cfg
@@ -34,22 +34,22 @@ exec(open("../master-private.cfg").read(), config, {})
 
 # the 'title' string will appear at the top of this buildbot installation's
 # home pages (linked to the 'titleURL').
-c["title"] = os.getenv("TITLE", default="MariaDB CI")
-c["titleURL"] = os.getenv("TITLE_URL", default="https://github.com/MariaDB/server")
-artifactsURL = os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+c["title"] = os.environ["TITLE"]
+c["titleURL"] = os.environ["TITLE_URL"]
+artifactsURL = os.environ["ARTIFACTS_URL"]
 
 # the 'buildbotURL' string should point to the location where the buildbot's
 # internal web server is visible. This typically uses the port number set in
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
-c["buildbotURL"] = os.getenv("BUILDMASTER_URL", default="https://buildbot.mariadb.org/")
+c["buildbotURL"] = os.environ["BUILDMASTER_URL"]
 
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers. You must define at least 'port' option that workers
 # could connect to your master with this protocol.
 # 'port' must match the value configured into the workers (with their
 # --master option)
-port = int(os.getenv("PORT", default="9990"))
+port = int(os.environ["PORT"])
 c["protocols"] = {"pb": {"port": port}}
 
 ####### DB URL
@@ -386,7 +386,7 @@ c["multiMaster"] = True
 
 c["mq"] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     "type": "wamp",
-    "router_url": os.getenv("MQ_ROUTER_URL", default="ws://localhost:8085/ws"),
+    "router_url": os.environ["MQ_ROUTER_URL"],
     "realm": "realm1",
     # valid are: none, critical, error, warn, info, debug, trace
     "wamp_debug_level": "info",

--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -38,21 +38,21 @@ exec(open("../master-private.cfg").read(), config, {})
 
 # the 'title' string will appear at the top of this buildbot installation's
 # home pages (linked to the 'titleURL').
-c["title"] = os.getenv("TITLE", default="MariaDB CI")
-c["titleURL"] = os.getenv("TITLE_URL", default="https://github.com/MariaDB/server")
+c["title"] = os.environ["TITLE"]
+c["titleURL"] = os.environ["TITLE_URL"]
 
 # the 'buildbotURL' string should point to the location where the buildbot's
 # internal web server is visible. This typically uses the port number set in
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
-c["buildbotURL"] = os.getenv("BUILDMASTER_URL", default="https://buildbot.mariadb.org/")
+c["buildbotURL"] = os.environ["BUILDMASTER_URL"]
 
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers. You must define at least 'port' option that workers
 # could connect to your master with this protocol.
 # 'port' must match the value configured into the workers (with their
 # --master option)
-port = int(os.getenv("PORT", default="9989"))
+port = int(os.environ["PORT"])
 c["protocols"] = {"pb": {"port": port}}
 
 ####### DB URL
@@ -87,10 +87,7 @@ gs = reporters.GitHubStatusPush(
 c["services"].append(gs)
 c["secretsProviders"] = [
     secrets.SecretInAFile(
-        dirname=os.getenv(
-            "MASTER_CREDENTIALS_DIR",
-            default="/srv/buildbot/master/master-credential-provider",
-        )
+        dirname=os.environ["MASTER_CREDENTIALS_DIR"]
     )
 ]
 ####### Builder priority
@@ -121,11 +118,11 @@ c["workers"].append(aix_worker)
 
 # Docker Library
 dockerlibrary_worker = mkWorker(
-    os.getenv("MASTER_NONLATENT_DOCKERLIBRARY_WORKER", default="bb-rhel8-docker"),
+    os.environ["MASTER_NONLATENT_DOCKERLIBRARY_WORKER"],
     properties={
         "jobs": 1,
-        "push_containers": os.getenv("ENVIRON") != "DEV",
-        "scriptpath": "dev" if os.getenv("ENVIRON") == "DEV" else "main",
+        "push_containers": os.environ["ENVIRON"] != "DEV",
+        "scriptpath": "dev" if os.environ["ENVIRON"] == "DEV" else "main",
     },
 )
 c["workers"].append(dockerlibrary_worker)
@@ -216,7 +213,7 @@ f_windows.addStep(
             "-command",
             "curl",
             util.Interpolate(
-                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                os.environ["ARTIFACTS_URL"]
                 + "/%(prop:tarbuildnum)s/%(prop:mariadb_version)s.tar.gz"
             ),
             "-o",
@@ -305,7 +302,7 @@ f_windows.addStep(
             + "%(prop:buildername)s"
         ),
         url=util.Interpolate(
-            f'{os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")}'
+            f'{os.environ["ARTIFACTS_URL"]}'
             "/"
             "%(prop:tarbuildnum)s"
             "/"
@@ -339,12 +336,12 @@ f_windows.addStep(
 f_windows_msi_env = {
     "TMP": util.Interpolate(
         "{0}\\%(prop:buildername)s\\build\\tmpdir".format(
-            "D:\\DEV\\Buildbot" if os.getenv("ENVIRON") == "DEV" else "D:\\Buildbot"
+            "D:\\DEV\\Buildbot" if os.environ["ENVIRON"] == "DEV" else "D:\\Buildbot"
         )
     ),
     "TEMP": util.Interpolate(
         "{0}\\%(prop:buildername)s\\build\\tmpdir".format(
-            "D:\\DEV\\Buildbot" if os.getenv("ENVIRON") == "DEV" else "D:\\Buildbot"
+            "D:\\DEV\\Buildbot" if os.environ["ENVIRON"] == "DEV" else "D:\\Buildbot"
         )
     ),
 }
@@ -397,7 +394,7 @@ f_windows_msi.addStep(
             "-command",
             "curl",
             util.Interpolate(
-                os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                os.environ["ARTIFACTS_URL"]
                 + "/%(prop:tarbuildnum)s/%(prop:mariadb_version)s.tar.gz"
             ),
             "-o",
@@ -500,7 +497,7 @@ f_windows_msi.addStep(
             + "%(prop:buildername)s"
         ),
         url=util.Interpolate(
-            f'{os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")}'
+            f'{os.environ["ARTIFACTS_URL"]}'
             "/"
             "%(prop:tarbuildnum)s"
             "/"
@@ -540,7 +537,7 @@ f_windows_msi.addStep(
         ),
         mode=0o755,
         url=util.Interpolate(
-            f'{os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")}'
+            f'{os.environ["ARTIFACTS_URL"]}'
             "/"
             "%(prop:tarbuildnum)s"
             "/"
@@ -562,7 +559,7 @@ f_windows_msi.addStep(
         ),
         mode=0o755,
         url=util.Interpolate(
-            f'{os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")}'
+            f'{os.environ["ARTIFACTS_URL"]}'
             "/"
             "%(prop:tarbuildnum)s"
             "/"
@@ -697,9 +694,7 @@ f_dockerlibrary.addStep(
     steps.ShellCommand(
         name="building MariaDB docker library test image",
         env={
-            "ARTIFACTS_URL": os.getenv(
-                "ARTIFACTS_URL", default="https://ci.mariadb.org"
-            )
+            "ARTIFACTS_URL": os.environ["ARTIFACTS_URL"]
         },
         command=[
             "bash",
@@ -1044,15 +1039,11 @@ c["builders"] = []
 
 c["builders"].append(
     util.BuilderConfig(
-        name=os.getenv(
-            "MASTER_NONLATENT_DOCKERLIBRARY_WORKER", default="bb-rhel8-docker"
-        )
+        name=os.environ["MASTER_NONLATENT_DOCKERLIBRARY_WORKER"]
         .replace("bb", "amd64")
         .replace("docker", "wordpress"),
         workernames=[
-            os.getenv(
-                "MASTER_NONLATENT_DOCKERLIBRARY_WORKER", default="bb-rhel8-docker"
-            )
+            os.environ["MASTER_NONLATENT_DOCKERLIBRARY_WORKER"]
         ],
         tags=["RHEL"],
         collapseRequests=True,
@@ -1064,21 +1055,17 @@ c["builders"].append(
 
 c["builders"].append(
     util.BuilderConfig(
-        name=os.getenv(
-            "MASTER_NONLATENT_DOCKERLIBRARY_WORKER", default="bb-rhel8-docker"
-        ).replace("bb", "amd64")
+        name=os.environ["MASTER_NONLATENT_DOCKERLIBRARY_WORKER"].replace("bb", "amd64")
         + "library",
         workernames=[
-            os.getenv(
-                "MASTER_NONLATENT_DOCKERLIBRARY_WORKER", default="bb-rhel8-docker"
-            )
+            os.environ["MASTER_NONLATENT_DOCKERLIBRARY_WORKER"]
         ],
         tags=["RHEL"],
         collapseRequests=True,
         nextBuild=nextBuild,
         canStartBuild=canStartBuild,
         factory=f_dockerlibrary,
-        properties={"push_containers": os.getenv("ENVIRON") != "DEV"},
+        properties={"push_containers": os.environ["ENVIRON"] != "DEV"},
     )
 )
 
@@ -1167,7 +1154,7 @@ c["multiMaster"] = True
 
 c["mq"] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     "type": "wamp",
-    "router_url": os.getenv("MQ_ROUTER_URL", default="ws://localhost:8085/ws"),
+    "router_url": os.environ["MQ_ROUTER_URL"],
     "realm": "realm1",
     # valid are: none, critical, error, warn, info, debug, trace
     "wamp_debug_level": "info",

--- a/master-private.cfg-sample
+++ b/master-private.cfg-sample
@@ -1,5 +1,5 @@
-private["db_url"] = "mysql://buildmaster:password@localhost/buildbot?max_idle=300&storage_engine=InnoDB"
-private["db_host"] = "localhost"
+private["db_url"] = "mysql://buildmaster:password@127.0.0.1/buildbot?max_idle=300&storage_engine=InnoDB"
+private["db_host"] = "127.0.0.1"
 private["db_user"] = "buildmaster"
 private["db_password"] = "password"
 private["db_mtr_db"] = "buildbot"
@@ -52,6 +52,7 @@ private["worker_pass"]= {
     "bbw1-windows":"1234",
     "bbw2-windows":"1234",
     "bb-rhel8-docker":"1234",
+    "bb-rhel9-docker":"1234",
     "ro-apexis-bbw03-x64": "1234",
     "monty-bbw1-x64": "1234",
     "s390x-rhel8":"1234",

--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -51,26 +51,26 @@ gs = reporters.GitHubStatusPush(
     builders=GITHUB_STATUS_BUILDERS,
 )
 c["services"].append(gs)
-c['secretsProviders'] = [secrets.SecretInAFile(dirname=os.getenv("MASTER_CREDENTIALS_DIR", default="/srv/buildbot/master/master-credential-provider"))]
+c['secretsProviders'] = [secrets.SecretInAFile(dirname=os.environ["MASTER_CREDENTIALS_DIR"])]
 ####### PROJECT IDENTITY
 
 # the 'title' string will appear at the top of this buildbot installation's
 # home pages (linked to the 'titleURL').
-c["title"] = os.getenv("TITLE", default="MariaDB CI")
-c["titleURL"] = os.getenv("TITLE_URL", default="https://github.com/MariaDB/server")
+c["title"] = os.environ["TITLE"]
+c["titleURL"] = os.environ["TITLE_URL"]
 
 # the 'buildbotURL' string should point to the location where the buildbot's
 # internal web server is visible. This typically uses the port number set in
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
-c["buildbotURL"] = os.getenv("BUILDMASTER_URL", default="https://buildbot.mariadb.org/")
+c["buildbotURL"] = os.environ["BUILDMASTER_URL"]
 
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers. You must define at least 'port' option that workers
 # could connect to your master with this protocol.
 # 'port' must match the value configured into the workers (with their
 # --master option)
-port = int(os.getenv("PORT", default="9994"))
+port = int(os.environ["PORT"])
 c["protocols"] = {"pb": {"port": port}}
 
 ####### DB URL
@@ -104,10 +104,8 @@ c["schedulers"] = SCHEDULERS
 c["workers"] = []
 
 # Docker workers
-FQDN = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
-MASTER_PACKAGES = os.getenv(
-    "MASTER_PACKAGES_DIR", default="/mnt/autofs/master_packages"
-)
+FQDN = os.environ["BUILDMASTER_WG_IP"]
+MASTER_PACKAGES = os.environ["MASTER_PACKAGES_DIR"]
 
 ## hz-bbw2-docker
 c["workers"].append(
@@ -115,7 +113,7 @@ c["workers"].append(
         "hz-bbw1-docker-tarball-debian-12",
         None,
         docker_host=config["private"]["docker_workers"]["hz-bbw1-docker"],
-        image=os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12",
+        image=os.environ["CONTAINER_REGISTRY_URL"] + "debian12",
         followStartupLogs=False,
         autopull=True,
         alwaysPull=True,
@@ -133,7 +131,7 @@ c["workers"].append(
         "hz-bbw4-docker-tarball-debian-12",
         None,
         docker_host=config["private"]["docker_workers"]["hz-bbw4-docker"],
-        image=os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12",
+        image=os.environ["CONTAINER_REGISTRY_URL"] + "debian12",
         followStartupLogs=False,
         autopull=True,
         alwaysPull=True,
@@ -183,7 +181,7 @@ for w_name in ["hz-bbw"]:
             w_name,
             i,
             "-debian-11-debug-ps-embed",
-            os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian11",
+            os.environ["CONTAINER_REGISTRY_URL"] + "debian11",
             jobs=14,
             save_packages=False,
         )
@@ -191,7 +189,7 @@ for w_name in ["hz-bbw"]:
             w_name,
             i,
             "-debian-12",
-            os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12",
+            os.environ["CONTAINER_REGISTRY_URL"] + "debian12",
             jobs=jobs,
             save_packages=True,
         )
@@ -199,7 +197,7 @@ for w_name in ["hz-bbw"]:
             w_name,
             i,
             "-debian-12-debug-embed",
-            os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "debian12",
+            os.environ["CONTAINER_REGISTRY_URL"] + "debian12",
             jobs=14,
             save_packages=False,
         )
@@ -207,7 +205,7 @@ for w_name in ["hz-bbw"]:
             w_name,
             i,
             "-fedora-40",
-            os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "fedora40",
+            os.environ["CONTAINER_REGISTRY_URL"] + "fedora40",
             jobs=jobs,
             save_packages=True,
         )
@@ -215,7 +213,7 @@ for w_name in ["hz-bbw"]:
             w_name,
             i,
             "-last-N-failed",
-            os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "rhel9",
+            os.environ["CONTAINER_REGISTRY_URL"] + "rhel9",
             jobs=jobs,
             save_packages=True,
         )
@@ -231,7 +229,7 @@ for w_name in ["hz-bbw"]:
             w_name,
             i,
             "-ubuntu-2004-debug",
-            os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "ubuntu20.04",
+            os.environ["CONTAINER_REGISTRY_URL"] + "ubuntu20.04",
             jobs=14,
             save_packages=True,
         )
@@ -239,7 +237,7 @@ for w_name in ["hz-bbw"]:
             w_name,
             i,
             "-ubuntu-2204-debug-ps",
-            os.getenv("CONTAINER_REGISTRY_URL", default="quay.io/mariadb-foundation/bb-worker:") + "ubuntu22.04",
+            os.environ["CONTAINER_REGISTRY_URL"] + "ubuntu22.04",
             jobs=14,
             save_packages=False,
         )
@@ -570,7 +568,7 @@ c["multiMaster"] = True
 
 c["mq"] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     "type": "wamp",
-    "router_url": os.getenv("MQ_ROUTER_URL", default="ws://localhost:8085/ws"),
+    "router_url": os.environ["MQ_ROUTER_URL"],
     "realm": "realm1",
     # valid are: none, critical, error, warn, info, debug, trace
     "wamp_debug_level": "info",

--- a/master-web/master.cfg
+++ b/master-web/master.cfg
@@ -37,11 +37,11 @@ exec(open("../master-private.cfg").read(), config, {})
 
 ####### PROJECT IDENTITY
 
-c["title"] = os.getenv("TITLE", default="MariaDB CI")
-c["titleURL"] = os.getenv("TITLE_URL", default="https://github.com/MariaDB/server")
-c["buildbotURL"] = os.getenv("BUILDMASTER_URL", default="https://buildbot.mariadb.org/")
+c["title"] = os.environ["TITLE"]
+c["titleURL"] = os.environ["TITLE_URL"]
+c["buildbotURL"] = os.environ["BUILDMASTER_URL"]
 
-port = int(os.getenv("PORT", default="8010"))
+port = int(os.environ["PORT"])
 # minimalistic config to activate web UI
 c["www"] = dict(
     port=port,
@@ -113,7 +113,7 @@ c["multiMaster"] = True
 # Need to enable multimaster aware mq. Wamp is the only option for now.
 c["mq"] = {
     "type": "wamp",
-    "router_url": os.getenv("MQ_ROUTER_URL", default="ws://localhost:8085/ws"),
+    "router_url": os.environ["MQ_ROUTER_URL"],
     "realm": "realm1",
     # valid are: none, critical, error, warn, info, debug, trace
     "wamp_debug_level": "info",
@@ -156,7 +156,7 @@ schedulerTarball = schedulers.AnyBranchScheduler(
 )
 c["schedulers"].append(schedulerTarball)
 
-if os.getenv("ENVIRON") == "DEV":
+if os.environ["ENVIRON"] == "DEV":
     schedulerTarball = schedulers.AnyBranchScheduler(
         name="s_faust_tarball",
         change_filter=util.ChangeFilter(

--- a/master.cfg
+++ b/master.cfg
@@ -55,28 +55,28 @@ gs = reporters.GitHubStatusPush(
 )
 c["services"].append(gs)
 c["secretsProviders"] = [
-    secrets.SecretInAFile(dirname="/srv/buildbot/master/master-credential-provider")
+    secrets.SecretInAFile(dirname=os.environ["MASTER_CREDENTIALS_DIR"])
 ]
 
 ####### PROJECT IDENTITY
 
 # the 'title' string will appear at the top of this buildbot installation's
 # home pages (linked to the 'titleURL').
-c["title"] = os.getenv("TITLE", default="MariaDB CI")
-c["titleURL"] = os.getenv("TITLE_URL", default="https://github.com/MariaDB/server")
+c["title"] = os.environ["TITLE"]
+c["titleURL"] = os.environ["TITLE_URL"]
 
 # the 'buildbotURL' string should point to the location where the buildbot's
 # internal web server is visible. This typically uses the port number set in
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
-c["buildbotURL"] = os.getenv("BUILDMASTER_URL", default="https://buildbot.mariadb.org/")
+c["buildbotURL"] = os.environ["BUILDMASTER_URL"]
 
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers. You must define at least 'port' option that workers
 # could connect to your master with this protocol.
 # 'port' must match the value configured into the workers (with their
 # --master option)
-c["protocols"] = {"pb": {"port": os.getenv("PORT", default=master_config["port"])}}
+c["protocols"] = {"pb": {"port": os.environ["PORT"]}}
 
 ####### DB URL
 
@@ -158,10 +158,7 @@ for w_name in master_config["workers"]:
             image_tag = image_tag[:-2] + "." + image_tag[-2:]
 
         quay_name = (
-            os.getenv(
-                "CONTAINER_REGISTRY_URL",
-                default="quay.io/mariadb-foundation/bb-worker:",
-            )
+            os.environ["CONTAINER_REGISTRY_URL"]
             + image_tag
         )
         if builder.startswith("x86"):
@@ -385,7 +382,7 @@ c["multiMaster"] = True
 
 c["mq"] = {  # Need to enable multimaster aware mq. Wamp is the only option for now.
     "type": "wamp",
-    "router_url": os.getenv("MQ_ROUTER_URL", default="ws://localhost:8085/ws"),
+    "router_url": os.environ["MQ_ROUTER_URL"],
     "realm": "realm1",
     # valid are: none, critical, error, warn, info, debug, trace
     "wamp_debug_level": "info",

--- a/utils.py
+++ b/utils.py
@@ -44,7 +44,7 @@ def envFromProperties(envlist: list[str]) -> dict[str, str]:
 
 
 def getScript(scriptname: str) -> steps.ShellCommand:
-    branch = os.getenv("BRANCH", default="main")
+    branch = os.environ["BRANCH"]
     return steps.ShellCommand(
         name=f"fetch_{scriptname}",
         command=[
@@ -61,9 +61,7 @@ def getScript(scriptname: str) -> steps.ShellCommand:
 
 
 # BUILD HELPERS
-MASTER_PACKAGES = os.getenv(
-    "MASTER_PACKAGES_DIR", default="/mnt/autofs/master_packages"
-)
+MASTER_PACKAGES = os.environ["MASTER_PACKAGES_DIR"]
 
 
 # Helper function that creates a worker instance.
@@ -102,7 +100,7 @@ def createWorker(
     base_name = b_name + "-docker" + worker_type
 
     # Set master FQDN - default to wireguard interface
-    fqdn = os.getenv("BUILDMASTER_WG_IP", default="100.64.100.1")
+    fqdn = os.environ["BUILDMASTER_WG_IP"]
     if re.match("aarch64-bbw[1-4]", worker_name):
         fqdn = "buildbot.mariadb.org"
     if "vladbogo" in dockerfile or "quay" in dockerfile:
@@ -165,11 +163,7 @@ def getSourceTarball() -> steps.ShellCommand:
         description="get source tarball",
         descriptionDone="get source tarball...done",
         haltOnFailure=True,
-        env={
-            "ARTIFACTS_URL": os.getenv(
-                "ARTIFACTS_URL", default="https://ci.mariadb.org"
-            )
-        },
+        env={"ARTIFACTS_URL": os.environ["ARTIFACTS_URL"]},
         command=[
             "bash",
             "-ec",
@@ -185,11 +179,7 @@ def saveLogs() -> steps.ShellCommand:
         descriptionDone="save logs...done",
         alwaysRun=True,
         haltOnFailure=True,
-        env={
-            "ARTIFACTS_URL": os.getenv(
-                "ARTIFACTS_URL", default="https://ci.mariadb.org"
-            )
-        },
+        env={"ARTIFACTS_URL": os.environ["ARTIFACTS_URL"]},
         command=[
             "bash",
             "-ec",
@@ -234,7 +224,7 @@ def uploadDebArtifacts() -> steps.ShellCommand:
             util.Interpolate(
                 """
     artifacts_url="""
-                + os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+                + os.environ["ARTIFACTS_URL"]
                 + """
     . /etc/os-release
     if [[ $ID == "debian" ]]; then
@@ -265,7 +255,7 @@ EOF
         descriptionDone=util.Interpolate(
             """
             Use """
-            + os.getenv("ARTIFACTS_URL", default="https://ci.mariadb.org")
+            + os.environ["ARTIFACTS_URL"]
             + """/%(prop:tarbuildnum)s/%(prop:buildername)s/mariadb.sources for testing.
             """
         ),
@@ -364,7 +354,7 @@ echo '<!DOCTYPE html>
 <html>
 <body>' >> {base_path}/mysql_logs.html
 
-echo '<a href=" {os.getenv('ARTIFACTS_URL', default='https://ci.mariadb.org')}/%(prop:tarbuildnum)s/logs/%(prop:buildername)s/">logs (mariadbd.gz + var.tar.gz)</a><br>' >> {base_path}/mysql_logs.html
+echo '<a href="{os.environ['ARTIFACTS_URL']}/%(prop:tarbuildnum)s/logs/%(prop:buildername)s/">logs (mariadbd.gz + var.tar.gz)</a><br>' >> {base_path}/mysql_logs.html
 
 echo '</body>
 </html>' >> {base_path}/mysql_logs.html"""

--- a/validate_master_cfg.sh
+++ b/validate_master_cfg.sh
@@ -38,9 +38,11 @@ fi
 case $ENVIRONMENT in
   DEV)
     IMAGE="quay.io/mariadb-foundation/bb-master:dev_master"
+    ENVFILE="docker-compose/.env.dev"
     ;;
   PROD)
     IMAGE="quay.io/mariadb-foundation/bb-master:master"
+    ENVFILE="docker-compose/.env"
     ;;
   *)
     err "Unknown environment: $ENVIRONMENT. Use DEV or PROD."
@@ -69,6 +71,7 @@ command -v python3 >/dev/null ||
 python3 define_masters.py
 echo "Checking master.cfg"
 $RUNC run -i -v "$(pwd):/srv/buildbot/master" \
+  --env-file <(sed "s/='\([^']*\)'/=\1/" $ENVFILE) \
   -w /srv/buildbot/master \
   $IMAGE \
   buildbot checkconfig master.cfg
@@ -85,6 +88,7 @@ for dir in autogen/* \
   master-web; do
   echo "Checking $dir/master.cfg"
   $RUNC run -i -v "$(pwd):/srv/buildbot/master" \
+    --env-file <(sed "s/='\([^']*\)'/=\1/" $ENVFILE) \
     -w /srv/buildbot/master \
     $IMAGE \
     bash -c "cd $dir && buildbot checkconfig master.cfg"

--- a/validate_master_cfg.sh
+++ b/validate_master_cfg.sh
@@ -70,7 +70,9 @@ command -v python3 >/dev/null ||
 
 python3 define_masters.py
 echo "Checking master.cfg"
+# Port is set by generate-config.py (docker-compose), not present in .env
 $RUNC run -i -v "$(pwd):/srv/buildbot/master" \
+  --env PORT=1234 \
   --env-file <(sed "s/='\([^']*\)'/=\1/" $ENVFILE) \
   -w /srv/buildbot/master \
   $IMAGE \
@@ -88,9 +90,10 @@ for dir in autogen/* \
   master-web; do
   echo "Checking $dir/master.cfg"
   $RUNC run -i -v "$(pwd):/srv/buildbot/master" \
+    --env PORT=1234 \
     --env-file <(sed "s/='\([^']*\)'/=\1/" $ENVFILE) \
-    -w /srv/buildbot/master \
+    -w "/srv/buildbot/master/$dir" \
     $IMAGE \
-    bash -c "cd $dir && buildbot checkconfig master.cfg"
+    buildbot checkconfig master.cfg
   echo -e "done\n"
 done


### PR DESCRIPTION
Previously when the BuildBot **Production** environment was running on `systemd services`, we couldn't use the `.env `files defined in the project tree because they were specifically designed for usage in `docker-compose`. 

This led to hard coding variable defaults in the buildbot code, in the form of `os.getenv(#env_variable_for_containers#, default=#default_for_systemd#)`

**In this task:**
-> switch to a fail proof approach of loading variables using `os.environ` which will raise a `key not found exception` if the environment variable is not defined
-> adapt the GitHub CI script `validate_masters` to load the environment variables for each environment << dev , prod >>
-> remove "systemd" approach of loading PORTS for masters.


**This PR was tested using:**
`./validate_master_cfg.sh -e {PROD,DEV}`
`- run docker-compose with .env files`

Please see the commit messages for more details.