### PR TITLE
MDBF-1097: Improve ratelimit on BB

### DIFF
--- a/docker-compose/nginx/templates/bb.conf.template
+++ b/docker-compose/nginx/templates/bb.conf.template
@@ -14,8 +14,7 @@ server {
 	}
 }
 
-# Default rate limited zone, with 30 requests per minute
-limit_req_zone $request_uri zone=bb:10m rate=30r/m;
+limit_req_zone $binary_remote_addr zone=mylimit:10m rate=30r/s;
 client_max_body_size 10M;
 
 server {
@@ -32,9 +31,8 @@ server {
 	proxy_set_header X-Forwarded-Server  $host;
 	proxy_set_header X-Forwarded-Host  $host;
 
-	# Use default zone for rate limiting, allow burst of 10 requests with
-	# no delay
-	limit_req zone=bb burst=10 nodelay;
+	# rate limiting
+	limit_req zone=mylimit burst=80 nodelay;
 
 	location / {
 		proxy_pass http://127.0.0.1:8010;


### PR DESCRIPTION
I am not sure that this is the correct approach. The request_uri reqlimit is useless it would probably block legit users. The binary_remote_addr makes much more sense but it's probably still to agressive.

How to test:
1/ deploy on DEV
2/ on DEV: `sudo journalctl -f | grep " limiting "`
3/ visit https://buildbot.dev.mariadb.org/#/builders/110/builds/150 and expand immediately (as fast as possible) the second trigger --> we should be good.

But this ratelimit can be triggered if you open in tabs a sufficient amount of BB pages with lots of js calls. This probably also depend of your Internet connexion.