### PR TITLE
MDBF-1091 ignore libaio1 on ldd minor upgrade tests

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -605,7 +605,7 @@ check_upgraded_versions() {
     #
 
     # Remove after Q3 2025 release (MDEV-36234)
-    sed -i '/libaio.so/d;/liburing.so/d' ./reqs-*.cmp
+    sed -i '/libaio.so/d;/liburing.so/d;/libaio1/d' ./reqs-*.cmp
     sed -i '/libaio.so/d;/liburing.so/d' ./ldd-*.cmp
     sed -i '/lsof/d' ./reqs-*.cmp
 


### PR DESCRIPTION
libaio1 added as a dependency legitimately in MDEV-36234. It's normal to see differences during ldd tests between the packages on mirror and what is currently build.

To avoid false-positives better ignore the differences generated by the extra dependency, until Q3 2025 release. After the community server release, we can remove the workaround.
