### PR TITLE
MDBF-1188: add JDBC CLASSPATH for Windows connect tests

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -150,6 +150,35 @@ F_WINDOWS_ENV_WITHOUT_TEMP = {
 
 F_WINDOWS_ENV_WITHOUT_TEMP.update(MTR_ENV)
 
+
+WINDOWS_TESTS = {
+    "nm": {"create_scripts": True},
+    "connect": {
+        "suites": ["connect"],
+        "mtr_env": {
+            **F_WINDOWS_ENV,
+            "CLASSPATH": (
+                r"C:\connectors\mariadb-java-client-3.5.8.jar;"
+                r"C:\connectors\mysql-connector-j-9.6.0.jar"
+            ),
+        },
+    },
+}
+
+
+def windows_tests_steps(factory, windows_tests_dict: dict):
+    for typ in windows_tests_dict:
+        addWinTests(
+            factory=factory,
+            mtr_test_type=typ,
+            mtr_env=windows_tests_dict[typ].get("mtr_env", F_WINDOWS_ENV),
+            mtr_additional_args=util.Property("mtr_additional_args", default=""),
+            mtr_step_db_pool=mtrDbPool,
+            mtr_suites=windows_tests_dict[typ].get("suites", ["default"]),
+            create_scripts=windows_tests_dict[typ].get("create_scripts", False),
+        )
+
+
 ## f_windows
 f_windows = util.BuildFactory()
 f_windows.addStep(
@@ -239,23 +268,8 @@ f_windows.addStep(
     )
 )
 
-windows_tests = {
-    "nm": {"create_scripts": True},
-    "connect": {
-        "suites": ["connect"],
-    },
-}
 
-for typ in windows_tests:
-    addWinTests(
-        f_windows,
-        mtr_test_type=typ,
-        mtr_env=F_WINDOWS_ENV,
-        mtr_additional_args=util.Property("mtr_additional_args", default=""),
-        mtr_step_db_pool=mtrDbPool,
-        mtr_suites=windows_tests[typ].get("suites", ["default"]),
-        create_scripts=windows_tests[typ].get("create_scripts", False),
-    )
+windows_tests_steps(f_windows, WINDOWS_TESTS)
 
 
 def windows_save_logs_step():
@@ -444,12 +458,6 @@ f_windows_msi.addStep(
         warningPattern=vsWarningPattern,
     )
 )
-windows_msi_tests = {
-    "nm": {"create_scripts": True},
-    "connect": {
-        "suites": ["connect"],
-    },
-}
 
 f_windows_msi.addStep(
     steps.ShellCommand(
@@ -481,17 +489,7 @@ for script in MSI_SCRIPTS:
         )
     )
 
-
-for typ in windows_msi_tests:
-    addWinTests(
-        f_windows_msi,
-        mtr_test_type=typ,
-        mtr_env=F_WINDOWS_ENV,
-        mtr_additional_args=util.Property("mtr_additional_args", default=""),
-        mtr_step_db_pool=mtrDbPool,
-        mtr_suites=windows_msi_tests[typ].get("suites", ["default"]),
-        create_scripts=windows_msi_tests[typ].get("create_scripts", False),
-    )
+windows_tests_steps(f_windows_msi, WINDOWS_TESTS)
 
 f_windows_msi.addStep(
     steps.ShellCommand(


### PR DESCRIPTION
Set CLASSPATH for Windows connect test jobs so connect.jdbc tests running through the JVM can locate the MariaDB and MySQL JDBC driver JARs.