### PR TITLE
MDBF-1097 - Increase nginx burst value for buildsets location

### DIFF
--- a/docker-compose/nginx/templates/bb.conf.template
+++ b/docker-compose/nginx/templates/bb.conf.template
@@ -59,6 +59,7 @@ server {
 			return 403 "Not allowed.\n";
 		}
 		proxy_pass http://127.0.0.1:8010;
+		limit_req zone=bb burst=40 nodelay;
 	}
 
   # disallow bots


### PR DESCRIPTION
When expanding triggers under a build, requests to the /buildsets api will be sent proportional to the number of triggered builds. These requests are most probably sent async by javascript, thus arriving in very short intervals so the burst directive becomes effective.

