### PR TITLE
MDBF-135 - Add MTR S3 on protected builder amd64-ubuntu-2004-debug

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -63,6 +63,7 @@ BUILDERS_GALERA_MTR = [
 ]
 BUILDERS_S3_MTR = [
     "aarch64-ubuntu-2004-debug",
+    "amd64-ubuntu-2004-debug",
     "s390x-sles-1506",
 ]
 


### PR DESCRIPTION
Now that `s3.mysqldump` was resolved for the Main branch we can finally add S3 tests to branch protection.

See MDEV-35921:  https://github.com/MariaDB/server/commit/b8fa8b9b3d108002ada5715e12e935219490270c
and buildbot S3 run: https://buildbot.mariadb.org/#/builders/538/builds/23207/steps/13/logs/stdio

```
s3.amazon                                w15 [ skipped ]  Not connected to AWS
s3.unsupported                           w18 [ pass ]    192
s3.backup                                w19 [ pass ]    209
s3.select                                w14 [ pass ]    394
s3.debug                                 w10 [ pass ]    487
s3.encryption                            w3 [ pass ]    563
s3.partition_create_fail                 w13 [ pass ]    402
s3.arguments                             w7 [ pass ]    731
s3.innodb                                w12 [ pass ]    614
s3.alter2                                w1 [ pass ]    968
s3.partition_move                        w16 [ pass ]   1181
s3.mysqldump                             w6 [ pass ]   1539
s3.discovery                             w11 [ pass ]   1544
s3.replication_delayed 'mix'             w20 [ pass ]   1773
s3.alter                                 w5 [ pass ]   2472
s3.replication_mixed 'mix'               w17 [ pass ]   5178
s3.replication_stmt 'stmt'               w4 [ pass ]   5539
s3.basic                                 w9 [ pass ]  10117
s3.partition                             w2 [ pass ]  10334
s3.replication_partition 'mix'           w8 [ pass ]  10877
--------------------------------------------------------------------------
The servers were restarted 1 times
Spent 55.194 of 16 seconds executing testcases
Completed: All 20 tests were successful.
```
