### PR TITLE
s390x-bbw1 host was upgraded from EOL 2004 to 2404

### DIFF
--- a/master-private.cfg-sample
+++ b/master-private.cfg-sample
@@ -90,7 +90,7 @@ private["docker_workers"]= {
     "ns-x64-bbw5-docker":"tcp://IP_address:port", # bg-bbw5
     "ns-x64-bbw6-docker":"tcp://IP_address:port", # monty-bbw1
     "intel-bbw1-docker":"tcp://IP_address:port",
-    "s390x-bbw1-docker":"tcp://IP_address:port", # ibm-s390x-ubuntu20.04
+    "s390x-bbw1-docker":"tcp://IP_address:port", # ibm-s390x-ubuntu2404-03
     "s390x-bbw2-docker":"tcp://IP_address:port", # ibm-s390x-sles15
     "s390x-bbw3-docker":"tcp://IP_address:port", # ibm-s390x-rhel8
     "s390x-bbw4-docker":"tcp://IP_address:port", # ibm-s390x-ubuntu22.04
@@ -102,7 +102,7 @@ private["docker_workers"]= {
 }
 
 private["worker_name_mapping"] = {
-    "s390x-bbw1": "ibm-s390x-ubuntu20.04",
+    "s390x-bbw1": "ibm-s390x-ubuntu2404-03",
     "s390x-bbw2": "ibm-s390x-sles15",
     "s390x-bbw3": "ibm-s390x-rhel8",
     "s390x-bbw4": "ibm-s390x-ubuntu22.04",


### PR DESCRIPTION
Will handle file changes manually on both environments. 
Builds are scheduled based on host load and the data is retrieved from Zabbix based on the following mapping `private_config["private"]["worker_name_mapping"][worker_prefix]` 

s390x master restart is required.
