### PR TITLE
MDBF-995 – Enable More Architectures for Install/Upgrade on AlmaLinux/RockyLinux

### DIFF
--- a/os_info.yaml
+++ b/os_info.yaml
@@ -179,7 +179,6 @@ rockylinux-8:
   arch:
     - amd64
     - aarch64
-    - ppc64le
   type: rpm
   install_only: True
 rockylinux-9:


### PR DESCRIPTION
We are distributing aarch64 and ppc64le packages for AlmaLinux and Rocky Linux via the mirror. For example, see: https://mirror.mariadb.org/yum/10.11/

Although these are technically RHEL packages, it's sensible to be cautious. The prudent approach is to test installs and upgrades for these architectures as well.

