### PR TITLE
MDBF-1020 buildbot workers needs env USER=buildbot

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -210,6 +210,7 @@ SUPPORTED_PLATFORMS["main"] = SUPPORTED_PLATFORMS["12.0"].copy()
 # Define environment variables for MTR step
 MTR_ENV = {
     "MTR_PRINT_CORE": "detailed",
+    "USER": "buildbot",
 }
 
 # Define the mapping from MTR test types to mtr command line options


### PR DESCRIPTION
For the mtr tests around unix socket that depend on this env variable.

Given the presence of the tests and the long availablility of unix socket I'm not expecting the mtr tests to fail because of this change.