### PR TITLE
Enable workflow concurrency

### DIFF
--- a/.github/workflows/bbm_build_container.yml
+++ b/.github/workflows/bbm_build_container.yml
@@ -12,6 +12,10 @@ on:
       - "Dockerfile"
       - .github/workflows/bbm_build_container.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/bbm_deploy.yml
+++ b/.github/workflows/bbm_deploy.yml
@@ -41,6 +41,10 @@ on:
       - "validate_master_cfg.sh"
       - "worker_locks.yaml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   check:
     runs-on: ubuntu-22.04

--- a/.github/workflows/bbw_build_container_rhel.yml
+++ b/.github/workflows/bbw_build_container_rhel.yml
@@ -23,6 +23,10 @@ on:
       - 'ci_build_images/rhel7.Dockerfile'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build:
     runs-on: ${{ matrix.runner || 'ubuntu-22.04' }}

--- a/.github/workflows/build-bintar.yml
+++ b/.github/workflows/build-bintar.yml
@@ -22,6 +22,10 @@ on:
       - .github/workflows/bbw_build_container_template.yml
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/build-centos.pip-based.yml
+++ b/.github/workflows/build-centos.pip-based.yml
@@ -23,6 +23,10 @@ on:
 
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/build-container-release.yml
+++ b/.github/workflows/build-container-release.yml
@@ -18,6 +18,10 @@ on:
       - .github/workflows/bbw_build_container_template.yml
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/build-debian-based.yml
+++ b/.github/workflows/build-debian-based.yml
@@ -25,6 +25,10 @@ on:
 
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/build-debian.aocc-based.yml
+++ b/.github/workflows/build-debian.aocc-based.yml
@@ -22,6 +22,10 @@ on:
       - .github/workflows/bbw_build_container_template.yml
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/build-debian.jepsen-based.yml
+++ b/.github/workflows/build-debian.jepsen-based.yml
@@ -22,6 +22,10 @@ on:
       - .github/workflows/bbw_build_container_template.yml
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/build-debian.msan-based.yml
+++ b/.github/workflows/build-debian.msan-based.yml
@@ -26,6 +26,10 @@ on:
       - .github/workflows/bbw_build_container_template.yml
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/build-fedora-based.yml
+++ b/.github/workflows/build-fedora-based.yml
@@ -20,6 +20,10 @@ on:
       - .github/workflows/bbw_build_container_template.yml
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/build-opensuse.pip-based.yml
+++ b/.github/workflows/build-opensuse.pip-based.yml
@@ -24,6 +24,10 @@ on:
       - .github/workflows/bbw_build_container_template.yml
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/build-sles.pip-based.yml
+++ b/.github/workflows/build-sles.pip-based.yml
@@ -25,6 +25,10 @@ on:
 
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/build-srpm.yml
+++ b/.github/workflows/build-srpm.yml
@@ -13,6 +13,10 @@ on:
       - 'ci_build_images/srpm.Dockerfile'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   push:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,6 +10,10 @@ on:
       - configuration/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
[skip ci]

Running with skip CI to avoid mass runs.

**Expected behaviour:**
- On pull requests: new pushes cancel active workflow runs
- On main branches: only one job is allowed to run at a time.
  - If job A is running and job B is queued, pushing job C while A is still running will cancel B and queue C.

Concurrency is controlled using groups. A group is formed by a unique key based on the workflow name and Git reference (`refs/`).
