### PR TITLE
MDBF-967 - Lower the number of parallel builds on s390x

### DIFF
--- a/.github/workflows/bbm_deploy.yml
+++ b/.github/workflows/bbm_deploy.yml
@@ -19,6 +19,7 @@ on:
       - "script_templates/**"
       - "utils.py"
       - "validate_master_cfg.sh"
+      - "worker_locks.yaml"
   pull_request:
     paths:
       - ".github/workflows/bbm_deploy.yml"
@@ -36,6 +37,7 @@ on:
       - "script_templates/**"
       - "utils.py"
       - "validate_master_cfg.sh"
+      - "worker_locks.yaml"
 
 jobs:
   check:

--- a/worker_locks.yaml
+++ b/worker_locks.yaml
@@ -26,8 +26,8 @@ ns-x64-bbw1-docker: 3
 ns-x64-bbw2-docker: 2
 ns-x64-bbw3-docker: 2
 ns-x64-bbw4-docker: 2
-s390x-bbw1-docker: 3
-s390x-bbw2-docker: 3
-s390x-bbw3-docker: 3
-s390x-bbw4-docker: 3
-s390x-bbw5-docker: 3
+s390x-bbw1-docker: 1
+s390x-bbw2-docker: 1
+s390x-bbw3-docker: 1
+s390x-bbw4-docker: 1
+s390x-bbw5-docker: 1


### PR DESCRIPTION
Given that we have 5 s390x VM instances, each configured with 8vCPU's, we need to consider lowering the number of parallel builds on each VM from 3 to 1.

The builds are running Make with a parallel of 7 thus the 1 build per VM.
