### PR TITLE
MDBF-940: Steps with warnings should flag the entire build

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -707,6 +707,7 @@ f_dockerlibrary.addStep(
                 './docker-library-build.sh "%(prop:tarbuildnum)s" "%(prop:mariadb_version)s" "%(prop:parentbuildername)s" "%(prop:revision)s" "%(prop:branch)s"'
             ),
         ],
+        warnOnWarnings=True,
     )
 )
 f_dockerlibrary.addStep(
@@ -720,6 +721,7 @@ f_dockerlibrary.addStep(
                 './docker-library-test.sh "%(prop:tarbuildnum)s" "%(prop:parentbuildername)s"'
             ),
         ],
+        warnOnWarnings=True,
     )
 )
 f_dockerlibrary.addStep(
@@ -733,6 +735,7 @@ f_dockerlibrary.addStep(
                 './docker-library-manifest.sh "%(prop:tarbuildnum)s" "%(prop:mariadb_version)s" "%(prop:parentbuildername)s" "%(prop:revision)s" "%(prop:branch)s" "%(prop:push_containers)s"'
             ),
         ],
+        warnOnWarnings=True,
     )
 )
 f_dockerlibrary.addStep(


### PR DESCRIPTION
If any of the three docker-library scripts return a status of 2 and are marked with warnings, the entire build instance should be marked as completed with warnings. This way, we can easily inspect which builds are in this state
