### PR TITLE
MDBF-712 Fix Libvirt startup script

### DIFF
--- a/docker-compose/start.sh
+++ b/docker-compose/start.sh
@@ -33,8 +33,8 @@ echo "Crossbar started"
 if [[ $1 == "master-libvirt" ]]; then
   [[ -d /root/.ssh ]] || {
     mkdir /root/.ssh
-    cp id_ed25519 /root/.ssh
-    cp known_hosts /root/.ssh
+    cp ./master-libvirt/id_ed25519 /root/.ssh
+    cp ./master-libvirt/known_hosts /root/.ssh
   }
 fi
 


### PR DESCRIPTION
Libvirt authenticates with qemu+ssh to hosts that provide VM workers. It requires the private key for the session user and the list of known hosts.

Since the script was adapted to the new buildbot.tac paths, we need to ensure that we locate the two files mentioned above and copy them into the .ssh directory of the master container's user.
