### PR TITLE
Use NAS to transfer potentially large log files in f_msan_build.

### DIFF
--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -335,20 +335,8 @@ f_msan_build.addStep(
         doStepIf=hasFailed,
     )
 )
-f_msan_build.addStep(
-    steps.DirectoryUpload(
-        name="save mysqld log files",
-        compress="bz2",
-        alwaysRun=True,
-        workersrc="./buildbot/logs/",
-        masterdest=util.Interpolate(
-            "/srv/buildbot/packages/"
-            + "%(prop:tarbuildnum)s"
-            + "/logs/"
-            + "%(prop:buildername)s"
-        ),
-    )
-)
+f_msan_build.addStep(saveLogs())
+
 f_msan_build.addStep(
     steps.ShellCommand(
         name="cleanup", command="rm -r * .* 2> /dev/null || true", alwaysRun=True


### PR DESCRIPTION
Using DirectoryUpload can block the master in certain situations where the transfer is slow or the files are large. While in this blocked state, the master cannot respond to Crossbar heartbeats and will be disconnected. This results in an unrecoverable error that requires a master restart.