### PR TITLE
MDBF-1188: Enable SQLite3 ODBC tests in Connect engine

### DIFF
--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -83,6 +83,7 @@ RUN . /etc/os-release \
     libmecab-dev \
     libnet-ssleay-perl \
     libssl-dev \
+    libsqliteodbc \
     lsof \
     python3-dev \
     python3-setuptools \


### PR DESCRIPTION
The change will be picked up by [amd64-ubuntu-2204-fulltest](https://buildbot.mariadb.org/#/builders/913/builds/8119/steps/29/logs/stdio),

`libsqliteodbc` is required to run:
- connect.odbc_sqlite3_grant
- connect.odbc_sqlite3

Installation registers the driver in /etc/odbcinst.ini and will be automatically discovered by MariaDB Server