### PR TITLE
MDBF-1058: ignore github skip ci directives

### DIFF
--- a/master-web/master.cfg
+++ b/master-web/master.cfg
@@ -91,6 +91,7 @@ c["www"]["change_hook_dialects"] = {
         "secret": config["private"]["gh_secret"],
         "strict": True,
         "pullrequest_ref": "head",
+        "skips": [],
     }
 }
 


### PR DESCRIPTION
There are enabled by default[1], however interfere without our protected branch status of buildbot.

[1] https://docs.buildbot.net/current/manual/configuration/wwwhooks.html#github-hook