### PR TITLE
hadolint dislikes source

### DIFF
--- a/ci_build_images/fedora.Dockerfile
+++ b/ci_build_images/fedora.Dockerfile
@@ -12,7 +12,7 @@ ARG INSTALL_VALGRIND
 RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf \
     && dnf -y upgrade \
     && dnf -y install 'dnf-command(builddep)' 'dnf-command(config-manager)' \
-    && source /etc/os-release \
+    && . /etc/os-release \
     && ARCH=$(rpm --query --queryformat='%{ARCH}' rpm) \
     && if [ "$ARCH" = x86_64 ]; then ARCH=amd64 ; fi \
     && dnf config-manager --add-repo https://ci.mariadb.org/galera/mariadb-4.x-latest-gal-"${ARCH}"-fedora-"${VERSION_ID}".repo \

--- a/ci_build_images/opensuse.Dockerfile
+++ b/ci_build_images/opensuse.Dockerfile
@@ -12,7 +12,7 @@ COPY --chmod=755 mariadb_zypper_expect /
 # Install updates and required packages
 RUN zypper update -y \
     && zypper install -y -t pattern devel_basis \
-    && source /etc/os-release \
+    && . /etc/os-release \
     && VERSION_ID=${VERSION_ID%.*}0${VERSION_ID#*.} \
     && ARCH=$(rpm --query --queryformat='%{ARCH}' zypper) \
     && if [ "$ARCH" = x86_64 ]; then ARCH=amd64 ; fi \

--- a/ci_build_images/pip.Dockerfile
+++ b/ci_build_images/pip.Dockerfile
@@ -13,7 +13,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs >/tmp/rustup-init.
         *) bash /tmp/rustup-init.sh -y --profile=minimal ;; \
     esac \
     && rm -f /tmp/rustup-init.sh \
-    && source "$HOME/.cargo/env" \
+    && . "$HOME/.cargo/env" \
     # Disable until opensuse/sles dont break: && pip3 install --no-cache-dir -U pip \
     && curl -so /root/requirements.txt \
        https://raw.githubusercontent.com/MariaDB/buildbot/main/ci_build_images/requirements.txt \

--- a/ci_build_images/sles.Dockerfile
+++ b/ci_build_images/sles.Dockerfile
@@ -12,7 +12,7 @@ COPY --chmod=755 mariadb_zypper_expect /
 # Install updates and required packages
 RUN zypper -n update \
     && zypper -n install -t pattern devel_basis \
-    && source /etc/os-release \
+    && . /etc/os-release \
     && VERSION_ID=${VERSION_ID%%.*} \
     && ARCH=$(rpm --query --queryformat='%{ARCH}' zypper) \
     && if [ "$ARCH" = x86_64 ]; then ARCH=amd64 ; fi \


### PR DESCRIPTION
found in  #3301, assuming its a new hadolint version.

ci_build_images/fedora.Dockerfile:12 SC3046 warning: In POSIX sh, 'source' in place of '.' is undefined.

So used a . instead.