### PR TITLE
MDBF-1086 - gal-amd64-rhel-7 missing cpack -> cpack3 symlink

### DIFF
--- a/ci_build_images/rhel7.Dockerfile
+++ b/ci_build_images/rhel7.Dockerfile
@@ -76,6 +76,7 @@ RUN yum -y upgrade \
      # USE CMAKE 3
      && yum -y remove cmake \
      && ln -sf /usr/bin/cmake3 /usr/bin/cmake \
+     && ln -sf /usr/bin/cpack3 /usr/bin/cpack \
      && curl -sL "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_$(uname -m)" >/usr/local/bin/dumb-init \
      && chmod +x /usr/local/bin/dumb-init \
      # Upgrade pip


### PR DESCRIPTION
Create cpack -> cpack3 symlink
```
[root@5f79c6a59763 buildbot]# source /etc/os-release
[root@5f79c6a59763 buildbot]# echo $VERSION
7.9 (Maipo)
[root@5f79c6a59763 buildbot]# cpack
bash: cpack: command not found
[root@5f79c6a59763 buildbot]# cpack3 --version
cpack3 version 3.17.5

CMake suite maintained and supported by Kitware (kitware.com/cmake).
[root@5f79c6a59763 buildbot]# ln -sf /usr/bin/cpack3 /usr/bin/cpack
[root@5f79c6a59763 buildbot]# cpack --version
cpack3 version 3.17.5

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```