### PR TITLE
MDBF-1156: Add Ubuntu 26.04 - ci_images add galera

### DIFF
--- a/.github/workflows/build-debian-based.yml
+++ b/.github/workflows/build-debian-based.yml
@@ -38,18 +38,18 @@ jobs:
         include:
           - image: debian:11
             platforms: linux/amd64, linux/arm64/v8
-            branch: 10.11
+            branch: 11.4
             nogalera: false
 
           - image: debian:12
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
-            branch: 10.11
+            branch: 11.4
             tag: debian12
             nogalera: false
 
           - image: debian:12
             platforms: linux/386
-            branch: 10.11
+            branch: 11.4
             tag: debian12-386
             nogalera: false
             dockerfile: 'debian.Dockerfile hashicorp.fragment.Dockerfile minio.fragment.Dockerfile'
@@ -68,25 +68,25 @@ jobs:
 
           - image: debian:sid
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
-            branch: 11.4
+            branch: 11.8
             nogalera: false
             deploy_on_schedule: true
 
           - image: debian:sid
             platforms: linux/386
-            branch: 11.4
+            branch: 11.8
             tag: debiansid-386
             nogalera: false
             deploy_on_schedule: true
 
           - image: ubuntu:22.04
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-            branch: 10.11
+            branch: 11.4
             nogalera: false
 
           - image: ubuntu:24.04
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-            branch: 10.11
+            branch: 11.4
             nogalera: false
 
           - image: ubuntu:25.04

--- a/.github/workflows/build-debian-based.yml
+++ b/.github/workflows/build-debian-based.yml
@@ -38,18 +38,18 @@ jobs:
         include:
           - image: debian:11
             platforms: linux/amd64, linux/arm64/v8
-            branch: 11.4
+            branch: 10.11
             nogalera: false
 
           - image: debian:12
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le
-            branch: 11.4
+            branch: 10.11
             tag: debian12
             nogalera: false
 
           - image: debian:12
             platforms: linux/386
-            branch: 11.4
+            branch: 10.11
             tag: debian12-386
             nogalera: false
             dockerfile: 'debian.Dockerfile hashicorp.fragment.Dockerfile minio.fragment.Dockerfile'
@@ -81,12 +81,12 @@ jobs:
 
           - image: ubuntu:22.04
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-            branch: 11.4
+            branch: 10.11
             nogalera: false
 
           - image: ubuntu:24.04
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
-            branch: 11.4
+            branch: 10.11
             nogalera: false
 
           - image: ubuntu:25.04

--- a/.github/workflows/build-debian-based.yml
+++ b/.github/workflows/build-debian-based.yml
@@ -102,13 +102,13 @@ jobs:
           - image: ubuntu:26.04
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
             branch: 11.8
-            nogalera: true
+            nogalera: false
 
           - image: ubuntu:26.04
             tag: ubuntu26.04-amd64v3
             platforms: linux/amd64
             branch: 11.8
-            nogalera: true
+            nogalera: false
             arch_variant: amd64v3
 
     uses: ./.github/workflows/bbw_build_container_template.yml

--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -69,12 +69,10 @@ RUN . /etc/os-release \
     iproute2 \
     iputils-ping \
     libasio-dev \
-    # bootstrapping libboost additions in below line for MDEV-35826. \
-    # to be removed after https://github.com/MariaDB/server/pull/2651 merge to 11.4 \
-    libboost-atomic-dev libboost-chrono-dev libboost-date-time-dev libboost-regex-dev libboost-system-dev libboost-thread-dev \
-    libboost-dev \
+    # Required by galera-4 builds on all architectures
     libboost-filesystem-dev \
     libboost-program-options-dev \
+    #--
     libbz2-dev \
     libdbi-perl \
     libeigen3-dev \

--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -50,6 +50,10 @@ RUN . /etc/os-release \
     && curl -skO "https://raw.githubusercontent.com/MariaDB/server/$MARIADB_BRANCH/debian/autobake-deb.sh" \
     && chmod a+x autobake-deb.sh \
     && AUTOBAKE_PREP_CONTROL_RULES_ONLY=1 ./autobake-deb.sh \
+    # Hack to force install ARM boost deps on older Debian/Ubuntu,
+    # needed for building and packaging ARM CS 23.10.x for MariaDB Server >= 11.4
+    && sed -Ei '/libboost-/ s/\[amd64\]/[amd64 arm64]/g' debian/control \
+    # --
     && mk-build-deps -r -i debian/control \
     -t 'apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends' \
     && apt-get -y build-dep -q mariadb-server \


### PR DESCRIPTION
With MDEV-38978 resolved, there is now mariadb-4.x galera packages for 26.04 in both dev and prod BB environments.

This adds galera to the bb-worker images.

Note the 26.04-amd64v3 image will gain an non-amd64v3 galera package for now. There currently isn't a
galera-amd64v3 builder and changes to
ci_build_images/debian.Dockerfile needs to happen to include the variant package.

Note: I did test building galera-4 using `./scripts/build -p` on the amd64v3 bb worker and it built and unit tested ok.