### PR TITLE
MDBF-1108 Decomission ns-x64-bbw4 machine

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -197,43 +197,42 @@ for w_name in ["ppc64le-osuosl-bbw"]:
     )
 
 ## x64-bbw-docker
-for w_name in ["ns-x64-bbw", "apexis-bbw"]:
-    worker_ids = list(range(1, 5))
-    jobs = 7
-    if "apexis" in w_name:
-        worker_ids = [3]
-        jobs = 10
-    for i in worker_ids:
+x64_bbw_docker = {
+    "ns-x64-bbw": [{"id": 1, "jobs": 7}, {"id": 2, "jobs": 7}, {"id": 3, "jobs": 7}],
+    "apexis-bbw": [{"id": 3, "jobs": 10}],
+}
+for w_name, w_ids in x64_bbw_docker.items():
+    for w in w_ids:
         addWorker(
             w_name,
-            i,
+            w["id"],
             "aocc-debian-11",
             os.environ["CONTAINER_REGISTRY_URL"] + "debian11-aocc",
-            jobs=jobs,
+            jobs=w["jobs"],
             save_packages=False,
         )
         addWorker(
             w_name,
-            i,
+            w["id"],
             "asan-ubuntu-2404",
             os.environ["CONTAINER_REGISTRY_URL"] + "ubuntu24.04",
-            jobs=jobs,
+            jobs=w["jobs"],
             save_packages=False,
         )
         addWorker(
             w_name,
-            i,
+            w["id"],
             "icc-ubuntu-2204",
             os.environ["CONTAINER_REGISTRY_URL"] + "ubuntu22.04-icc",
-            jobs=jobs,
+            jobs=w["jobs"],
             save_packages=False,
         )
         addWorker(
             w_name,
-            i,
+            w["id"],
             "ubuntu-2204",
             os.environ["CONTAINER_REGISTRY_URL"] + "ubuntu22.04",
-            jobs=jobs,
+            jobs=w["jobs"],
             save_packages=True,
         )
 
@@ -307,7 +306,7 @@ addWorker(
     save_packages=True,
 )
 
-for w in (6,7):
+for w in (6, 7):
     addWorker(
         "s390x-bbw",
         w,

--- a/master-private.cfg-sample
+++ b/master-private.cfg-sample
@@ -87,7 +87,6 @@ private["docker_workers"]= {
     "ns-x64-bbw1-docker":"tcp://IP_address:port", # bg-bbw1
     "ns-x64-bbw2-docker":"tcp://IP_address:port", # bg-bbw2
     "ns-x64-bbw3-docker":"tcp://IP_address:port", # bg-bbw3
-    "ns-x64-bbw4-docker":"tcp://IP_address:port", # bg-bbw4
     "ns-x64-bbw5-docker":"tcp://IP_address:port", # bg-bbw5
     "ns-x64-bbw6-docker":"tcp://IP_address:port", # monty-bbw1
     "intel-bbw1-docker":"tcp://IP_address:port",

--- a/worker_locks.yaml
+++ b/worker_locks.yaml
@@ -26,7 +26,6 @@ apexis-bbw3-docker: 6
 ns-x64-bbw1-docker: 3
 ns-x64-bbw2-docker: 2
 ns-x64-bbw3-docker: 2
-ns-x64-bbw4-docker: 2
 s390x-bbw1-docker: 1
 s390x-bbw2-docker: 1
 s390x-bbw3-docker: 1


### PR DESCRIPTION
This runner has a RAM problem (sysadmin naming is bg-bbw4-x64).
Remove it from Buildbot.