### PR TITLE
Restrict buldsets API usage without query params

### DIFF
--- a/docker-compose/nginx/templates/bb.conf.template
+++ b/docker-compose/nginx/templates/bb.conf.template
@@ -54,6 +54,13 @@ server {
 		proxy_pass http://127.0.0.1:8010;
 	}
 
+	location = /api/v2/buildsets {
+		if ($args = "") {
+			return 403 "Not allowed.\n";
+		}
+		proxy_pass http://127.0.0.1:8010;
+	}
+
   # disallow bots
 	location = /robots.txt {
 		add_header Content-Type text/plain;


### PR DESCRIPTION
Related to https://github.com/MariaDB/buildbot/pull/794
