### PR TITLE
MDBF-740/741 ASAN/UBSAN to MSAN container

### DIFF
--- a/ci_build_images/msan.fragment.Dockerfile
+++ b/ci_build_images/msan.fragment.Dockerfile
@@ -141,3 +141,4 @@ ref sanitizer flags documents:\n\
 
 ENV ASAN_OPTIONS=quarantine_size_mb=512:atexit=0:detect_invalid_pointer_pairs=3:dump_instruction_bytes=1:allocator_may_return_null=1
 ENV UBSAN_OPTIONS=print_stacktrace=1:report_error_type=1
+ENV MTR_PARALLEL=auto


### PR DESCRIPTION
This is adding a few extension needed for ASAN/UBSAN so its ready. Added to msan so we don't need to maintain two similar containers.

Reusing MSAN container as latest clang also
provides up to date ASAN/UBSAN. The MSAN work
is isolation to the side.

Also with rr in this container it provides a
single portablility of recordings which is
dependent on rr versoin.

ASAN/UBSAN_OPTIONS to facilitate base debugging
from Roel.

Take suppression files and put these in the
image as a reference, but also for CI to
be able to pull the latest an update is needed.