### PR TITLE
MDEV-35844 - ncurses wrong terminfo database path

### DIFF
--- a/ci_build_images/scripts/ncurses.sh
+++ b/ci_build_images/scripts/ncurses.sh
@@ -70,7 +70,7 @@ rpm -ivh ncurses-*.src.rpm
 rpmbuild -bp $HOME/rpmbuild/SPECS/ncurses.spec
 cd $HOME/rpmbuild/BUILD/ncurses-*/
 
-CFLAGS="-fpic -fPIC" CXXFLAGS=${CFLAGS} ./configure --without-manpages --without-tests --without-progs --prefix=/scripts/local/
+CFLAGS="-fpic -fPIC" CXXFLAGS=${CFLAGS} ./configure --without-manpages --without-tests --without-progs --with-terminfo-dirs="/etc/terminfo:/lib/terminfo:/usr/share/terminfo" --with-xterm-kbs=del --disable-termcap --prefix=/scripts/local/
 make -j"$(nproc)" install
 mv /scripts/local/include/ncurses/* /scripts/local/include/
 # Snippet from spec file %INSTALL


### PR DESCRIPTION
NCURSES rely on terminfo database to find out what are the terminal capabilities so that keypresses are interpreted as intended.

In our case, backspace was interpreted as a simple space " ". terminfo database is available on most linux distributions by default so we just need to set the paths when compiling ncurses statically.

Example strace output of mariadb client after testing with this patch applied to ncurses:

```
stat("/home/razvan/.terminfo", 0x64c0fac3e450) = -1 ENOENT (No such file or directory)
stat("/etc/terminfo", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
stat("/lib/terminfo", 0x64c0fac3e4e0)   = -1 ENOENT (No such file or directory)
stat("/usr/share/terminfo", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
stat("/scripts/local//share/terminfo", 0x64c0fac3e570) = -1 ENOENT (No such file or directory)
access("/etc/terminfo/x/xterm-256color", R_OK) = -1 ENOENT (No such file or directory)
access("/usr/share/terminfo/x/xterm-256color", R_OK) = 0
openat(AT_FDCWD, "/usr/share/terminfo/x/xterm-256color", O_RDONLY) = 4
```

And backspace works as intended.