### PR TITLE
MDEV-37680: Fedora mysql-selinux dependency change and 2025 Q3 changes removal

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -669,11 +669,6 @@ check_upgraded_versions() {
     # The adjustments should be done to .cmp files, and removed after the release
     #
 
-    # Remove after Q3 2025 release (MDEV-36234), (MDBF-1099)
-    sed -i '/libaio.so/d;/liburing.so/d;/libaio1/d;/libc6/d;/libpam0g/d' ./reqs-*.cmp
-    sed -i '/libaio.so/d;/liburing.so/d' ./ldd-*.cmp
-    sed -i '/lsof/d' ./reqs-*.cmp
-
     # Remove after Q4 2025 release (MDEV-37680) - fedora adds mysql-selinux module
     # dependency
     sed -i '/mysql-selinux/d;/rpmlib(RichDependencies)/d' ./reqs-*.cmp


### PR DESCRIPTION

masking of additional dependency.

(most likely, though haven't finished testing).]

tested with x file:
```
$ sed -i '/mysql-selinux/d;/rpmlib(RichDependencies)/d' x.req 
(base) 
/tmp/t 
$ grep selinux x.req
(base) 
/tmp/t 
$ grep Rich x.req
(base) 
```