### PR TITLE
MDBF-993 Remove amd64-debian-11-msan and last-N-failed from status reporting

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -47,7 +47,6 @@ GITHUB_STATUS_BUILDERS = [
     "amd64-debian-12-debug-embedded",
     "amd64-debian-12-deb-autobake",
     "amd64-debian-11-debug-ps-embedded",
-    "amd64-debian-11-msan",
     "amd64-debian-11-msan-clang-16",
     "amd64-fedora-40",
     "amd64-ubuntu-2004-debug",

--- a/constants.py
+++ b/constants.py
@@ -50,7 +50,6 @@ GITHUB_STATUS_BUILDERS = [
     "amd64-debian-11-msan",
     "amd64-debian-11-msan-clang-16",
     "amd64-fedora-40",
-    "amd64-last-N-failed",
     "amd64-ubuntu-2004-debug",
     "amd64-ubuntu-2204-debug-ps",
     "amd64-windows",


### PR DESCRIPTION
Part of MDBF-993.
As per @cvicentiu  request,

**last-N-failed** is only reporting its status (not in branch protection) and @cvicentiu reported often sporadic failures for it.

**debian-11-msan** It will be replaced by a clang-20 builder in https://github.com/MariaDB/buildbot/pull/562 so no need to update GITHUB_STATUS_BUILDERS for it in this Pull Request.