### PR TITLE
docker-library - give ubi a mariadb repo name

### DIFF
--- a/scripts/docker-library-build.sh
+++ b/scripts/docker-library-build.sh
@@ -126,6 +126,7 @@ build() {
     curl "${artifacts_url}/galera/mariadb-4.x-latest-gal-${bbarch}-${galera_distro_noarch}".repo \
       -o "$repo"
     curl "${artifacts_url}/$tarbuildnum/${bbarch}-${builder_noarch}"/MariaDB.repo \
+      | sed 's/\[.*/[mariadb]/' \
       >> "$repo"
     args=( --build-arg MARIADB_VERSION="$mariadb_version" )
   else


### PR DESCRIPTION
In https://github.com/MariaDB/mariadb-docker/commit/076f286fe6290cc8a529e7c9f61b861edc3b4459 the mariadb repo is disabled as the releasever=10.1 isn't something on our mirrors.

However to disable the repo, the repo name 'mariadb' needs to exist.

https://buildbot.mariadb.org/#/builders/311/builds/31027
```
+ microdnf install --enablerepo=epel-testing --disablerepo=mariadb --releasever=10.1 -y procps-ng zstd xz jemalloc pwgen pv util-linux-core
error: repo mariadb not found
Error: building at STEP
```