### PR TITLE
openeuler 24.03-lts-sp2 (bump from release)

### DIFF
--- a/.github/workflows/build-centos.pip-based.yml
+++ b/.github/workflows/build-centos.pip-based.yml
@@ -43,7 +43,7 @@ jobs:
             runner: ubuntu-24.04
             nogalera: false
 
-          - image: docker.io/openeuler/openeuler:24.03-lts
+          - image: docker.io/openeuler/openeuler:24.03-lts-sp2
             platforms: linux/amd64, linux/arm64/v8
             tag: openeuler2403
             nogalera: false


### PR DESCRIPTION
openEuler 25.03 has probably EOL already.

openEuler 24.03 LTS SP1 has EOL in Dec 2026.

Bumping because galera needs a cmake macro
that was removed in their cmake package
but it fixed in the latest service pack.

ref: https://github.com/MariaDB/galera/pull/37

This is a rather blind bump to see if it installs.