### PR TITLE
MDBF 995 - buildbot-worker not in EPEL, install with pip

### DIFF
--- a/.github/workflows/bbw_build_container_rhel.yml
+++ b/.github/workflows/bbw_build_container_rhel.yml
@@ -55,7 +55,7 @@ jobs:
             nogalera: false
             runner: ubuntu-24.04
 
-          - dockerfile: rhel.Dockerfile
+          - dockerfile: rhel.Dockerfile pip.Dockerfile
             image: ubi10
             tag: rhel10
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x


### PR DESCRIPTION
Install buildbot-worker from pip
