### PR TITLE
MDBF-939: MariaDB Operator to use ubi workflow rather than ent

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -777,7 +777,7 @@ Repository available with: curl %(kw:url)s/%(prop:tarbuildnum)s/%(prop:builderna
                 "master_branch": Property("master_branch"),
                 "parentbuildername": Property("buildername"),
                 "ubi": "-ubi",
-                "GH_WORKFLOW": "test-image-ent.yml",
+                "GH_WORKFLOW": "test-image-ubi.yml",
             },
             doStepIf=lambda step: hasDockerLibrary(step),
         )


### PR DESCRIPTION
As requested by @mmontes.

same interface: https://github.com/mariadb-operator/mariadb-operator/blob/main/.github/workflows/test-image-ubi.yml