### PR TITLE
MDBF-1040: wget and wget 2 behaves differently

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -252,9 +252,9 @@ deb_setup_mariadb_mirror() {
   #//TEMP it's probably better to install the last stable release here...?
   mirror_url="https://deb.mariadb.org/$branch"
   archive_url="https://archive.mariadb.org/mariadb-$branch/repo"
-  if wget -q --spider "$mirror_url/$dist_name/dists/$version_name"; then
+  if wget -q --method=HEAD "$mirror_url/$dist_name/dists/$version_name"; then
     baseurl="$mirror_url"
-  elif wget -q --spider "$archive_url/$dist_name/dists/$version_name"; then
+  elif wget -q --method=HEAD "$archive_url/$dist_name/dists/$version_name"; then
     baseurl="$archive_url"
   else
     # the correct way of handling this would be to not even start the check
@@ -288,9 +288,9 @@ rpm_setup_mariadb_mirror() {
   #//TEMP it's probably better to install the last stable release here...?
   mirror_url="https://rpm.mariadb.org/$branch/$arch"
   archive_url="https://archive.mariadb.org/mariadb-$branch/yum/$arch"
-  if wget -q --spider "$mirror_url"; then
+  if wget -q --method=HEAD "$mirror_url"; then
     baseurl="$mirror_url"
-  elif wget -q --spider "$archive_url"; then
+  elif wget -q --method=HEAD "$archive_url"; then
     baseurl="$archive_url"
   else
     # the correct way of handling this would be to not even start the check


### PR DESCRIPTION
See:
```console
❯ wget --version
GNU Wget 1.25.0 built on linux-musl.
❯ wget --spider --server-response https://rpm.mariadb.org/10.10/fedora40-aarch64; echo $?
[..]
8
❯ wget --version
GNU Wget2 2.2.0 - multithreaded metalink/file/website downloader
❯ wget --spider --server-response https://rpm.mariadb.org/10.10/fedora40-aarch64; echo $?
[..]
0
```

This change makes behavior the same for both versions.

# Template selection

Please go the the `Preview` tab and select the appropriate sub-template:

* [Adding Worker Machine](?expand=1&template=add_worker.md)
* [Adding a New Build](?expand=1&template=add_build.md)
