### PR TITLE
MDBF-1103 rpm upgrade from distro default

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -297,8 +297,7 @@ for os_i in OS_INFO:
                 builder_name_autobake + "-minor-upgrade-columnstore"
             )
             BUILDERS_UPGRADE.append(builder_name_autobake + "-major-upgrade")
-            if "deb" in OS_INFO[os_i]["type"]:
-                BUILDERS_UPGRADE.append(builder_name_autobake + "-distro-upgrade")
+            BUILDERS_UPGRADE.append(builder_name_autobake + "-distro-upgrade")
 
 BUILDERS_GALERA = list(
     map(lambda x: "gal-" + "-".join(x.split("-")[:3]), BUILDERS_AUTOBAKE)


### PR DESCRIPTION
Introduced `alternative_names_package_list`
as a method to define how are the
client and server packages called in different distro repos.

The same steps are followed as in a major upgrade i.e.:
- install previous (distro) packages
- create data structures
- remove the packages
- install current packages
- verify the data structures
- verify engines old/new - see workaround
