### PR TITLE
MDBF-1115 create UBASAN Debug builder

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -181,6 +181,7 @@ SUPPORTED_PLATFORMS["10.11"] = [
     "amd64-rhel-10",
     "amd64-sles-1506",
     "amd64-ubasan-clang-20",
+    "amd64-ubasan-clang-20-debug",
     "amd64-ubuntu-2404",
     "ppc64le-centos-stream10",
     "ppc64le-rhel-10",

--- a/master-migration/master.cfg
+++ b/master-migration/master.cfg
@@ -272,9 +272,8 @@ def ubasan_builder(name: str, debug: bool) -> GenericBuilder:
     )
 
 
-#for builder in ["amd64-ubasan-clang-20", "amd64-ubasan-clang-20-debug"]:
-builder = "amd64-ubasan-clang-20"
-c["builders"].append(ubasan_builder(name=builder, debug=builder.endswith("debug")))
+for builder in ["amd64-ubasan-clang-20", "amd64-ubasan-clang-20-debug"]:
+    c["builders"].append(ubasan_builder(name=builder, debug=builder.endswith("debug")))
 
 
 


### PR DESCRIPTION
Previous open issues under Debug mode UBSAN/ASAN
have been resolved or that have UBSAN filters
in place.

With MDEV-37626 showing how serious looking
bugs can be missed without a debug builder
on UBASAN, lets readd this.

The largest cause of test failures MDEV-37502 is resolved in 10.11.