### PR TITLE
Disable plugin rocksdb for i386, cmake doesn't know the intended target

### DIFF
--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -899,7 +899,7 @@ c["builders"].append(
         factory=f_full_test(
             build_type="-DBUILD_CONFIG=mysql_release",
             test_configs=MYSQLREL_FULLTEST_MTR_CONFIGS,
-            cmake_additional_args="-DWITH_LIBARCHIVE=ON -DWITH_JEMALLOC=auto -DWITH_SSL=system -Wno-dev",
+            cmake_additional_args=" -DPLUGIN_ROCKSDB=NO -DWITH_LIBARCHIVE=ON -DWITH_JEMALLOC=auto -DWITH_SSL=system -Wno-dev",
         ),
     )
 )
@@ -916,7 +916,7 @@ c["builders"].append(
         factory=f_full_test(
             build_type="-DCMAKE_BUILD_TYPE=Debug",
             test_configs=DEFAULT_FULLTEST_MTR_CONFIGS,
-            cmake_additional_args="-DWITH_DBUG_TRACE=OFF",
+            cmake_additional_args="-DPLUGIN_ROCKSDB=NO -DWITH_DBUG_TRACE=OFF",
         ),
     )
 )


### PR DESCRIPTION
Fix for: https://github.com/MariaDB/buildbot/pull/670

Although the debian-12-i386 container image is build with the 32-bit toolchain, from compiler to mariadb build time dependencies,
CMAKE will detect the host system (docker host) arch, it will think it's x86_x64 and will attempt to build rocksdb see: https://github.com/MariaDB/server/commit/3eb8bc740817aa7010a070be0699bff6266f829c

This will cause the builds on the debug builder to fail, as warnings are treated as termination errors. https://buildbot.dev.mariadb.org/#/builders/533/builds/4

```
/home/buildbot/x86-debian-12-fulltest-debug/build/storage/rocksdb/ha_rocksdb.cc: In function ‘int myrocks::rocksdb_init_func(void*)’:
/home/buildbot/x86-debian-12-fulltest-debug/build/storage/rocksdb/ha_rocksdb.cc:5492:39: error: format ‘%ld’ expects argument of type ‘long int’, but argument 2 has type ‘std::__cxx1998::vector<std::__cxx11::basic_string<char>, std::allocator<std::__cxx11::basic_string<char> > >::size_type’ {aka ‘unsigned int’} [-Werror=format=]
 5492 |     sql_print_information("RocksDB: %ld column families found",
```

As oposed to the old-bb where the system host arch matches i386 because the build runs inside a 32-bit virtual machine.

old-bb debug full test builder will report:
```
-- Can't build rocksdb engine - Intel 32 bit not supported
```
