### PR TITLE
MDBF-882 - ColumnStore Package not created on SLES

### DIFF
--- a/ci_build_images/sles.Dockerfile
+++ b/ci_build_images/sles.Dockerfile
@@ -50,6 +50,7 @@ RUN zypper -n update \
     liblz4-devel \
     libopenssl-3-devel \
     liburing2-devel \
+    libxml2-devel \
     pam-devel \
     pcre2-devel \
     perl-Net-SSLeay \


### PR DESCRIPTION
This is a fix for https://github.com/MariaDB/buildbot/pull/681

While boost components were installed on SLES, the CS package was still missing. After doing a `CMAKE --trace` I've found out that `limbxml2` is missing.

```
MESSAGE_ONCE(CS_NO_LIBXML Could not find a usable libxml2 development environment! )
```

Tested locally with the current **sles1506** container image and after installing `libxml2-devel`, the CS packages are generated for mariadb server 10.11.
