### PR TITLE
MDEV-35844: Parsec plugins missing from generic binary tarball

### DIFF
--- a/ci_build_images/scripts/gnutls.sh
+++ b/ci_build_images/scripts/gnutls.sh
@@ -102,6 +102,8 @@ make install
 ### Install GnuTLS library under /usr/local/lib
 cd ${HOME}
 mkdir -v gmp gnutls nettle hogweed
+cp -v ~/a/lib/lib{gmp,nettle,hogweed}.a /usr/local/lib/
+cp -r -v ~/a/include/* /usr/local/include/
 (set -x;cd gmp && ar x ~/a/lib/libgmp.a)
 (set -x;cd nettle && ar x ~/a/lib/libnettle.a)
 (set -x;cd hogweed && ar x ~/a/lib/libhogweed.a)


### PR DESCRIPTION
In almalinux bintar we bundle all symbols into gnutls.a (the server
expects it like that). However for parsec plugin, cmake looks for
libhogweed and libnettle. These should be bundled as static libraries
separately as well. Including the header files.
