### PR TITLE
MDBF-978 Reinstate RHEL 7 Builder

### DIFF
--- a/.github/workflows/bbw_build_container_rhel.yml
+++ b/.github/workflows/bbw_build_container_rhel.yml
@@ -12,6 +12,7 @@ on:
       - 'ci_build_images/pip.Dockerfile'
       - 'ci_build_images/qpress.Dockerfile'
       - 'ci_build_images/rhel.Dockerfile'
+      - 'ci_build_images/rhel7.Dockerfile'
   pull_request:
     paths:
       - 'ci_build_images/buildbot-worker.Dockerfile'
@@ -19,6 +20,7 @@ on:
       - 'ci_build_images/pip.Dockerfile'
       - 'ci_build_images/qpress.Dockerfile'
       - 'ci_build_images/rhel.Dockerfile'
+      - 'ci_build_images/rhel7.Dockerfile'
   workflow_dispatch:
 
 jobs:
@@ -34,11 +36,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - dockerfile: rhel7.Dockerfile pip.Dockerfile
+            image: ubi7
+            tag: rhel7
+            platforms: linux/amd64
+            nogalera: false
+
           - dockerfile: rhel.Dockerfile
             image: ubi8
             tag: rhel8
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
             nogalera: false
+
           - dockerfile: rhel.Dockerfile
             image: ubi9
             tag: rhel9

--- a/ci_build_images/rhel7.Dockerfile
+++ b/ci_build_images/rhel7.Dockerfile
@@ -1,0 +1,91 @@
+# Buildbot worker for building MariaDB
+#
+# Provides a base RHEL-7 AMD64 image with latest buildbot worker installed
+# and MariaDB build dependencies
+
+ARG BASE_IMAGE
+FROM registry.access.redhat.com/$BASE_IMAGE AS repo
+
+LABEL maintainer="MariaDB Buildbot maintainers"
+
+RUN --mount=type=secret,id=rhel_orgid,target=/run/secrets/rhel_orgid \
+    --mount=type=secret,id=rhel_keyname,target=/run/secrets/rhel_keyname \
+    # Make subscription-manager work in container
+    sed -i 's/\(def in_container():\)/\1\n    return False/g' /usr/lib64/python*/*-packages/rhsm/config.py \
+    && subscription-manager register \
+         --org="$(cat /run/secrets/rhel_orgid)" \
+         --activationkey="$(cat /run/secrets/rhel_keyname)" \
+    && subscription-manager repos --enable=rhel-7-server-optional-rpms \
+    && rpm -ivh https://dl.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm \
+    #TODO(razvanv): Currently Galera 26.4.20-1.el7_9. Run RH 7 Galera builder and rebuild this image to update latest-galera
+    && yum-config-manager --add-repo https://ci.mariadb.org/galera/mariadb-4.x-latest-gal-amd64-rhel-7.repo
+
+FROM repo AS buildeps
+# hadolint ignore=DL3032
+RUN yum -y upgrade \
+     && yum-builddep -y mariadb-server \
+     && yum -y install \
+          @development \
+          asio-devel \
+          bison \
+          boost-devel \
+          bzip2 \
+          bzip2-devel \
+          ccache \
+          check-devel \
+          cmake3 \
+          cracklib-devel \
+          createrepo \
+          curl-devel \
+          fmt-devel \
+          galera-4 \
+          gnutls-devel \
+          java-1.8.0-openjdk \
+          java-1.8.0-openjdk-devel \
+          jemalloc-devel \
+          libaio-devel \
+          libevent-devel \
+          libffi-devel \
+          libpmem-devel \
+          libzstd-devel \
+          libxml2-devel \
+          lsof \
+          lz4-devel \
+          lzo-devel \
+          openssl-devel \
+          ncurses-devel \
+          pam-devel \
+          perl-autodie \
+          perl-devel \
+          perl-Net-SSLeay \
+          pcre2-devel \
+          python3-devel \
+          python3-pip \
+          readline-devel \
+          rpmlint \
+          ruby \
+          snappy-devel \
+          socat \
+          systemd-devel \
+          unixODBC \
+          unixODBC-devel \
+          wget \
+     && yum -y install \
+          "https://kojipkgs.fedoraproject.org/packages/Judy/1.0.5/7.el7/x86_64/Judy-1.0.5-7.el7.x86_64.rpm" \
+          "https://kojipkgs.fedoraproject.org/packages/Judy/1.0.5/7.el7/x86_64/Judy-devel-1.0.5-7.el7.x86_64.rpm" \
+     # USE CMAKE 3
+     && yum -y remove cmake \
+     && ln -sf /usr/bin/cmake3 /usr/bin/cmake \
+     && curl -sL "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_$(uname -m)" >/usr/local/bin/dumb-init \
+     && chmod +x /usr/local/bin/dumb-init
+
+ENV CRYPTOGRAPHY_ALLOW_OPENSSL_102=1
+ENV WSREP_PROVIDER=/usr/lib64/galera/libgalera_smm.so
+
+
+FROM buildeps AS cleanup
+RUN yum clean all \
+     && subscription-manager unregister
+
+# FRAGMENT DOCKERFILES (bb-worker, pip, etc) ARE CONCATENATED HERE
+FROM cleanup as fragments

--- a/constants.py
+++ b/constants.py
@@ -124,6 +124,7 @@ SUPPORTED_PLATFORMS["10.5"] = [
     "amd64-fedora-40-valgrind",
     "amd64-freebsd-14",
     "amd64-openeuler-2403",
+    "amd64-rhel-7",
     "amd64-rhel-8",
     "amd64-rhel-9",
     "amd64-last-N-failed",
@@ -187,6 +188,7 @@ SUPPORTED_PLATFORMS["10.11"] = [
 SUPPORTED_PLATFORMS["10.11"] += SUPPORTED_PLATFORMS["10.10"]
 
 SUPPORTED_PLATFORMS["11.0"] = SUPPORTED_PLATFORMS["10.11"].copy()
+SUPPORTED_PLATFORMS["11.0"].remove("amd64-rhel-7")
 SUPPORTED_PLATFORMS["11.1"] = SUPPORTED_PLATFORMS["11.0"].copy()
 SUPPORTED_PLATFORMS["11.2"] = SUPPORTED_PLATFORMS["11.1"].copy()
 SUPPORTED_PLATFORMS["11.3"] = SUPPORTED_PLATFORMS["11.2"].copy()

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -105,6 +105,14 @@ opensuse-1506:
   arch:
     - amd64
   type: rpm
+rhel-7:
+  image_tag: rhel7
+  tags:
+    - release_packages
+  version_name: 7
+  arch:
+    - amd64
+  type: rpm
 rhel-8:
   image_tag: rhel8
   tags:


### PR DESCRIPTION
This is a revert of https://github.com/MariaDB/buildbot/commit/c5ff095750aee990e2190d90e2cb2b4ded41dd21

Additional changes:
- build RH7 only for server versions <= 10.11
- use archived EPEL repository
- use galera from ci.mariadb.org. #TODO: update it to latest version
- install missing dependencies to build all already released packages on mirror
- use multi-stage build in base dockerfile for clarity

VM (install / upgrade):
- VM already deployed on APEXIS by Faustin. Will sync for PROD after DEV testing
