### PR TITLE
Run columnstore upgrade on specified architectures only

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -303,12 +303,13 @@ for os_i in OS_INFO:
         if arch not in ["s390x", "x86"]:
             BUILDERS_INSTALL.append(builder_name_autobake + "-install")
             BUILDERS_UPGRADE.append(builder_name_autobake + "-minor-upgrade-all")
-            BUILDERS_UPGRADE.append(
-                builder_name_autobake + "-minor-upgrade-columnstore"
-            )
             BUILDERS_UPGRADE.append(builder_name_autobake + "-major-upgrade")
             BUILDERS_UPGRADE.append(builder_name_autobake + "-distro-upgrade")
 
+        if arch in ["amd64", "aarch64"]:
+            BUILDERS_UPGRADE.append(
+                builder_name_autobake + "-minor-upgrade-columnstore"
+            )
 BUILDERS_GALERA = list(
     map(lambda x: "gal-" + "-".join(x.split("-")[:3]), BUILDERS_AUTOBAKE)
 )

--- a/scripts/deb-upgrade.sh
+++ b/scripts/deb-upgrade.sh
@@ -79,11 +79,6 @@ case $test_mode in
     package_list=mariadb-server
     ;;
   columnstore)
-    get_packages_file_mirror
-    if ! grep columnstore Packages >/dev/null; then
-      bb_log_warn "Columnstore was not found in packages, the test will not be run"
-      exit
-    fi
     package_list="mariadb-server mariadb-plugin-columnstore"
     ;;
   *)

--- a/scripts/rpm-upgrade.sh
+++ b/scripts/rpm-upgrade.sh
@@ -57,11 +57,6 @@ case $test_mode in
     fi
     ;;
   columnstore)
-    package_list=$(rpm_repoquery)
-    if ! echo "$package_list" | grep -q columnstore-engine; then
-      bb_log_warn "Columnstore was not found in the released packages, the test will not be run"
-      exit
-    fi
     package_list="MariaDB-server MariaDB-columnstore-engine"
     alternative_names_package_list=$package_list
     ;;


### PR DESCRIPTION
This prevents a no-op on ppc64le

extracted out of #831 to get builder list one no-op builder shorter

two arches only:
https://github.com/MariaDB/server/blob/main/storage/columnstore/CMakeLists.txt#L54-L56
