### PR TITLE
docker library: git checkout -f

### DIFF
--- a/scripts/docker-library-build.sh
+++ b/scripts/docker-library-build.sh
@@ -8,7 +8,7 @@ umask 0002
 if [ -d mariadb-docker ]; then
   pushd mariadb-docker
   git fetch
-  git checkout origin/next
+  git checkout -f origin/next
   popd
 else
   git clone --branch next https://github.com/MariaDB/mariadb-docker.git


### PR DESCRIPTION
To get past:

error: Your local changes to the following files would be overwritten by checkout:
	11.6-ubi/MariaDB.repo
	11.7-ubi/MariaDB.repo

e.g.
https://buildbot.mariadb.org/#/builders/311/builds/30522
