### PR TITLE
MDEV-30953: mariadb-server-galera package

### DIFF
--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -765,6 +765,12 @@ check_upgraded_versions() {
         fi
       ;;
     esac
+    # Remove after Q2 2026 release MDEV-30953 Add mariadb-server-galera package - 12.3+
+    sed -i -e '/^WSREP_/s/NOT INSTALLED/ACTIVE/g'  ./plugins-*.cmp
+    # mariadb-test now depends on mariadb-galera-server - and RPM had the
+    # second expression change.
+    sed -i -e 's/Depends: mariadb-server$/Depends: mariadb-server-galera/' \
+	   -e 's/MariaDB-common/MariaDB-server-galera/' ./reqs-*.cmp
 
     # Remove after Q4 2025 release - MDEV-37600 - 11.4 onwards
     sed -i '/auth_mysql_sha2.so/,/^\===/ { /^\===/!d; /auth_mysql_sha2.so/d }' ./ldd-*.cmp

--- a/scripts/bash_lib.sh
+++ b/scripts/bash_lib.sh
@@ -753,6 +753,12 @@ check_upgraded_versions() {
     # Remove after Q2 2026 release (MDEV-38913) - deb re-adds mtr pamv1 test module
     sed -i '/libc6/d;/libpam0g/d' ./reqs-*.cmp
 
+    # Remove after Q2 2026 release MDEV-30953 Add mariadb-server-galera package
+    # adds wsrep_info to mariadb-server-galera
+    gawk -i inplace '/^=== \/usr\/lib(64)?\/mysql\/plugin\/wsrep_info.so/ { skip=1; next }
+                     skip && /^\t/ { next }
+                     { skip=0; print }' ldd-*.cmp
+
     # Remove after Q4 2025 release (MDEV-37680) - fedora adds mysql-selinux module
     # dependency
     sed -i '/mysql-selinux/d;/rpmlib(RichDependencies)/d' ./reqs-*.cmp

--- a/scripts/deb-upgrade.sh
+++ b/scripts/deb-upgrade.sh
@@ -52,6 +52,14 @@ get_packages_file_mirror() {
   set +u
 }
 
+# This function updates package_list to include mariadb-server-galera
+# if available
+update_to_include_mariadb_server_galera() {
+  if grep -qi mariadb-server-galera Packages; then
+    package_list="${package_list} mariadb-server-galera"
+  fi
+}
+
 # Define the list of packages to install/upgrade
 case $test_mode in
   all)
@@ -76,12 +84,15 @@ case $test_mode in
     ;;
   deps)
     package_list="mariadb-server mariadb-client mariadb-common mariadb-test mysql-common libmysqlclient18"
+    update_to_include_mariadb_server_galera
     ;;
   server)
     package_list=mariadb-server
+    update_to_include_mariadb_server_galera
     ;;
   columnstore)
     package_list="mariadb-server mariadb-plugin-columnstore"
+    update_to_include_mariadb_server_galera
     ;;
   *)
     bb_log_err "unknown test mode: $test_mode"

--- a/scripts/rpm-upgrade.sh
+++ b/scripts/rpm-upgrade.sh
@@ -37,6 +37,15 @@ rpm_pkg_makecache
 
 rpm_setup_mariadb_mirror "$prev_major_version"
 
+
+# This function updates package_list to include MariaDB-server-galera
+# if available
+update_to_include_mariadb_server_galera() {
+  if [[ "$(rpm_repoquery)" =~ MariaDB-server-galera ]]; then
+    package_list="${package_list} MariaDB-server-galera"
+  fi
+}
+
 # Define the list of packages to install/upgrade
 case $test_mode in
   all)
@@ -49,6 +58,7 @@ case $test_mode in
     ;;
   server)
     package_list="MariaDB-server MariaDB-client"
+    update_to_include_mariadb_server_galera
     alternative_names_package_list=$package_list
     if [[ "$test_type" == "distro" ]]; then
       if [[ "$ID_LIKE" =~ ^suse.* ]]; then
@@ -60,6 +70,7 @@ case $test_mode in
     ;;
   columnstore)
     package_list="MariaDB-server MariaDB-columnstore-engine"
+    update_to_include_mariadb_server_galera
     alternative_names_package_list=$package_list
     ;;
   *)


### PR DESCRIPTION
The ldd differences need to account that
this is a new 12.3 package.

MDEV-30953, currently being prototyped on bb-12.3-MDEV-30953-mariadb-server-galera-pkgtest [ci](https://buildbot.mariadb.org/#/grid?branch=bb-12.3-MDEV-30953-mariadb-server-galera-pkgtest).

needs to normalise to expectations for https://buildbot.mariadb.org/#/builders/784/builds/1861/steps/4/logs/stdio
```
-=== /usr/lib/mysql/plugin/wsrep_info.so
-	/lib/ld-linux-aarch64.so.1 
-	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 
-	libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 
-	libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 
-	libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 
-	libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 
-	linux-vdso.so.1 
```

and
```
--- ./plugins.old.cmp	2026-03-13 03:51:08.520277534 +0000
+++ ./plugins.new.cmp	2026-03-13 03:51:08.516277442 +0000
@@ -69,8 +69,6 @@
 THREAD_POOL_STATS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
 THREAD_POOL_WAITS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
 USER_STATISTICS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
-WSREP_MEMBERSHIP	NOT INSTALLED	INFORMATION SCHEMA	wsrep_info.so	GPL
-WSREP_STATUS	NOT INSTALLED	INFORMATION SCHEMA	wsrep_info.so	GPL
 associative_array	ACTIVE	DATA TYPE	NULL	GPL
 binlog	ACTIVE	DAEMON	NULL	GPL
 ed25519	NOT INSTALLED	AUTHENTICATION	auth_ed25519.so	GPL
```

I haven't yet found rpm example. Other server bugs in Columnstore (that are reported) preventing this output to be visible.

Obvious for test env testing. But suggestions on better ways most welcome.