### PR TITLE
Fix galera jobs

### DIFF
--- a/master-galera/master.cfg
+++ b/master-galera/master.cfg
@@ -300,7 +300,7 @@ f_deb_build.addStep(
             ),
         ],
         workdir="build",
-        env={"DEBIAN": "1", "JOBS": util.Property("jobs")},
+        env={"DEBIAN": "1", "JOBS": util.Interpolate("%(prop:jobs)s")},
     )
 )
 f_deb_build.addStep(dpkgDeb())
@@ -355,7 +355,7 @@ f_rpm_build.addStep(
     steps.ShellCommand(
         name="build packages",
         command=["bash", "-xc", "./scripts/build.sh -p"],
-        env={"JOBS": util.Property("jobs")},
+        env={"JOBS": util.Interpolate("%(prop:jobs)s")},
         workdir="build",
     )
 )


### PR DESCRIPTION
https://buildbot.dev.mariadb.org/#/builders/675/builds/3
```
buildbot.process.remotecommand.RemoteException: b'builtins.RuntimeError': 'env' values must be strings or lists; key 'JOBS' is incorrect Traceback (most recent call last): File "/usr/local/lib/python3.11/site-packages/twisted/internet/defer.py", line 216, in maybeDeferred result = f(*args, **kwargs) File "/usr/local/lib/python3.11/site-packages/buildbot_worker/commands/shell.py", line 27, in start c = runprocess.RunProcess( File "/usr/local/lib/python3.11/site-packages/buildbot_worker/runprocess.py", line 394, in __init__ raise RuntimeError( builtins.RuntimeError: 'env' values must be strings or lists; key 'JOBS' is incorrect
```

Fix: https://buildbot.dev.mariadb.org/#/builders/675/builds/4
```
 environment:
  BUILDMASTER=100.64.101.1
  BUILDMASTER_PORT=10004
  HOME=/home/buildbot
  HOSTNAME=3dce66cb65e2
  JOBS=7
  ```