### PR TITLE
MDBF-1099 Temporarly Ignore mariadb-test-data dropping deps

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -604,8 +604,8 @@ check_upgraded_versions() {
     # The adjustments should be done to .cmp files, and removed after the release
     #
 
-    # Remove after Q3 2025 release (MDEV-36234)
-    sed -i '/libaio.so/d;/liburing.so/d;/libaio1/d' ./reqs-*.cmp
+    # Remove after Q3 2025 release (MDEV-36234), (MDBF-1099)
+    sed -i '/libaio.so/d;/liburing.so/d;/libaio1/d;/libc6/d;/libpam0g/d' ./reqs-*.cmp
     sed -i '/libaio.so/d;/liburing.so/d' ./ldd-*.cmp
     sed -i '/lsof/d' ./reqs-*.cmp
 


### PR DESCRIPTION
Ubuntu-2204-deb-autobake-minor-upgrade-all (and 2404)

 -----------------
 mariadb-test-data:
-  Depends: libc6
-  Depends: libpam0g