### PR TITLE
MDBF-1077 centos/fedora images to include aio and uring

### DIFF
--- a/ci_build_images/centos.Dockerfile
+++ b/ci_build_images/centos.Dockerfile
@@ -72,6 +72,7 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     eigen3-devel \
     flex \
     galera-4 \
+    libaio-devel \
     libcurl-devel \
     libevent-devel \
     libffi-devel \

--- a/ci_build_images/fedora.Dockerfile
+++ b/ci_build_images/fedora.Dockerfile
@@ -39,6 +39,7 @@ RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf \
     java-1.8.0-openjdk-devel \
     java-1.8.0-openjdk \
     jemalloc-devel \
+    libaio-devel \
     libcurl-devel \
     libevent-devel \
     libffi-devel \

--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -604,7 +604,7 @@ check_upgraded_versions() {
     # The adjustments should be done to .cmp files, and removed after the release
     #
 
-    # Remove after Q4 2024 release
+    # Remove after Q3 2025 release (MDEV-36234)
     sed -i '/libaio.so/d;/liburing.so/d' ./reqs-*.cmp
     sed -i '/libaio.so/d;/liburing.so/d' ./ldd-*.cmp
     sed -i '/lsof/d' ./reqs-*.cmp


### PR DESCRIPTION
Note in bash_lib the MDEV-36234 reference for when both uring and aio became part of the dependencies (if available, hence aio only in RHEL7) and updated the expected change date.

Other containers had the dependency already.

