### PR TITLE
MDBF-1076: Create MSAN Debug builder (for aarch64)

### DIFF
--- a/.github/workflows/build-debian.msan-based.yml
+++ b/.github/workflows/build-debian.msan-based.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         include:
           - image: debian:12
-            platforms: linux/amd64
+            platforms: linux/amd64, linux/arm64/v8
             branch: 10.11
             tag: debian12-msan-clang-20
             clang_version: 20

--- a/ci_build_images/rr.Dockerfile
+++ b/ci_build_images/rr.Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update \
       cmake \
       curl \
       g++ \
-      g++-multilib \
       gdb \
       libcapnp-dev \
       libzstd-dev \
@@ -41,7 +40,7 @@ RUN apt-get update \
     && rm master.zip \
     && mkdir -p build \
     && cd build \
-    && cmake -DCMAKE_PREFIX=/usr ../rr-master \
+    && cmake -Ddisable32bit=ON -DCMAKE_PREFIX=/usr ../rr-master \
     && cmake --build . --parallel 12 \
     && cmake --install . --prefix /tmp/install/usr \
     && apt-get purge -y \
@@ -50,7 +49,6 @@ RUN apt-get update \
       cmake \
       curl \
       g++ \
-      g++-multilib \
       gdb \
       libcapnp-dev \
       libzstd-dev \


### PR DESCRIPTION
Container prep work for new builder (and a general aarch64 rr capability)

On aarch64 g++-multilib isn't a package. The requirement for this package was to produce 32bit RR replay capability.

I don't think we've needed this capability so we can just remove this.