### PR TITLE
MDBF-1109 - is_scheduled_event is a boolean

### DIFF
--- a/.github/workflows/bbw_build_container_template.yml
+++ b/.github/workflows/bbw_build_container_template.yml
@@ -208,7 +208,7 @@ jobs:
 
 
       - name: ghcr.io - move tag to production
-        if: ${{ env.DEPLOY_IMAGES == 'true' && (inputs.is_scheduled_event == 'true' || env.MAIN_BRANCH == 'true') }}
+        if: ${{ env.DEPLOY_IMAGES == 'true' && (inputs.is_scheduled_event || env.MAIN_BRANCH == 'true') }}
         run: |
           msg="Update tag (dev_${{ env.IMG }} --> ${{ env.IMG }})"
           line="${msg//?/=}"
@@ -236,7 +236,7 @@ jobs:
             docker://quay.io/mariadb-foundation/${{ env.REPO }}:dev_${{ env.IMG }}
 
       - name: quay.io - move tag to production
-        if: ${{ env.DEPLOY_IMAGES == 'true' && (inputs.is_scheduled_event == 'true' || env.MAIN_BRANCH == 'true')}}
+        if: ${{ env.DEPLOY_IMAGES == 'true' && (inputs.is_scheduled_event || env.MAIN_BRANCH == 'true')}}
         run: |
           msg="Update tag (dev_${{ env.IMG }} --> ${{ env.IMG }})"
           line="${msg//?/=}"

--- a/.github/workflows/build-workflow-dispatcher.yml
+++ b/.github/workflows/build-workflow-dispatcher.yml
@@ -2,7 +2,7 @@ name: Dispatch all build container images workflows
 
 on:
   schedule:
-    - cron: '0 12 5 * *' # FIXME: Adjust after first run
+    - cron: '0 3 8 * *' # FIXME: Adjust after first run
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
[skip ci]

On the last run of the workflow on schedule, the tag was not deployed to production because `is_scheduled_event` is not a string and should be handled as a boolean.

Modify the schedule to 08.09 for a re-try.
