### PR TITLE
MDEV-36156/MDBF-793 MSAN no longer requires explict CMAKE_CXX_FLAGS

### DIFF
--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -281,7 +281,6 @@ f_msan_build.addStep(
                 -DWITH_MSAN=ON \\
                 -DHAVE_CXX_NEW=1 \\
                 -DCMAKE_{EXE,MODULE}_LINKER_FLAGS="-L${MSAN_LIBDIR} -Wl,-rpath=${MSAN_LIBDIR}" \\
-                -DCMAKE_CXX_FLAGS=-fsanitize=memory \\
                 -DWITH_DBUG_TRACE=OFF \\
                 && cmake --build . --parallel %(kw:jobs)s --verbose""",
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),


### PR DESCRIPTION
Explict CMAKE_CXX_FLAGS where required for the testing of -stdlib=libc++. With the server change in MDEV-36156 we don't need to do this in Buildbot.

# Template selection

Please go the the `Preview` tab and select the appropriate sub-template:

* [Adding Worker Machine](?expand=1&template=add_worker.md)
* [Adding a New Build](?expand=1&template=add_build.md)
