### PR TITLE
MDBF-887 - LDD Minor upgrade tests fail on RHEL ha_spider.so

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -679,6 +679,11 @@ collect_dependencies() {
   # Spider_package_list variable does not exist for RPM upgrades.
   set +u
   for p in ${package_list} ${spider_package_list} ; do
+    # TEMP: Skip debuginfo packages as ldd is not reliable. See MDBF-887
+    if [[ "$p" =~ -debuginfo$ ]]; then
+      continue
+    fi
+
     if [[ "$p" =~ columnstore ]] ; then
       suffix="columnstore"
     else


### PR DESCRIPTION
As investigated in https://jira.mariadb.org/browse/MDBF-887 by me and Elena, it seems that running LDD on
`ha_spider.so-10.6.20-1.el8.x86_64.debug` yields either return code 0 or 1 on different server versions with no really useful output for the comparison. Although the file is in ELF format and dynamically linked, LDD cannot provide any useful output.

```
ldd ha_spider.so-10.6.20-1.el8.x86_64.debug
ldd: warning: you do not have execution permission for `./ha_spider.so-10.6.20-1.el8.x86_64.debug'

$ echo $?
1
```
```
ldd ha_spider.so-10.6.21-1.el8.x86_64.debug
ldd: warning: you do not have execution permission for `./ha_spider.so-10.6.21-1.el8.x86_64.debug'
	statically linked

$ echo $?
0
```

This underlying issue may be the subject to another task, for now in order to exclude the false-positive results from Buildbot and save developers time on looking on these, it's best to exclude the `-debuginfo` packages from `collect_dependencies().`

**How to test this PR:**
-> use a fresh RHEL 8 virtual machine
-> clone buildbot repo and checkout this PR
-> run `./scripts/rpm-upgrade.sh https://buildbot.mariadb.org/#/builders/743/builds/178`
   ( the above step will reproduce what buildbot does)

one can use any link to a failed build for the current arch/os variant in the rpm-upgrade command.