### PR TITLE
More storage on the new BBM (increase replication days)

### DIFF
--- a/docker-compose/mariadb-config/prod/mariadb.cnf
+++ b/docker-compose/mariadb-config/prod/mariadb.cnf
@@ -36,7 +36,7 @@ server-id = 1
 log-basename = mariadb
 
 log_bin
-expire_logs_days = 5
+expire_logs_days = 14
 max_binlog_size = 100M
 binlog_format = MIXED
 # the following permits to simplify the process of moving a replica to a


### PR DESCRIPTION
We can increase replication storage on the BBM since storage is not limiting anymore. This will give us more time to fix replication problem if they occur in the future.

No impact on DEV, needs to be pushed on PROD but DB restart should probably be planned.