### PR TITLE
MDBF-1101 - RPM build package 1200s timeout is too low

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -680,6 +680,7 @@ def getRpmAutobakeFactory():
             ],
             env={"CCACHE_DIR": "/mnt/ccache"},
             description="make package",
+            timeout=3600,
         )
     )
     # list rpm contents


### PR DESCRIPTION
1200 seconds timeout seems to be too low, building an rpm MariaDB-test package often is killed because of this timeout. rpmbuild apparently goes over all files in the package, and mysql-test has a lot of files.
