### PR TITLE
Fix rebase error: nextBuild should return which build to process

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -283,6 +283,8 @@ def nextBuild(builder: Builder, requests: list[BuildRequest]) -> str:
             request.getSubmitTime(),
         )
 
+    return sorted(requests, build_request_sort_key)[0]
+
 
 def canStartBuild(
     builder: Builder, wfb: AbstractWorkerForBuilder, request: BuildRequest


### PR DESCRIPTION
The line was lost during a rebase, making the function always return None