### PR TITLE
MDBF-973 Fix master-web http log location

### DIFF
--- a/master-web/master.cfg
+++ b/master-web/master.cfg
@@ -7,6 +7,7 @@ import os
 from buildbot.plugins import schedulers, util
 from flask import Flask, render_template
 from master_common import base_master_config
+from pathlib import Path
 from utils import upstream_branch_fn
 
 cfg_dir = os.path.abspath(os.path.dirname(__file__))
@@ -19,6 +20,7 @@ cfg_dir = os.path.abspath(os.path.dirname(__file__))
 #
 # Non autogen masters load from <srcdir> for now.
 base_dir = os.path.abspath(f"{cfg_dir}/../")
+log_basedir_path = Path("/var/log/buildbot/")
 
 # Load the slave, database passwords and 3rd-party tokens from an external private file, so
 # that the rest of the configuration can be public.
@@ -34,6 +36,7 @@ c = BuildmasterConfig = base_master_config(config)
 c["protocols"] = {}
 # minimalistic config to activate web UI
 c["www"] = {
+    "logfileName": str(log_basedir_path / 'master-web-www.log'),
     "port": int(os.environ["PORT"]),
     "plugins": {
         "waterfall_view": {},


### PR DESCRIPTION
We write the http master-web log file in the wrong path.

Previously relative to the master directory and currently,
in the root path of the buildbot deployment after the .tac update

```
$ find . -type f -name "http.log*" -exec realpath {} \;

/srv/dev/master-web/http.log
/srv/dev/http.log.2
/srv/dev/http.log.14
/srv/dev/http.log.16
...
```

This patch will change the http log dir to the common Logs folder for all masters.
Expected location after this patch

```
$ find . -type f -name "master-web-www.log*" -exec realpath {} \;
/srv/dev/docker-compose/logs/master-web-www.log
```