### PR TITLE
MDBF-1062 - macos cleanup previous build artifacts

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -862,6 +862,13 @@ f_aix.addStep(
 ## f_macos
 def get_macos_factory(compile_only=False):
     f_macos = util.BuildFactory()
+    f_macos.addStep(
+        steps.ShellCommand(
+            name="cleanup-previous-build",
+            command="rm -r * .*i ./packages/* ./buildbot_logs/* /System/Volumes/Data/cores/* 2> /dev/null || true",
+            alwaysRun=True,
+        )
+    )
     f_macos.addStep(getSourceTarball())
     f_macos.addStep(
         steps.ShellCommand(
@@ -975,7 +982,7 @@ def get_macos_factory(compile_only=False):
         )
     f_macos.addStep(
         steps.ShellCommand(
-            name="cleanup",
+            name="cleanup-current-build",
             command="rm -r * .*i ./packages/* ./buildbot_logs/* /System/Volumes/Data/cores/* 2> /dev/null || true",
             alwaysRun=True,
         )


### PR DESCRIPTION
If the connection is lost in a non-clean fashion then:
- current run:  the build dir won't be cleaned
- next run:  will fail and perform the cleanup as a last step.
- third run:  will run as expected (starting with an empty build dir)
