### PR TITLE
MDBF-793: clang 20 msan builder

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -124,8 +124,6 @@ SUPPORTED_PLATFORMS["10.5"] = [
     "amd64-rhel-8",
     "amd64-rhel-9",
     "amd64-last-N-failed",
-    "amd64-msan-clang-20",
-    "amd64-msan-clang-20-debug",
     "amd64-ubuntu-2004",
     "amd64-ubuntu-2004-debug",
     "amd64-ubuntu-2004-fulltest",
@@ -153,6 +151,7 @@ SUPPORTED_PLATFORMS["10.6"] = SUPPORTED_PLATFORMS["10.5"].copy()
 
 SUPPORTED_PLATFORMS["10.6"] += [
     "aarch64-ubuntu-2204",
+    "amd64-msan-clang-20",
     "amd64-ubuntu-2204",
     "ppc64le-ubuntu-2204",
     "s390x-ubuntu-2204",


### PR DESCRIPTION
Rectifing Debug build failures has stalled on some review and further test failures are known. As such disable this for now.

Move the non-debug to 10.6 branch where tests are being fixed. Remain C/C update approved, and one archive-big test mask waiting to be fixed in server branches.