### PR TITLE
MDBF-1020 - macos user != buildbot

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -887,6 +887,9 @@ def get_macos_factory(compile_only=False):
         )
     )
     if not compile_only:
+        # TODO(Razvan) run worker under buildbot on macos
+        macos_mtr_env = MTR_ENV.copy()
+        macos_mtr_env.pop("USER",None) # User != buildbot. Already set by worker
         f_macos.addStep(
             steps.MTR(
                 logfiles={"mysqld*": "./buildbot_logs/mysql_logs.html"},
@@ -914,7 +917,7 @@ def get_macos_factory(compile_only=False):
                 parallel=mtrJobsMultiplier,
                 dbpool=mtrDbPool,
                 autoCreateTables=True,
-                env=MTR_ENV,
+                env=macos_mtr_env,
             )
         )
         f_macos.addStep(


### PR DESCRIPTION
macos aws instances run the buildbot-worker under a different user. the user is already exposed in the environment and the unix socket tests are running

This is a quick fix to preserve user:buildbot in MTR_ENV.