### PR TITLE
MDBF-1079 Same container name between dev-prod

### DIFF
--- a/configuration/builders/base.py
+++ b/configuration/builders/base.py
@@ -1,3 +1,4 @@
+import os
 from typing import Callable, Iterable
 
 from buildbot.plugins import util
@@ -78,6 +79,7 @@ class BaseBuilder:
         # Step Pre-Processing
         active_steps = processor_set_docker_runtime_environment(
             builder_name=self.name,
+            environment=os.environ["ENVIRON"],
             active_steps=active_steps,
         )
 

--- a/configuration/steps/processors.py
+++ b/configuration/steps/processors.py
@@ -221,7 +221,7 @@ def processor_worker_cleanup(
 
 
 def processor_set_docker_runtime_environment(
-    builder_name: str, active_steps: list[BaseStep]
+    builder_name: str, active_steps: list[BaseStep], environment: str
 ) -> None:
     """Set the Docker runtime environment for InContainer steps.
     This function updates the Docker environment for all InContainer steps in the
@@ -235,5 +235,7 @@ def processor_set_docker_runtime_environment(
     for step in active_steps:
         if isinstance(step, InContainer):
             step.docker_environment._container_name = builder_name
+            if environment == "DEV":
+                step.docker_environment._container_name = f"dev_{builder_name}"
 
     return active_steps


### PR DESCRIPTION
When a build runs on the same host both in dev and prod the container name is the same and one will delete the resources of the other and vice-versa Example: https://buildbot.dev.mariadb.org/#/builders/572/builds/7

```
docker: Error response from daemon: Conflict. The container name "/amd64-rhel-9-rpm-autobake-migration" is already in use by container "3f0c43e92d0dfb79fe988db0e24ce005708ac6972f6b1b05270a84b89ce7bb41". You have to remove (or rename) that container to be able to reuse that name.
```
where the running container is from buildbot.mariadb.org

The fix is to prepend the dev containers with dev_

