### PR TITLE
MDBF-188: we need more crossbar logs

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
     network_mode: host
     volumes:
       - ./crossbar/dev/config.json:/node/.crossbar/config.json
+    command: --loglevel=debug
     logging:
       driver: journald
       options:


### PR DESCRIPTION
Sporadicaly, the master-web process disconnect from crossbar and brings buildbot web interface down. In order to investigate this problem, we need more logs. We are not sure that it's related to crossbar but that's an option.

Error is on master-web:
| Guru meditation! We have been disconnected from wamp server