### PR TITLE
Windows - PermissionDenied: (mysqld.exe:FileInfo)

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -137,7 +137,7 @@ f_windows = util.BuildFactory()
 f_windows.addStep(
     steps.ShellCommand(
         name="stop_processes",
-        command="taskkill /im mariadb-test.exe /im mariadbd.exe /f || ver>nul",
+        command="taskkill /im mariadb-test.exe /im mariadbd.exe /im mysqld.exe /f || ver>nul",
         alwaysRun=True,
     )
 )
@@ -309,7 +309,7 @@ f_windows_msi = util.BuildFactory()
 f_windows_msi.addStep(
     steps.ShellCommand(
         name="stop_processes",
-        command="taskkill /im mariadb-test.exe /im mariadbd.exe /f || ver>nul",
+        command="taskkill /im mariadb-test.exe /im mariadbd.exe /im mysqld.exe /f || ver>nul",
         alwaysRun=True,
     )
 )


### PR DESCRIPTION
Failing MTR tests can result in stuck processes, which may cause the cleanup step to fail. 
Subsequent builds may also fail if they run in a non-empty build directory. 
Add mysqld to the `stop_processes` step.
