### PR TITLE
Fix centos-stream-9 container image build

### DIFF
--- a/ci_build_images/centos.Dockerfile
+++ b/ci_build_images/centos.Dockerfile
@@ -33,6 +33,9 @@ RUN dnf -y install 'dnf-command(config-manager)' \
     && case "$ID" in \
         "centos") \
           ID=centos-stream; \
+          if [ "$VERSION_ID" = "9" ]; then \
+            dnf module enable mariadb:11.8 -y; \
+          fi; \
           ;; \
         "openEuler") \
           ID=openeuler; \


### PR DESCRIPTION
I can't find why previous builds (January 2026) worked but now we need to enable the mariadb module.

```
bash-5.1# dnf module list mariadb
CentOS Stream 9 - AppStream
Name                                         Stream                                      Profiles                                                        Summary
mariadb                                      10.11                                       client, galera, server [d]                                      MariaDB Module
mariadb                                      11.8                                        client, galera, server [d]                                      MariaDB Module
```

```
dnf module enable mariadb:11.8 -y

bash-5.1# dnf repoquery --source mariadb-server
mariadb-11.8.5-1.module_el9+1304+6dbdc612.src.rpm
```