### PR TITLE
Galera (revert old) + JOBS env variable for RPM and Deb build

### DIFF
--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -300,7 +300,7 @@ f_deb_build.addStep(
             ),
         ],
         workdir="build",
-        env={"DEBIAN": "1"},
+        env={"DEBIAN": "1", "JOBS": util.Property("jobs")},
     )
 )
 f_deb_build.addStep(dpkgDeb())
@@ -355,6 +355,7 @@ f_rpm_build.addStep(
     steps.ShellCommand(
         name="build packages",
         command=["bash", "-xc", "./scripts/build.sh -p"],
+        env={"JOBS": util.Property("jobs")},
         workdir="build",
     )
 )

--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -288,20 +288,6 @@ f_deb_build.addStep(
         submodules=True,
     )
 )
-# Work around while waiting for https://github.com/MariaDB/galera/pull/13
-f_deb_build.addStep(
-    steps.ShellCommand(
-        name="correct build script to use CC/CXX",
-        command=[
-            "sed",
-            "-i",
-            "-e",
-            "/unset/d",
-            "./scripts/build.sh",
-        ],
-        workdir="build",
-    )
-)
 f_deb_build.addStep(
     steps.ShellCommand(
         name="build packages",


### PR DESCRIPTION
The debian builds in scripts/build.sh already use JOBS
```
DEB_BUILD_OPTIONS="version=$GALERA_VER revno=$GALERA_REV parallel=$JOBS ...
```

This add it to RPMs also in anticipation being used there too.

https://github.com/MariaDB/galera/pull/37#discussion_r2181146501