### PR TITLE
MDBF-933 - DockerLatentWorker containers name not unique

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -122,7 +122,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: master-nonlatent
+    hostname: dev_master-nonlatent
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -162,7 +162,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: master-libvirt
+    hostname: dev_master-libvirt
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -201,7 +201,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: autogen_aarch64-master-0
+    hostname: dev_autogen_aarch64-master-0
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -240,7 +240,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: autogen_amd64-master-0
+    hostname: dev_autogen_amd64-master-0
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -279,7 +279,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: autogen_amd64-master-1
+    hostname: dev_autogen_amd64-master-1
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -318,7 +318,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: autogen_ppc64le-master-0
+    hostname: dev_autogen_ppc64le-master-0
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -357,7 +357,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: autogen_s390x-master-0
+    hostname: dev_autogen_s390x-master-0
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -396,7 +396,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: autogen_x86-master-0
+    hostname: dev_autogen_x86-master-0
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -435,7 +435,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: master-docker-nonstandard
+    hostname: dev_master-docker-nonstandard
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -475,7 +475,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: master-galera
+    hostname: dev_master-galera
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -514,7 +514,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: master-protected-branches
+    hostname: dev_master-protected-branches
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -553,7 +553,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: master-docker-nonstandard-2
+    hostname: dev_master-docker-nonstandard-2
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master
@@ -593,7 +593,7 @@ services:
       - TITLE
       - TITLE_URL
     stop_grace_period: 5m
-    hostname: master-bintars
+    hostname: dev_master-bintars
     volumes:
       - ./logs:/var/log/buildbot
       - ./buildbot/:/srv/buildbot/master

--- a/docker-compose/generate-config.py
+++ b/docker-compose/generate-config.py
@@ -115,7 +115,7 @@ DOCKER_COMPOSE_TEMPLATE = """
     restart: unless-stopped
     container_name: {master_name}
     stop_grace_period: {buildbot_stop_grace_period}
-    hostname: {master_name}
+    hostname: {master_hostname}
     {volumes}
     entrypoint:
       - /bin/bash
@@ -213,10 +213,14 @@ def main(args):
         port = starting_port
         for master_directory in MASTER_DIRECTORIES:
             master_name = master_directory.replace("/", "_")
-
+            if args.env == "dev":
+                master_hostname = "dev_" + master_name
+            else:
+                master_hostname = master_name
             # Generate Docker Compose piece
             docker_compose_piece = docker_compose_template.format(
                 master_name=master_name,
+                master_hostname=master_hostname,
                 master_directory=master_directory,
                 port=port,
                 mc_host=mc_host,


### PR DESCRIPTION
Buildbot calculate the container name on a worker host based on the sha of the master name.

If the master name is the same between dev / prod, which is true at this moment (both environments running in containers), then when the same builder runs on the same host on both environments a conflict will occur causing one of the builds to fail and retry.

`Error: The container name "/buildbot-hz-bbw1-docker-tarball-debian-12-15cc21" is already in use by container `

This is an error on the development environment when a build << tarball-docker >> was already running in production on hz-bbw1.

Sometimes builds get stuck in "Preparing worker" state and Production is affected. This is why this patch is important, because we can impact Production during our tests in buildbot.dev.mariadb.org