### PR TITLE
MDBF-899 - SLES version_name RPM

### DIFF
--- a/os_info.yaml
+++ b/os_info.yaml
@@ -100,7 +100,7 @@ rockylinux-9:
   type: rpm
   install_only: True
 sles-1506:
-  version_name: 15.6
+  version_name: 15
   arch:
     - amd64
     - s390x


### PR DESCRIPTION
Fix the repository path to /sles15-amd64/rpms/ for upgrade tests.
buildbot.mariadb.net has only one builder (sles 15 sp3) which is providing packages on the mirror and all paths on the repository are just symlinks.

To be decided how these paths will be adjusted when SLES 15 SP7 will be released, and we will have both SP6 and SP7 creating packages.
