### PR TITLE
MDBF-1060 - Fedora 40 is EOL - remove release builders

### DIFF
--- a/.github/workflows/build-fedora-based.yml
+++ b/.github/workflows/build-fedora-based.yml
@@ -26,10 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: fedora:40
-            platforms: linux/amd64, linux/arm64/v8
-            nogalera: false
-
           - image: fedora:41
             platforms: linux/amd64, linux/arm64/v8
             nogalera: true

--- a/constants.py
+++ b/constants.py
@@ -170,7 +170,6 @@ SUPPORTED_PLATFORMS["10.10"] += SUPPORTED_PLATFORMS["10.9"]
 SUPPORTED_PLATFORMS["10.11"] = [
     "aarch64-centos-stream10",
     "aarch64-debian-12",
-    "aarch64-fedora-40",
     "aarch64-fedora-41",
     "aarch64-rhel-10",
     "aarch64-ubuntu-2404",
@@ -178,7 +177,6 @@ SUPPORTED_PLATFORMS["10.11"] = [
     "amd64-debian-12",
     "amd64-debian-12-deb-autobake-migration",
     "amd64-debian-12-debug-embedded",
-    "amd64-fedora-40",
     "amd64-fedora-41",
     "amd64-opensuse-1506",
     "amd64-rhel-10",

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -96,15 +96,6 @@ debian-sid:
     - ppc64le
     - x86
   type: deb
-fedora-40:
-  image_tag: fedora40
-  tags:
-    - release_packages
-  version_name: 40
-  arch:
-    - amd64
-    - aarch64
-  type: rpm
 fedora-41:
   image_tag: fedora41
   tags:


### PR DESCRIPTION
[2/4] patch in the series.
Merge after https://github.com/MariaDB/buildbot/pull/774