### PR TITLE
MDBF-980 - libvirt: Handle Major update from 11.8 to 12.0

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -548,6 +548,12 @@ check_upgraded_versions() {
         diff -u /tmp/version.old /tmp/version.new
         exit 1
       fi
+    elif ((old_branch_digit == 11)) && ((old_major_digit == 8)); then
+      if ((new_branch_digit == 12)) && ((new_major_digit != 0)); then
+        bb_log_err "This does not look like a major upgrade from 11.8 to 12.0:"
+        diff -u /tmp/version.old /tmp/version.new
+        exit 1
+      fi
     else
       old_major_digit_incr=$((old_major_digit + 1))
       ((old_major_digit_incr == new_major_digit)) || {


### PR DESCRIPTION
The upgrade from 11.8.1 to 12.0.0 is legit but `check_upgraded_versions()` was not patched to handle it.
```
+ check_upgraded_versions
+ for file in /tmp/version.old /tmp/version.new
+ [[ -f /tmp/version.old ]]
+ for file in /tmp/version.old /tmp/version.new
+ [[ -f /tmp/version.new ]]
+ [[ major == \m\a\j\o\r ]]
++ cut -d . -f1
+ old_branch_digit=11
++ cut -d . -f2
+ old_major_digit=8
++ cut -d . -f1
+ new_branch_digit=12
++ cut -d . -f2
+ new_major_digit=0
+ (( old_branch_digit == 10 ))
+ old_major_digit_incr=9
+ (( old_major_digit_incr == new_major_digit ))
+ bb_log_err 'This does not look like a major upgrade:'
+ set +x
ERROR: This does not look like a major upgrade:
+ diff -u /tmp/version.old /tmp/version.new
--- /tmp/version.old	2025-02-20 03:19:38.015106234 -0500
+++ /tmp/version.new	2025-02-20 03:19:54.479195336 -0500
@@ -1 +1 @@
-11.8.1
+12.0.0
+ exit 1
```