### PR TITLE
Fixes for #637 - ls2string does not append to the package list

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -23,9 +23,9 @@ from utils import (
     hasDockerLibrary,
     hasEco,
     hasFailed,
-    hasFiles,
     hasGalera,
     hasInstall,
+    hasPackagesGenerated,
     hasRpmLint,
     hasS3,
     hasUpgrade,
@@ -755,7 +755,7 @@ EOF
 """
             ),
             doStepIf=(
-                lambda step: hasFiles(step)
+                lambda step: hasPackagesGenerated(step)
                 and savePackageIfBranchMatch(step, SAVED_PACKAGE_BRANCHES)
             ),
             descriptionDone=util.Interpolate(
@@ -797,7 +797,7 @@ Repository available with: curl %(kw:url)s/%(prop:tarbuildnum)s/%(prop:builderna
             doStepIf=(
                 lambda step: hasInstall(step)
                 and savePackageIfBranchMatch(step, SAVED_PACKAGE_BRANCHES)
-                and hasFiles(step)
+                and hasPackagesGenerated(step)
             ),
         )
     )
@@ -816,7 +816,7 @@ Repository available with: curl %(kw:url)s/%(prop:tarbuildnum)s/%(prop:builderna
             doStepIf=(
                 lambda step: hasUpgrade(step)
                 and savePackageIfBranchMatch(step, SAVED_PACKAGE_BRANCHES)
-                and hasFiles(step)
+                and hasPackagesGenerated(step)
             ),
         )
     )

--- a/master.cfg
+++ b/master.cfg
@@ -258,7 +258,7 @@ f_deb_autobake.addStep(
         doStepIf=(
             lambda step: hasInstall(step)
             and savePackageIfBranchMatch(step, SAVED_PACKAGE_BRANCHES)
-            and hasFiles(step)
+            and hasPackagesGenerated(step)
         ),
     )
 )
@@ -277,7 +277,7 @@ f_deb_autobake.addStep(
         doStepIf=(
             lambda step: hasUpgrade(step)
             and savePackageIfBranchMatch(step, SAVED_PACKAGE_BRANCHES)
-            and hasFiles(step)
+            and hasPackagesGenerated(step)
         ),
     )
 )

--- a/utils.py
+++ b/utils.py
@@ -322,7 +322,7 @@ def ls2string(rc: int, stdout: str, stderr: str) -> dict[str, str]:
     ls_filenames = []
     for line in stdout.strip().split("\n"):
         line = line.strip()
-        if not line:
+        if line:
             ls_filenames.append(line)
 
     return {"packages": " ".join(ls_filenames)}

--- a/utils.py
+++ b/utils.py
@@ -207,7 +207,7 @@ def createDebRepo() -> steps.ShellCommand:
             ),
         ],
         doStepIf=(
-            lambda step: hasFiles(step)
+            lambda step: hasPackagesGenerated(step)
             and savePackageIfBranchMatch(step, SAVED_PACKAGE_BRANCHES)
         ),
     )
@@ -249,7 +249,7 @@ EOF
             ),
         ],
         doStepIf=(
-            lambda step: hasFiles(step)
+            lambda step: hasPackagesGenerated(step)
             and savePackageIfBranchMatch(step, SAVED_PACKAGE_BRANCHES)
         ),
         descriptionDone=util.Interpolate(
@@ -444,7 +444,7 @@ def dockerfile(props: IProperties) -> str:
 
 
 # checks if the list of files is empty
-def hasFiles(step: BuildStep) -> bool:
+def hasPackagesGenerated(step: BuildStep) -> bool:
     return len(step.getProperty("packages")) >= 1
 
 


### PR DESCRIPTION
This patch is mainly a fix for https://github.com/MariaDB/buildbot/pull/637 and a renaming suggestion for the `hasFiles` function to better highlight its purpose.