### PR TITLE
MDBF-1074 - EOL 10.5

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -480,11 +480,7 @@ def addGaleraTests(factory, mtrDbPool):
 
 
 def addS3Tests(factory, mtrDbPool):
-    runS3 = (
-        lambda props: hasS3(props)
-        and props.hasProperty("compile_step_completed")
-        and "10.5" not in str(props.getProperty("master_branch"))
-    )
+    runS3 = lambda props: hasS3(props) and props.hasProperty("compile_step_completed")
     factory.addStep(
         steps.MasterShellCommand(
             name="Create minio S3 bucket",

--- a/constants.py
+++ b/constants.py
@@ -6,7 +6,6 @@ DEVELOPMENT_BRANCH = "11.3"
 
 # Used to trigger the appropriate main branch
 BRANCHES_MAIN = [
-    "10.5",
     "10.6",
     "10.11",
     "11.0",
@@ -101,7 +100,7 @@ RELEASE_BRANCHES = ["bb-*-release", "preview-*"]
 # Maximum supported branch is the one where the default distro MariaDB package major version <= branch
 # For example, if Debian 10 has MariaDB 10.3 by default, we don't support MariaDB 10.2 on it.
 SUPPORTED_PLATFORMS = {}
-SUPPORTED_PLATFORMS["10.5"] = [
+SUPPORTED_PLATFORMS["10.6"] = [
     "aarch64-centos-stream9",
     "aarch64-debian-11",
     "aarch64-macos",
@@ -111,6 +110,7 @@ SUPPORTED_PLATFORMS["10.5"] = [
     "aarch64-rhel-9",
     "aarch64-ubuntu-2004",
     "aarch64-ubuntu-2004-debug",
+    "aarch64-ubuntu-2204",
     "amd64-centos-7-bintar",
     "amd64-centos-stream9",
     "amd64-debian-11",
@@ -119,6 +119,7 @@ SUPPORTED_PLATFORMS["10.5"] = [
     "amd64-debian-12-rocksdb",
     "amd64-fedora-40-valgrind",
     "amd64-freebsd-14",
+    "amd64-msan-clang-20",
     "amd64-openeuler-2403",
     "amd64-rhel-7",
     "amd64-rhel-8",
@@ -128,6 +129,7 @@ SUPPORTED_PLATFORMS["10.5"] = [
     "amd64-ubuntu-2004",
     "amd64-ubuntu-2004-debug",
     "amd64-ubuntu-2004-fulltest",
+    "amd64-ubuntu-2204",
     "amd64-ubuntu-2204-debug-ps",
     "amd64-ubuntu-2204-icc",
     "amd64-ubuntu-2404-clang18-asan",
@@ -140,23 +142,15 @@ SUPPORTED_PLATFORMS["10.5"] = [
     "ppc64le-ubuntu-2004",
     "ppc64le-ubuntu-2004-debug",
     "ppc64le-ubuntu-2004-without-server",
+    "ppc64le-ubuntu-2204",
     "s390x-rhel-8",
     "s390x-rhel-9",
     "s390x-ubuntu-2004",
     "s390x-ubuntu-2004-debug",
-    "x86-debian-12-fulltest",
-    "x86-debian-12-fulltest-debug",
-]
-
-SUPPORTED_PLATFORMS["10.6"] = SUPPORTED_PLATFORMS["10.5"].copy()
-
-SUPPORTED_PLATFORMS["10.6"] += [
-    "aarch64-ubuntu-2204",
-    "amd64-msan-clang-20",
-    "amd64-ubuntu-2204",
-    "ppc64le-ubuntu-2204",
     "s390x-ubuntu-2204",
     "x86-debian-12",
+    "x86-debian-12-fulltest",
+    "x86-debian-12-fulltest-debug",
 ]
 
 SUPPORTED_PLATFORMS["10.9"] = SUPPORTED_PLATFORMS["10.6"].copy()

--- a/master-docker-nonstandard-2/master.cfg
+++ b/master-docker-nonstandard-2/master.cfg
@@ -491,9 +491,8 @@ class TestConfig:
 # Define a function to add test steps to a factory
 def add_test_steps(factory: BuildFactory, test_configs: Iterable[TestConfig]):
     def run_vault(step: BuildStep) -> bool:
-        return all(
-            item not in str(step.getProperty("master_branch"))
-            for item in ["10.5", "10.6"]
+        # Vault tests are not present in server versions <= 10.6, so we skip them for that version
+        return "10.6" not in str(step.getProperty("master_branch")
         )
 
     for test_config in test_configs:

--- a/master-web/templates/grid_view/grid.jade
+++ b/master-web/templates/grid_view/grid.jade
@@ -13,8 +13,6 @@
             ul
               li
                 | Grid View for main branches:
-                a(href="#grid?branch=10.5") 10.5
-                | ,
                 a(href="#grid?branch=10.6") 10.6
                 | ,
                 a(href="#grid?branch=10.11") 10.11

--- a/master-web/templates/home.jade
+++ b/master-web/templates/home.jade
@@ -13,8 +13,6 @@
         ul
           li
             | The Grid Display (
-            a(href="#grid?branch=10.5") 10.5
-            | ,
             a(href="#grid?branch=10.6") 10.6
             | ,
             a(href="#grid?branch=10.11") 10.11

--- a/scripts/aix-build-and-test.sh
+++ b/scripts/aix-build-and-test.sh
@@ -84,8 +84,8 @@ rpl.rpl_xa_empty_transaction : NDEV-30222
 rpl.rpl_row_img_sequence_noblob : NDEV-30222
 main.mysql_client_test : mysqltest: At line 27: exec of '/home/buildbot/aix/build/build/tests/mysql_client_test - possibly LIBPATH related
 EOF
-  case "${1:-mariadb-10.5.10}" in
-	  mariadb-10.[56].*)
+  case "${1:-mariadb-10.6}" in
+	  mariadb-10.6.*)
 		  echo "innodb.log_buffer_size : Marko request" >> ../unstable-tests
 		  ;;
   esac

--- a/utils.py
+++ b/utils.py
@@ -486,7 +486,7 @@ def hasDockerLibrary(step: BuildStep) -> bool:
     builder_name = step.getProperty("buildername")
 
     # from https://github.com/MariaDB/mariadb-docker/blob/next/update.sh#L7-L15
-    if fnmatch.fnmatch(branch, "10.[56]"):
+    if fnmatch.fnmatch(branch, "10.6"):
         dockerbase = "ubuntu-2004-deb-autobake"
     elif fnmatch.fnmatch(branch, "10.11"):
         dockerbase = "ubuntu-2204-deb-autobake"
@@ -494,7 +494,7 @@ def hasDockerLibrary(step: BuildStep) -> bool:
         dockerbase = "ubuntu-2404-deb-autobake"
 
     # UBI images
-    if branch != "10.5" and builder_name.endswith("amd64-rhel-9-rpm-autobake"):
+    if builder_name.endswith("amd64-rhel-9-rpm-autobake"):
         return True
 
     # We only build on the above autobakes for all architectures
@@ -502,8 +502,6 @@ def hasDockerLibrary(step: BuildStep) -> bool:
 
 
 def filterBranch(step: BuildStep) -> str:
-    if "10.5" in step.getProperty("branch"):
-        return False
     if "10.6" in step.getProperty("branch"):
         return False
     return True


### PR DESCRIPTION
This patch is targeted for buildbot release v1.0.7 I know I had an attempt to cover it in
https://github.com/MariaDB/buildbot/pull/756

but I don't like getting merge conflicts on constants.py. so it's better to separate the concerns a bit,
remove 10.5 and then handle any platform deprecation / addition.
