### PR TITLE
MDBF-878 - Register bsd worker 2

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -112,11 +112,17 @@ mac_worker = mkWorker(
 )
 c["workers"].append(mac_worker)
 
-## hz-freebsd-bbw1
-freebds_worker = mkWorker(
-    "hz-freebsd-bbw1", max_builds=1, properties={"jobs": 10, "save_packages": False}
-)
-c["workers"].append(freebds_worker)
+## hz-freebsd-bbw1 and bbw-2
+freebds_workers = [
+    mkWorker(
+        "hz-freebsd-bbw1", max_builds=1, properties={"jobs": 10, "save_packages": False}
+    ),
+    mkWorker(
+        "hz-freebsd-bbw2", max_builds=1, properties={"jobs": 10, "save_packages": False}
+    ),
+]
+
+c["workers"].extend(freebds_workers)
 
 ####### FACTORY CODE
 
@@ -1068,7 +1074,7 @@ c["builders"].append(
 c["builders"].append(
     util.BuilderConfig(
         name="amd64-freebsd-14",
-        workernames=["hz-freebsd-bbw1"],
+        workernames=["hz-freebsd-bbw1", "hz-freebsd-bbw2"],
         tags=["FreeBSD", "quick", "experimental"],
         collapseRequests=True,
         properties={

--- a/master-private.cfg-sample
+++ b/master-private.cfg-sample
@@ -44,6 +44,7 @@ private["worker_pass"]= {
     "hz-bbw2-ubuntu1804":"1234",
     "hz-bbw2-libvirt-debian-10":"1234",
     "hz-freebsd-bbw1":"1234",
+    "hz-freebsd-bbw2":"1234",
     "bm-bbw1-ubuntu1804":"1234",
     "shinnok-bbw1-macos":"1234",
     "aix-worker":"1234",


### PR DESCRIPTION
### TODO before merge:
- upgrade galera lib to latest (@fauust )
- Ansible deploy on bbw2 (@fauust ):
  - ccache dir `(/mnt) ccache -> /data/ccache/`
  - buildbot dev / prod dirs and .tac in /data . @fauust , worker identity should be `hz-freebsd-bbw2`
  - bsd services (RC) . @fauust , let them stopped and disabled . Will enable the DEV service right after merge
- master-private change (@RazvanLiviuVarzaru ). @fauust , send credentials to me.

### Rollout plan:
1. TODO's before merge
2. BBW-2 DEV service UP, BBW-1 DEV service DOWN, tests on DEV (@RazvanLiviuVarzaru )
3. Release on Production (@RazvanLiviuVarzaru )
4. on PROD: BBW-1 worker paused, finish runs, BBW-1 SERVICE DOWN, BBW-2 SERVICE UP (@RazvanLiviuVarzaru )
5. Pull-Request to remove BBW-1 from configuration (@RazvanLiviuVarzaru )

