### PR TITLE
MDBF-972 - Fix Master Global Locks

### DIFF
--- a/locks.py
+++ b/locks.py
@@ -37,6 +37,6 @@ def getLocks(props):
         return []
 
     for worker_base_name in LOCKS:
-        if worker_base_name in worker_name:
+        if worker_name.startswith(worker_base_name):
             return [LOCKS[worker_base_name].access("counting")]
     return []

--- a/locks.py
+++ b/locks.py
@@ -16,9 +16,9 @@ with open(
     encoding="utf-8",
 ) as file:
     locks = yaml.safe_load(file)
-    for worker_name in locks:
-        LOCKS[worker_name] = util.MasterLock(
-            f"{worker_name}_lock", maxCount=locks[worker_name]
+    for worker_base_name in locks:
+        LOCKS[worker_base_name] = util.MasterLock(
+            f"{worker_base_name}_lock", maxCount=locks[worker_base_name]
         )
 
 
@@ -36,6 +36,7 @@ def getLocks(props):
     ):
         return []
 
-    if worker_name not in LOCKS:
-        return []
-    return [LOCKS[worker_name].access("counting")]
+    for worker_base_name in LOCKS:
+        if worker_base_name in worker_name:
+            return [LOCKS[worker_base_name].access("counting")]
+    return []


### PR DESCRIPTION
Currently `locks.py` doesn't work in BuildBot because the script is checking if the **runtime worker_name** is in LOCKS dictionary by the full name of the worker which is composed by a `worker_base + OS`

Examples:
- runtime worker_name: s390x-bbw4-docker-ubuntu-2204
- worker_name (base) in worker_locks.yaml: s390x-bbw4-docker

Implemented a for loop to check if the base name is in the runtime worker_name string instead.