### PR TITLE
MDBF-981 hz-bbw5 - OOM due to docker workload requestion too much resources

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -322,7 +322,7 @@ addWorker(
     5,
     "debian-12",
     os.environ["CONTAINER_REGISTRY_URL"] + "debian12",
-    jobs=20,
+    jobs=10,
     save_packages=False,
 )
 

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -305,7 +305,7 @@ addWorker(
     5,
     "msan-clang-16-debian-11",
     os.environ["CONTAINER_REGISTRY_URL"] + "debian11-msan-clang-16",
-    jobs=30,
+    jobs=20,
     save_packages=False,
 )
 


### PR DESCRIPTION
**hz-bbw5**
- RAM: 128 GB
- CPU's : 32, 1 socket, 64 threads

Current docker workload:
```
amd64-debian-12-asan-ubsan
    - > Jobs = 20
amd64-debian-12-rocksdb
    - > Jobs = 20
amd64-debian-11-msan-clang-16
     -> Jobs = 30
```

In the worst case scenario, all three builders requesting a build on `hz-bbw5` would result in **70/64** CPU parity which is not acceptable given that:

- we run libvirt workers for amd64 on this machine
- we run mariadb replica (crossreference) on this machine