### PR TITLE
MDBF-1014 - use refs/pull/#id#/head for Pull-Request changes

### DIFF
--- a/master-web/master.cfg
+++ b/master-web/master.cfg
@@ -90,6 +90,7 @@ c["www"]["change_hook_dialects"] = {
     "github": {
         "secret": config["private"]["gh_secret"],
         "strict": True,
+        "pullrequest_ref": "head",
     }
 }
 


### PR DESCRIPTION
Rationale:
- refs/pull/#id#/merge is not always updated right after someone pushes a commit on the source PR branch, causing buildbot to test on older versions of the branch
- /head ref is always showing the developer intention testing on his/her version of the codebase
- integration testing will still happen because, right before merging the PR, branch policies will enforce a rebase
