### PR TITLE
MDBF-994: MTR Generator to unify mtr invocation in Buildbot

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-ignore-words-list = crossreference,ro
+ignore-words-list = crossreference,ro,assertin
 # following contains a typo in an INNODB test
 exclude = scripts/aix-build-and-test.sh
 skip = cross-reference/crossreference/cr/static/*

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,6 +10,7 @@ disable=
     W0122, # exec-used
     W1514, # unspecified-encoding
     E0611, # no-name-in-module
+    E0402, # relative-beyond-top-level
     E0606, # possibly-used-before-assignment
 
 # Analyse import fallback blocks. This can be used to support both Python 2 and

--- a/steps/base/exceptions.py
+++ b/steps/base/exceptions.py
@@ -1,0 +1,7 @@
+class DuplicateFlagException(Exception):
+    def __init__(self, flag_name: str, existing_value: str, new_value: str):
+        super().__init__(
+            f"Duplicate flag detected: {flag_name}"
+            f"(existing: {existing_value}, new: {new_value})"
+        )
+        super().__init__(f"Duplicate flag detected: {flag_name}")

--- a/steps/base/generator.py
+++ b/steps/base/generator.py
@@ -1,0 +1,50 @@
+from typing import Iterable
+
+from .exceptions import DuplicateFlagException
+from .options import Option
+
+
+class BaseGenerator:
+    def __init__(
+        self,
+        base_cmd: list[str],
+        flags: Iterable[Option] = [],
+        allow_duplicates: bool = False,
+    ):
+        self.base_cmd = base_cmd
+        self.allow_duplicates = allow_duplicates
+        self.flags_names: set[str] = set()
+        self.flags: list[Option] = []
+        self.append_flags(flags)
+
+    def append_flags(self, flags: Iterable[Option]):
+        """
+        Appends new flags to the generator.
+
+        Raises:
+            DuplicateFlagException: If a flag with the same name already
+                                    exists and self.allow_duplicates is False.
+        """
+        for flag in flags:
+            # Do not allow duplicate flags being set.
+            # Flags should only be set once to avoid confusion about them
+            # being overwritten.
+            if not self.allow_duplicates and flag.name in self.flags_names:
+                # Yes, this is O(N) but this should only happen in cases
+                # when we end execution anyway, so a slow error path is ok.
+                for other in self.flags:
+                    if flag.name == other.name:
+                        existing_flag = other
+                        break
+                raise DuplicateFlagException(flag.name, existing_flag.value, flag.value)
+            self.flags_names.add(flag.name)
+            self.flags.append(flag)
+
+    def generate(self) -> list[str]:
+        """
+        Generates the command as a list of strings.
+        """
+        result = self.base_cmd.copy()
+        for flag in sorted(self.flags, key=lambda x: x.name):
+            result.append(flag.as_cmd_arg())
+        return result

--- a/steps/base/options.py
+++ b/steps/base/options.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+from enum import StrEnum
+
+
+class Option(ABC):
+    @staticmethod
+    def _quote_value(value: str):
+        """
+        Quote the value if it contains spaces or special characters.
+        """
+        if " " in value or '"' in value:
+            return f'"{value.replace('"', '\\\"')}"'
+        return value
+
+    def __init__(self, name: StrEnum, value: str | int | bool = True):
+        assert isinstance(name, StrEnum)
+        assert (
+            isinstance(value, str) or isinstance(value, bool) or isinstance(value, int)
+        )
+        self.name = str(name)
+        if isinstance(value, str):
+            # Quote if necessary.
+            self.value = self._quote_value(value)
+        else:
+            self.value = value
+
+    @abstractmethod
+    def as_cmd_arg(self) -> str: ...
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.name}, {self.value})"
+
+    def __str__(self) -> str:
+        return self.as_cmd_arg()

--- a/steps/cmake/options.py
+++ b/steps/cmake/options.py
@@ -1,5 +1,7 @@
 from enum import StrEnum
 
+from ..base.generator import Option
+
 
 # Flag names use UPPER_CASE
 class CMAKE(StrEnum):
@@ -84,36 +86,15 @@ class BuildConfig(StrEnum):
     MYSQL_RELEASE = "mysql_release"
 
 
-class CMakeOption:
+class CMakeOption(Option):
     """
     Represents a CMake option in the form `-D<name>=<value>`.
     """
 
-    @staticmethod
-    def _quote_value(value: str):
-        """
-        Quote the value if it contains spaces or special characters.
-        """
-        if " " in value or '"' in value:
-            return f'"{value.replace('"', '\\\"')}"'
-        return value
-
     def __init__(self, name: StrEnum, value: str | bool):
-        assert isinstance(name, StrEnum)
-        assert isinstance(value, str) or isinstance(value, bool)
-        self.name = str(name)
         if isinstance(value, bool):
-            self.value = "ON" if value else "OFF"
-        elif isinstance(value, str):
-            self.value = value
-        # Quote if necessary.
-        self.value = self._quote_value(self.value)
+            value = "ON" if value else "OFF"
+        super().__init__(name, value)
 
     def as_cmd_arg(self) -> str:
         return f"-D{self.name}={self.value}"
-
-    def __str__(self) -> str:
-        return self.as_cmd_arg()
-
-    def __repr__(self) -> str:
-        return f"CMakeOption({self.name}, {self.value})"

--- a/steps/mtr/generator.py
+++ b/steps/mtr/generator.py
@@ -1,0 +1,14 @@
+from typing import Iterable
+
+from ..base.generator import BaseGenerator
+from .options import MTR, MTROption, TestSuiteCollection
+
+
+class MTRGenerator(BaseGenerator):
+    def __init__(self, flags: Iterable[MTROption]):
+        super().__init__(
+            base_cmd=["perl", "mariadb-test-run.pl"], flags=flags, allow_duplicates=True
+        )
+
+    def set_test_suites(self, suites: TestSuiteCollection):
+        self.append_flags([MTROption(MTR.SUITE, str(suites))])

--- a/steps/mtr/options.py
+++ b/steps/mtr/options.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ..base.options import Option
+
+
+class MTR(StrEnum):
+    # This class is used for type safety and preventing typos. Instead of
+    # passing raw strings to create an MTR run command, generate the flag
+    # list via an array of MTRFlags and their values.
+    PREPARED_STATEMENT_PROTOCOL = "ps-protocol"
+    VIEW_PROTOCOL = "view-protocol"
+    STORED_PROCEDURE_PROTOCOL = "sp-protocol"
+    WITH_EMBEDDED = "embedded"
+    FORCE = "force"
+    MAX_TEST_FAILURE = "max-test-failure"
+    MAX_SAVE_CORE = "max-save-core"
+    MAX_TEST_FAIL = "max-test-fail"
+    IN_MEMORY = "mem"
+    VALGRIND = "valgrind"
+    VERBOSE_RESTART = "verbose-restart"
+    PARALLEL = "parallel"
+    SUITE = "suite"
+
+
+class SUITE(StrEnum):
+    ARCHIVE = "archive"
+    ATOMIC = "atomic"
+    BINLOG = "binlog"
+    BINLOG_ENCRYPTION = "binlog_encryption"
+    COMAT_MSSQL = "compat/mssql"
+    COMPAT_MAXDB = "compat/maxdb"
+    COMPAT_ORACLE = "compat/oracle"
+    CSV = "csv"
+    DISKS = "disks"
+    ENCRYPTION = "encryption"
+    EVENTS = "events"
+    FEDERATED = "federated"
+    FUNCS_1 = "funcs_1"
+    FUNCS_2 = "funcs_2"
+    FUNC_TEST = "func_test"
+    GCOL = "gcol"
+    HANDLER = "handler"
+    HEAP = "heap"
+    INNODB = "innodb"
+    INNODB_FTS = "innodb_fts"
+    INNODB_GIS = "innodb_gis"
+    INNODB_I_S = "innodb_i_s"
+    INNODB_ZIP = "innodb_zip"
+    JSON = "json"
+    MAIN = "main"
+    MARIA = "maria"
+    MARIABACKUP = "mariabackup"
+    MERGE = "merge"
+    METADATA_LOCK_INFO = "metadata_lock_info"
+    MULTI_SOURCE = "multi_source"
+    OPTIMIZER_UNFIXED_BUGS = "optimizer_unfixed_bugs"
+    PARTS = "parts"
+    PERFSCHEMA = "perfschema"
+    PERIOD = "period"
+    PLUGINS = "plugins"
+    QUERY_RESPONSE_TIME = "query_response_time"
+    ROLES = "roles"
+    RPL = "rpl"
+    SEQUENCE = "sequence"
+    SPIDER = "spider"
+    SPIDER_BG = "spider/bg"
+    SPIDER_BUGFIX = "spider/bugfix"
+    SPIDER_FEATURE = "spider/feature"
+    SPIDER_REGRESSION_E1121 = "spider/regression/e1121"
+    SPIDER_REGRESSION_E112122 = "spider/regression/e112122"
+    SQL_DISCOVERY = "sql_discovery"
+    SQL_SEQUENCE = "sql_sequence"
+    STRESS = "stress"
+    SYSSCHEMA = "sysschema"
+    SYS_VARS = "sys_vars"
+    TYPE_INET = "type_inet"
+    TYPE_MYSQL_TIMESTAMP = "type_mysql_timestamp"
+    TYPE_TEST = "type_test"
+    TYPE_UUID = "type_uuid"
+    UNIT = "unit"
+    USER_VARIABLES = "user_variables"
+    VCOL = "vcol"
+    VERSIONING = "versioning"
+
+
+@dataclass
+class TestSuiteCollection:
+    suites: list[StrEnum]
+
+    def __post_init__(self):
+        assert self.suites
+        self.suites = sorted(self.suites)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.__str__()})"
+
+    def __str__(self):
+        res = ""
+        for suite in self.suites:
+            res += f"{suite.value},"
+        return res[:-1]
+
+
+class MTROption(Option):
+    def as_cmd_arg(self) -> str:
+        if isinstance(self.value, bool):
+            if not self.value:
+                return f"--no{self.name}"
+            else:
+                return f"--{self.name}"
+        return f"--{self.name}={self.value}"

--- a/tests/test_cmake_generator.py
+++ b/tests/test_cmake_generator.py
@@ -1,7 +1,8 @@
 import unittest
 
+from steps.base.exceptions import DuplicateFlagException
 from steps.cmake.compilers import CompilerCommand
-from steps.cmake.generator import CMakeGenerator, DuplicateFlagException
+from steps.cmake.generator import CMakeGenerator
 from steps.cmake.options import CMAKE, PLUGIN, WITH, BuildConfig, BuildType, CMakeOption
 
 

--- a/tests/test_mtr_generator.py
+++ b/tests/test_mtr_generator.py
@@ -1,0 +1,99 @@
+import unittest
+
+from steps.mtr.generator import MTRGenerator
+from steps.mtr.options import MTR, SUITE, MTROption, TestSuiteCollection
+
+
+class TestMTRGenerator(unittest.TestCase):
+    def test_initialization_with_flags(self):
+        """Test that the generator initializes with provided flags."""
+        flags = [
+            MTROption(MTR.FORCE, True),
+            MTROption(MTR.MAX_TEST_FAILURE, 5),
+            MTROption(MTR.VALGRIND, True),
+            MTROption(MTR.PARALLEL, 4),
+        ]
+        generator = MTRGenerator(flags=flags)
+        command = generator.generate()
+        self.assertEqual(
+            command,
+            [
+                "perl",
+                "mariadb-test-run.pl",
+                "--force",
+                "--max-test-failure=5",
+                "--parallel=4",
+                "--valgrind",
+            ],
+        )
+
+    def test_append_flags_successful(self):
+        """
+        Test that flags are appended successfully.
+        """
+        generator = MTRGenerator(flags=[])
+        generator.append_flags(
+            [
+                MTROption(MTR.VERBOSE_RESTART, True),
+                MTROption(MTR.WITH_EMBEDDED, True),
+            ]
+        )
+        command = generator.generate()
+        self.assertEqual(
+            command,
+            [
+                "perl",
+                "mariadb-test-run.pl",
+                "--embedded",
+                "--verbose-restart",
+            ],
+        )
+
+    def test_append_flags_duplicate_allow(self):
+        """
+        Test that appending a duplicate flag does not raise an exception.
+        """
+        flags = [MTROption(MTR.MAX_TEST_FAIL, 10)]
+        generator = MTRGenerator(flags=flags)
+        duplicate_flag = MTROption(MTR.MAX_TEST_FAIL, 5)
+        generator.append_flags([duplicate_flag])
+        command = generator.generate()
+        self.assertEqual(
+            command,
+            [
+                "perl",
+                "mariadb-test-run.pl",
+                # Stable sort, by name, first in, first out if name equal.
+                "--max-test-fail=10",
+                "--max-test-fail=5",
+            ],
+        )
+
+    def test_generate_with_no_flags(self):
+        """
+        Test that generate produces only the 'perl mariadb-test-run.pl' command if no flags are set.
+        """
+        generator = MTRGenerator(flags=[])
+        command = generator.generate()
+        self.assertEqual(command, ["perl", "mariadb-test-run.pl"])
+
+    def test_set_test_suites(self):
+        """
+        Test that setting test suites adds the correct suite flag.
+        """
+        generator = MTRGenerator(flags=[])
+        suites = TestSuiteCollection([SUITE.ARCHIVE, SUITE.MAIN])
+        generator.set_test_suites(suites)
+        command = generator.generate()
+        self.assertIn("--suite=archive,main", command)
+
+    def test_set_test_suites_with_other_flags(self):
+        """
+        Test that setting test suites works alongside other flags.
+        """
+        generator = MTRGenerator(flags=[MTROption(MTR.FORCE, True)])
+        suites = TestSuiteCollection([SUITE.ARCHIVE, SUITE.MAIN])
+        generator.set_test_suites(suites)
+        command = generator.generate()
+        self.assertIn("--force", command)
+        self.assertIn("--suite=archive,main", command)


### PR DESCRIPTION
This PR introduces an MTR Generator so we can standardise MTR invocation. It's likely not in its final form, we will likely have to add ENVIRONMENT variables support, for MTR_FEEDBACK_PLUGIN=1 for instance, but this will happen when we have specific builders use this class. For now the code is not used in any buildbot config, although it does have unit tests.

Refactoring:
Extract the base common logic from CMakeGenerator and put it into the "base" folder instead.