### PR TITLE
MDBF-882 - ColumnStore packages not created for OpenSuse/Sles

### DIFF
--- a/ci_build_images/opensuse.Dockerfile
+++ b/ci_build_images/opensuse.Dockerfile
@@ -37,9 +37,14 @@ RUN zypper update -y \
     judy-devel \
     krb5-devel \
     libaio-devel \
+    libboost_atomic1_75_0-devel \
+    libboost_chrono1_75_0-devel \
+    libboost_date_time1_75_0-devel \
     libboost_filesystem1_75_0-devel \
     libboost_program_options1_75_0-devel \
+    libboost_regex1_75_0-devel \
     libboost_system1_75_0-devel \
+    libboost_thread1_75_0-devel \
     libbz2-devel \
     libcurl-devel \
     libedit-devel \

--- a/ci_build_images/sles.Dockerfile
+++ b/ci_build_images/sles.Dockerfile
@@ -35,9 +35,14 @@ RUN zypper -n update \
     glibc-locale \
     jemalloc-devel \
     libaio-devel \
+    libboost_atomic1_66_0-devel \
+    libboost_chrono1_66_0-devel \
+    libboost_date_time1_66_0-devel \
     libboost_filesystem1_66_0-devel \
     libboost_program_options1_66_0-devel \
+    libboost_regex1_66_0-devel \
     libboost_system1_66_0-devel \
+    libboost_thread1_66_0-devel \
     libcurl-devel \
     libffi-devel \
     libfmt8 \


### PR DESCRIPTION
This is 1/2 PR in the series for solving **MDBF-882**. It will align `buildbot.mariadb.{NET,ORG}` in terms of produced packages by fixing ColumnStore package creation for MariaDB Server versions 10.5, 10.6, 10.11

ColumnStore package creation for 11.4 onward will be solved in a separate PR as it needs more attention.

**How to test this PR:**
-> pull an opensuse/sles container image from quay -> install the missing libraries added in this PR
-> follow build instructions on any opensuse / sles autobake builder -> check that the CS package was produced.

**How to deploy to Production:**
-> after the OpenSuse/Sles images are re-generated in DEV, sync with Main branch and the GitHub workflow
     will automatically promote it to Production.
