### PR TITLE
docker library: use DecodeRC for warnings

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -3,6 +3,7 @@
 
 from buildbot.plugins import *
 from buildbot.process.properties import Property, Properties
+from buildbot.process.results import SUCCESS, FAILURE, WARNINGS
 from buildbot.steps.shell import ShellCommand, Compile, Test, SetPropertyFromCommand
 from buildbot.steps.mtrlogobserver import MTR, MtrLogObserver
 from buildbot.steps.source.github import GitHub
@@ -677,6 +678,8 @@ f_wordpress.addStep(
 )
 
 # f_dockerlibrary
+DECODE_RC={0:SUCCESS,1:FAILURE,2:WARNINGS}
+
 f_dockerlibrary = util.BuildFactory()
 f_dockerlibrary.addStep(
     steps.ShellCommand(
@@ -696,6 +699,7 @@ f_dockerlibrary.addStep(
         env={
             "ARTIFACTS_URL": os.environ["ARTIFACTS_URL"]
         },
+        decodeRC=DECODE_RC,
         command=[
             "bash",
             "-xc",
@@ -708,6 +712,7 @@ f_dockerlibrary.addStep(
 f_dockerlibrary.addStep(
     steps.ShellCommand(
         name="test MariaDB docker library image",
+        decodeRC=DECODE_RC,
         command=[
             "bash",
             "-xc",
@@ -720,6 +725,7 @@ f_dockerlibrary.addStep(
 f_dockerlibrary.addStep(
     steps.ShellCommand(
         name="build quay.io manifest image for MariaDB",
+        decodeRC=DECODE_RC,
         command=[
             "bash",
             "-xc",

--- a/scripts/docker-library-build.sh
+++ b/scripts/docker-library-build.sh
@@ -86,7 +86,7 @@ entries=$(wc -l < "$reffile")
 if [ "$entries" -lt ${#arches[@]} ]; then
 	echo "Only $entries architectures so far"
 	# so we're not going to do anything until we have a full list.
-	exit 0
+	exit 2
 fi
 
 # Don't remove file here. Leave a manual retrigger of

--- a/scripts/docker-library-manifest.sh
+++ b/scripts/docker-library-manifest.sh
@@ -40,7 +40,7 @@ if ! buildah manifest exists "$image"; then
 	echo "No manifest we can't push"
 	# Not fatal, but this means logic can stay
 	# here rather than in bb steps.
-	exit 0
+	exit 2
 fi
 
 #

--- a/scripts/docker-library-test.sh
+++ b/scripts/docker-library-test.sh
@@ -15,7 +15,7 @@ fi
 
 if ! buildah manifest exists "$image"; then
 	echo "No manifest we can't test"
-	exit 0
+	exit 2
 fi
 #
 # TEST Image
@@ -24,7 +24,7 @@ fi
 if [ "${builderarch}" != amd64 ]; then
   export DOCKER_LIBRARY_START_TIMEOUT=350
   echo "Temporarily disable non-amd64 testing"
-  exit 0
+  exit 2
 else
   export DOCKER_LIBRARY_START_TIMEOUT=150
 fi


### PR DESCRIPTION
non-fatal things are listed as warnings so its easy to look at bb interface to see which docker library job actually did the work rather than just skipping.

concept from https://github.com/MariaDB/buildbot/pull/697#issuecomment-2633503606
