### PR TITLE
Add vhost info in log format

### DIFF
--- a/docker-compose/nginx/nginx.conf
+++ b/docker-compose/nginx/nginx.conf
@@ -12,7 +12,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    log_format  main  '$remote_addr - $http_host - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 


### PR DESCRIPTION
The vhost information helps understanding which vhost is connected to, this is also how logging in other nginx deployments is configured. See: https://gitlab.com/mariadb/sysadmin/-/commit/89e24cbd5557ad8dffcb98069493ce5ab2037abd#4d97535fdaa046f7967f4d5988eab8dbfa834960_0_12