### PR TITLE
MDBF-978 - fix pip buildbot-worker

### DIFF
--- a/.github/workflows/bbw_build_container_rhel.yml
+++ b/.github/workflows/bbw_build_container_rhel.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}
     services:
       registry:
         image: registry:2
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dockerfile: rhel7.Dockerfile pip.Dockerfile
+          - dockerfile: rhel7.Dockerfile
             image: ubi7
             tag: rhel7
             platforms: linux/amd64
@@ -53,6 +53,7 @@ jobs:
             tag: rhel9
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
             nogalera: false
+            runner: ubuntu-24.04
     env:
       MAIN_BRANCH: false
       BUILD_RHEL: false

--- a/ci_build_images/rhel7.Dockerfile
+++ b/ci_build_images/rhel7.Dockerfile
@@ -77,13 +77,18 @@ RUN yum -y upgrade \
      && yum -y remove cmake \
      && ln -sf /usr/bin/cmake3 /usr/bin/cmake \
      && curl -sL "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_$(uname -m)" >/usr/local/bin/dumb-init \
-     && chmod +x /usr/local/bin/dumb-init
+     && chmod +x /usr/local/bin/dumb-init \
+     # Upgrade pip
+     && pip3 install --no-cache-dir -U pip
 
 ENV CRYPTOGRAPHY_ALLOW_OPENSSL_102=1
 ENV WSREP_PROVIDER=/usr/lib64/galera/libgalera_smm.so
 
+# Latest worker (4.2.x) doesn't work on Python 3.6
+FROM buildeps as bbworker
+RUN pip3 install --no-cache-dir buildbot-worker==4.0.1
 
-FROM buildeps AS cleanup
+FROM bbworker AS cleanup
 RUN yum clean all \
      && subscription-manager unregister
 


### PR DESCRIPTION
- upgrade pip
- latest buildbot worker 4.2.x does not work on python 3.6
- don't use pip.Dockerfile
- rhel9 ppc64le needs a newer qemu-user-static to build (e.g. newer github runner) https://gitlab.com/qemu-project/qemu/-/issues/1471

Tests:
https://github.com/MariaDB/buildbot/actions/runs/14260753047/job/39971625922
