### PR TITLE
Docker library (fix 20.04 EOL) + RHEL10 base

### DIFF
--- a/scripts/docker-library-build.sh
+++ b/scripts/docker-library-build.sh
@@ -55,7 +55,7 @@ case "${buildername#*ubuntu-}" in
   2204-deb-autobake)
     pkgver=ubu2204
     ;;
-  *-rhel-9-rpm-autobake)
+  *-rhel-*-rpm-autobake)
     ubi=-ubi
     # first arch only
     arches=( linux/amd64 )

--- a/scripts/docker-library-manifest.sh
+++ b/scripts/docker-library-manifest.sh
@@ -23,7 +23,7 @@ else
 fi
 
 ubi=
-if [[ "$buildername" = *-rhel-9-rpm-autobake ]]; then
+if [[ "$buildername" = *-rhel-*-rpm-autobake ]]; then
     ubi=-ubi
     master_branch=${master_branch}-ubi
 fi

--- a/utils.py
+++ b/utils.py
@@ -486,7 +486,7 @@ def hasDockerLibrary(step: BuildStep) -> bool:
     builder_name = step.getProperty("buildername")
 
     # from https://github.com/MariaDB/mariadb-docker/blob/next/update.sh#L7-L15
-    if fnmatch.fnmatch(branch, "10.11]") or fnmatch.fnmatch(branch, "10.6]"):
+    if fnmatch.fnmatch(branch, "10.11") or fnmatch.fnmatch(branch, "10.6"):
         dockerbase = "ubuntu-2204-deb-autobake"
     else:
         dockerbase = "ubuntu-2404-deb-autobake"

--- a/utils.py
+++ b/utils.py
@@ -493,7 +493,10 @@ def hasDockerLibrary(step: BuildStep) -> bool:
 
     # UBI images
     if builder_name.endswith("amd64-rhel-9-rpm-autobake"):
-        return True
+        return fnmatch.fnmatch(branch, "10.*") or fnmatch.fnmatch(branch, "11.*")
+
+    if builder_name.endswith("amd64-rhel-10-rpm-autobake"):
+        return not (fnmatch.fnmatch(branch, "10.*") or fnmatch.fnmatch(branch, "11.*"))
 
     # We only build on the above autobakes for all architectures
     return builder_name.endswith(dockerbase)


### PR DESCRIPTION
Adjust the triggers for Docker Library:
* 10.11 /10.6 are being triggered incorrectly.
* Add RHEL10 as base for MariaDB-12+


Supported by https://github.com/MariaDB/mariadb-docker/pull/653