### PR TITLE
docker library: arch match against amd64 incorrect for tagging wordpress

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -718,21 +718,6 @@ f_dockerlibrary.addStep(
     )
 )
 f_dockerlibrary.addStep(
-    steps.Trigger(
-        name="WordPress",
-        schedulerNames=["s_wordpress"],
-        waitForFinish=False,
-        updateSourceStamp=False,
-        set_properties={
-            "tarbuildnum": Property("tarbuildnum"),
-            "ubi": Property("ubi"),
-        },
-        doStepIf=lambda step: str(step.getProperty("parentbuildername")).startswith(
-            "amd64"
-        ),
-    )
-)
-f_dockerlibrary.addStep(
     steps.ShellCommand(
         name="build quay.io manifest image for MariaDB",
         command=[
@@ -756,6 +741,19 @@ f_dockerlibrary.addStep(
     )
 )
 f_dockerlibrary.addStep(
+    steps.Trigger(
+        name="WordPress",
+        schedulerNames=["s_wordpress"],
+        waitForFinish=False,
+        updateSourceStamp=False,
+        set_properties={
+            "tarbuildnum": Property("tarbuildnum"),
+            "ubi": Property("ubi"),
+        },
+        doStepIf=lambda step: (str(step.getProperty("lasttag")) != ""),
+    )
+)
+f_dockerlibrary.addStep(
     steps.SetPropertyFromCommand(
         name="Determine sha for the last tag",
         command=[
@@ -766,7 +764,10 @@ f_dockerlibrary.addStep(
             ),
         ],
         property="lastsha",
-        doStepIf=lambda step: (str(step.getProperty("lasttag")) != ""),
+        doStepIf=lambda step: (
+            step.getProperty("push_containers")
+            and str(step.getProperty("lasttag")) != ""
+        ),
     )
 )
 f_dockerlibrary.addStep(
@@ -778,7 +779,9 @@ f_dockerlibrary.addStep(
             "gh auth login --with-token < ~/gh_auth",
         ],
         doStepIf=lambda step: (
-            str(step.getProperty("lastsha")) != "null" and step.hasProperty("lastsha")
+            step.getProperty("push_containers")
+            and str(step.getProperty("lastsha")) != "null"
+            and step.hasProperty("lastsha")
         ),
     )
 )
@@ -797,7 +800,9 @@ f_dockerlibrary.addStep(
             ),
         ],
         doStepIf=lambda step: (
-            str(step.getProperty("lastsha")) != "null" and step.hasProperty("lastsha")
+            step.getProperty("push_containers")
+            and str(step.getProperty("lastsha")) != "null"
+            and step.hasProperty("lastsha")
         ),
     )
 )

--- a/scripts/docker-library-build.sh
+++ b/scripts/docker-library-build.sh
@@ -181,7 +181,7 @@ buildah manifest create "$image"
 for arch in "${arches[@]}"; do
   build "$arch"
   buildah manifest add "$image" "$image-$arch"
-  if [ "$arch" = amd64 ]; then
+  if [ "$arch" = linux/amd64 ]; then
     buildah tag "${image}-${arch}" "${image}-wordpress"
   fi
 done

--- a/scripts/docker-library-manifest.sh
+++ b/scripts/docker-library-manifest.sh
@@ -108,10 +108,9 @@ trap 'manifest_image_cleanup "$devmanifest" "$t"' EXIT
 
 if [ "$prod_environment" = "True" ]; then
   buildah manifest push --all "$devmanifest" "docker://quay.io/mariadb-foundation/mariadb-devel:${container_tag}"
-  echo "${container_tag}" > last_tag
-else
-  rm -f last_tag
 fi
+# Still want last_tag in dev environment to trigger wordpress build.
+echo "${container_tag}" > last_tag
 
 #
 # MAKE Debug manifest


### PR DESCRIPTION
showed in last step of build

https://buildbot.dev.mariadb.org/#/builders/4/builds/72
```
+ '[' linux/amd64 = amd64 ']'
program finished with exit code 0
elapsedTime=84.804340
```

The trigging of wordpress also is after the manifest is built.