### PR TITLE
MDBF-1086 - gal-amd64-rhel-7 missing ctest -> ctest3 symlink

### DIFF
--- a/ci_build_images/rhel7.Dockerfile
+++ b/ci_build_images/rhel7.Dockerfile
@@ -77,6 +77,7 @@ RUN yum -y upgrade \
      && yum -y remove cmake \
      && ln -sf /usr/bin/cmake3 /usr/bin/cmake \
      && ln -sf /usr/bin/cpack3 /usr/bin/cpack \
+     && ln -sf /usr/bin/ctest3 /usr/bin/ctest \
      && curl -sL "https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_$(uname -m)" >/usr/local/bin/dumb-init \
      && chmod +x /usr/local/bin/dumb-init \
      # Upgrade pip


### PR DESCRIPTION
sorry - should have seen this at the same time.

Create ctest -> ctest3 symlink
```
[buildbot@6f5dbfde1c6a ~]$ source /etc/os-release
[buildbot@6f5dbfde1c6a ~]$ echo $VERSION
7.9 (Maipo)
[buildbot@6f5dbfde1c6a ~]$ ctest
bash: ctest: command not found
[buildbot@6f5dbfde1c6a ~]$ ctest3 --version
ctest3 version 3.17.5

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

# Template selection

Please go the the `Preview` tab and select the appropriate sub-template:

* [Adding Worker Machine](?expand=1&template=add_worker.md)
* [Adding a New Build](?expand=1&template=add_build.md)
