### PR TITLE
MDBF-811 - galera-4 CI build package is available  on all supported distros

### DIFF
--- a/.github/workflows/bbw_build_container_rhel.yml
+++ b/.github/workflows/bbw_build_container_rhel.yml
@@ -59,7 +59,7 @@ jobs:
             image: ubi10
             tag: rhel10
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-            nogalera: true
+            nogalera: false
             runner: ubuntu-24.04
     env:
       MAIN_BRANCH: false

--- a/.github/workflows/build-centos.pip-based.yml
+++ b/.github/workflows/build-centos.pip-based.yml
@@ -34,7 +34,7 @@ jobs:
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
             tag: centosstream10
             runner: ubuntu-24.04
-            nogalera: true
+            nogalera: false
             extradockerfile: pip.Dockerfile
 
           - image: quay.io/centos/centos:stream9

--- a/.github/workflows/build-debian-based.yml
+++ b/.github/workflows/build-debian-based.yml
@@ -53,13 +53,13 @@ jobs:
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
             branch: 11.8
             tag: debian13
-            nogalera: true
+            nogalera: false
 
           - image: debian:trixie
             platforms: linux/386
             branch: 11.8
             tag: debian13-386
-            nogalera: true
+            nogalera: false
 
           - image: debian:sid
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
@@ -90,7 +90,7 @@ jobs:
           - image: ubuntu:25.04
             platforms: linux/amd64, linux/arm64/v8
             branch: 11.4
-            nogalera: true
+            nogalera: false
 
     uses: ./.github/workflows/bbw_build_container_template.yml
     with:

--- a/.github/workflows/build-fedora-based.yml
+++ b/.github/workflows/build-fedora-based.yml
@@ -28,11 +28,11 @@ jobs:
         include:
           - image: fedora:41
             platforms: linux/amd64, linux/arm64/v8
-            nogalera: true
+            nogalera: false
 
           - image: fedora:42
             platforms: linux/amd64, linux/arm64/v8
-            nogalera: true
+            nogalera: false
 
           - image: fedora:40
             platforms: linux/amd64

--- a/.github/workflows/build-fedora-based.yml
+++ b/.github/workflows/build-fedora-based.yml
@@ -38,7 +38,7 @@ jobs:
             platforms: linux/amd64
             tag: fedora40-valgrind
             install_valgrind: "true"
-            nogalera: false
+            nogalera: true
 
     uses: ./.github/workflows/bbw_build_container_template.yml
     with:

--- a/.github/workflows/build-sles.pip-based.yml
+++ b/.github/workflows/build-sles.pip-based.yml
@@ -39,7 +39,7 @@ jobs:
           - image: registry.suse.com/bci/bci-base:15.7
             platforms: linux/amd64, linux/s390x
             tag: sles1507
-            nogalera: true
+            nogalera: false
 
     uses: ./.github/workflows/bbw_build_container_template.yml
     with:

--- a/ci_build_images/fedora.Dockerfile
+++ b/ci_build_images/fedora.Dockerfile
@@ -15,7 +15,7 @@ RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf \
     && . /etc/os-release \
     && ARCH=$(rpm --query --queryformat='%{ARCH}' rpm) \
     && if [ "$ARCH" = x86_64 ]; then ARCH=amd64 ; fi \
-    && dnf config-manager --add-repo https://ci.mariadb.org/galera/mariadb-4.x-latest-gal-"${ARCH}"-fedora-"${VERSION_ID}".repo \
+    && dnf config-manager addrepo --from-repofile https://ci.mariadb.org/galera/mariadb-4.x-latest-gal-"${ARCH}"-fedora-"${VERSION_ID}".repo \
     && dnf -y builddep mariadb-server \
     && dnf -y install \
     @development-tools \


### PR DESCRIPTION
From https://buildbot.mariadb.org/#/grid?branch=mariadb-4.x

Fedora:
- arm fedora 41: https://buildbot.mariadb.org/#/builders/855/builds/41
- amd fedora 41: https://buildbot.mariadb.org/#/builders/851/builds/41
- arm fedora 42: https://buildbot.mariadb.org/#/builders/934/builds/7
- amd fedora 42: https://buildbot.mariadb.org/#/builders/935/builds/7

RHEL:
- amd rhel 10: https://buildbot.mariadb.org/#/builders/930/builds/7
- arm rhe 10: https://buildbot.mariadb.org/#/builders/936/builds/7
- ppc rhel 10: https://buildbot.mariadb.org/#/builders/927/builds/9
- s390x rhel 10: https://buildbot.mariadb.org/#/builders/938/builds/8

CENTOS:
- amd stream 10: https://buildbot.mariadb.org/#/builders/865/builds/32
- arm stream 10: https://buildbot.mariadb.org/#/builders/863/builds/33
- ppc stream 10: https://buildbot.mariadb.org/#/builders/864/builds/57

SLES:
- amd sles 15 sp7: https://buildbot.mariadb.org/#/builders/929/builds/7
- s390x sles 15 sp7:  https://buildbot.mariadb.org/#/builders/928/builds/7

DEBIAN:
- amd trixie: https://buildbot.mariadb.org/#/builders/933/builds/7
- arm trixie: https://buildbot.mariadb.org/#/builders/931/builds/7
- ppc trixie: https://buildbot.mariadb.org/#/builders/932/builds/7 
- 386 trixie:  https://buildbot.mariadb.org/#/builders/937/builds/7

