### PR TITLE
MDBF-985 Protected branches worker hosts are fully loaded

### DIFF
--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -125,7 +125,7 @@ def addWorker(
 
 for w_name in ["hz-bbw"]:
     jobs = 7
-    for i in [1, 4]:
+    for i in [1, 4, 7]:
         addWorker(
             w_name,
             i,

--- a/worker_locks.yaml
+++ b/worker_locks.yaml
@@ -4,10 +4,11 @@
 # The keys are worker names, as used in locks.py.
 # TODO: There should be a single place where these keys are defined, currently
 # there are more places.
-hz-bbw1-docker: 9
+hz-bbw1-docker: 6
 hz-bbw2-docker: 1
-hz-bbw4-docker: 9
+hz-bbw4-docker: 6
 hz-bbw5-docker: 9
+hz-bbw7-docker: 6
 amd-bbw1-docker: 4
 amd-bbw2-docker: 6
 intel-bbw1-docker: 5


### PR DESCRIPTION
Recently getting a lot of OOM conditions in which libvirt VM's on hz-bbw4 are the victims of a too much Docker load on this machine.

This led to analyzing the theoretical load on the protected branches worker hosts, hz-bbw1 and hz-bbw4 and it doesn't surprise me that we assign more builders than the infrastructure allows us to do.

I propose to add hz-bbw7 as a protected branches worker host, as on hz-bbw7 currently only bintar (centos7, almalinux-8) run and we have enough room.

More on that, if multiple tarball's are triggered in a short amount of time, is a safer choice to decrease the locks value on hz-bbw 1,4,7 so that we don't risk over-provisioning builds.