### PR TITLE
MDBF-1046 - stream 10 disable CS tests during Install

### DIFF
--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -84,7 +84,7 @@ sudo mariadb -e "drop database if exists test; \
   drop table t;"
 # Columnstore tests are currently skipped for Fedora (see MCOL-5825) or Columnstore packages were not found
 
-if [[ $ID != "fedora" ]] && ( echo "$pkg_list" | grep -qi "columnstore" ) ; then
+if [[ $ID != "fedora" && "${ID}${VERSION_ID}" != "centos10" ]] && ( echo "$pkg_list" | grep -qi "columnstore" ) ; then
   sudo mariadb --verbose -e "create database cs; \
     use cs; \
     create table cs.t_columnstore (a int, b char(8)) engine=Columnstore; \


### PR DESCRIPTION
Workaround for
```
ERROR 2026 (HY000) at line 1: TLS/SSL error: unexpected eof while reading
```

during
```
+ sudo mariadb --verbose -e 'create database cs;     use cs;     create table cs.t_columnstore (a int, b char(8)) engine=Columnstore;     insert into cs.t_columnstore select seq, concat('\''val'\'',seq) from seq_1_to_10;     select * from cs.t_columnstore'
```

until https://jira.mariadb.org/browse/MCOL-5825 is sorted out.

