### PR TITLE
MDBF-1122 - SLES 15 SP 7 default mariadb is 11.8

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -202,9 +202,7 @@ SUPPORTED_PLATFORMS["11.3"] = SUPPORTED_PLATFORMS["11.2"].copy()
 SUPPORTED_PLATFORMS["11.4"] = SUPPORTED_PLATFORMS["11.3"].copy()
 SUPPORTED_PLATFORMS["11.4"] += [
     "aarch64-ubuntu-2504",
-    "amd64-sles-1507",
     "amd64-ubuntu-2504",
-    "s390x-sles-1507",
 ]
 
 SUPPORTED_PLATFORMS["11.5"] = SUPPORTED_PLATFORMS["11.4"].copy()
@@ -222,6 +220,8 @@ SUPPORTED_PLATFORMS["11.8"] += [
     "amd64-debian-13",
     "ppc64le-debian-13",
     "x86-debian-13",
+    "amd64-sles-1507",
+    "s390x-sles-1507",
 ]
 SUPPORTED_PLATFORMS["12.0"] = SUPPORTED_PLATFORMS["11.8"].copy()
 SUPPORTED_PLATFORMS["12.1"] = SUPPORTED_PLATFORMS["12.0"].copy()


### PR DESCRIPTION
sles 15 sp7 offered mariadb 11.4 when we configured the builder in June 2025 but upgraded to 11.8 one month after

```
2ec249e0ebbb:/home/buildbot # rpm -q --changelog mariadb
* Wed Jul 23 2025 antonio.teixeira@suse.com
- Update to 11.8.2:
    https://mariadb.com/kb/en/mariadb-11-8-2-release-notes/
    https://mariadb.com/kb/en/mariadb-11-8-2-changelog/
- Refresh gcc13-fix.patch
- Update list of skipped tests

* Tue Apr 08 2025 antonio.teixeira@suse.com
- Update to 11.4.5:
```