### PR TITLE
MDBF-1126 - ppc64le-ubuntu-2204-debug - ENOSPC

### DIFF
--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -193,6 +193,7 @@ for w_name in ["ppc64le-osuosl-bbw"]:
         "ubuntu-2204-debug",
         os.environ["CONTAINER_REGISTRY_URL"] + "ubuntu22.04",
         jobs=30,
+        shm_size="40G",
         save_packages=True,
     )
 


### PR DESCRIPTION
Getting
```
2025-09-22 10:58:26 0 [ERROR] InnoDB: Cannot close '/dev/shm/var_auto_V20G/26/mysqld.2/data/ib_buffer_pool.incomplete': No space left on device
```

Builder runs on `ppc64le-osuosl-bbw1` where shm-size is currently 15G. Raised the value to eliminate ENOSPC occurances.

