### PR TITLE
MDBF-1196: C/ODBC Valgrind builder

### DIFF
--- a/configuration/builders/definitions/connectors/conodbc.py
+++ b/configuration/builders/definitions/connectors/conodbc.py
@@ -59,6 +59,7 @@ def generate_bintar_sqs(
     upload_packages_to_ci=True,
     get_source_from_git=False,
     with_asan_ubsan=False,
+    with_valgrind=False,
 ):
 
     source_sq = [
@@ -86,6 +87,7 @@ def generate_bintar_sqs(
                 package_platform_suffix=f"{ops}{version}",
                 jobs=util.Property("jobs"),
                 with_asan_ubsan=with_asan_ubsan,
+                with_valgrind=with_valgrind,
             ),
         ]
         + (
@@ -269,5 +271,19 @@ UBASAN_BUILDER = GenericBuilder(
         upload_packages_to_ci=False,
         with_asan_ubsan=True,
         get_source_from_git=True,
+    ),
+)
+
+VALGRIND_BUILDER = GenericBuilder(
+    name="codbc-ubuntu-26.04-valgrind",
+    sidecar=SIDECAR,
+    sequences=generate_bintar_sqs(
+        build_environment=docker_config(
+            image="ubuntu26.04",
+            artifacts_url=f"{os.environ['ARTIFACTS_URL']}/connector-odbc/",
+        ),
+        with_valgrind=True,
+        ops="ubuntu",
+        version="26.04",
     ),
 )

--- a/configuration/builders/sequences/connectors/conodbc.py
+++ b/configuration/builders/sequences/connectors/conodbc.py
@@ -8,7 +8,7 @@ from configuration.builders.infra.runtime import (
     InContainer,
 )
 from configuration.steps.base import StepOptions
-from configuration.steps.commands.base import URL, BashCommand
+from configuration.steps.commands.base import URL, BashCommand, BashScriptCommand
 from configuration.steps.commands.compile import MAKE, CompileCMakeCommand
 from configuration.steps.commands.configure import ConfigureMariaDBCMake
 from configuration.steps.commands.download import FetchTarball, GitInitFromCommit
@@ -670,6 +670,7 @@ def bintar(
     bintar_path: str,
     source_path: str,
     with_asan_ubsan=False,
+    with_valgrind=False,
 ):
     sequence = BuildSequence()
     env_vars = None
@@ -748,16 +749,46 @@ def bintar(
             docker_environment=config,
         ),
     )
+    test_command = BashCommand(
+        name="Test bintar - ODBC ctest",
+        workdir=PurePath(f"{bintar_path}/test"),
+        cmd='sed -i "s/localhost/$SIDECAR_HOST/" odbc.ini && export TEST_SERVER=$SIDECAR_HOST && ctest --output-on-failure',
+    )
+
+    if with_valgrind:
+        if any(x in package_platform_suffix for x in ["ubu", "deb"]):
+            command_install = InstallDEBPackages(
+                packages=["valgrind"],
+            )
+        else:
+            command_install = InstallRPMPackages(
+                packages=["valgrind"],
+            )
+        sequence.add_step(
+            InContainer(
+                ShellStep(
+                    command=command_install,
+                    options=StepOptions(
+                        description="Installing Valgrind",
+                        descriptionDone="Valgrind installed",
+                    ),
+                ),
+                docker_environment=config,
+                container_commit=True,
+            ),
+        )
+
+        test_command = BashScriptCommand(
+            script_name="valgrind.sh",
+            args=["'/odbc_*'"],
+            workdir=PurePath(f"{bintar_path}/test"),
+        )
 
     # For the bintar test, we use libmariadb previously built from the source tree
     sequence.add_step(
         InContainer(
             ShellStep(
-                command=BashCommand(
-                    name="Test bintar - ODBC ctest",
-                    workdir=PurePath(f"{bintar_path}/test"),
-                    cmd='sed -i "s/localhost/$SIDECAR_HOST/" odbc.ini && export TEST_SERVER=$SIDECAR_HOST && ctest --output-on-failure',
-                ),
+                command=test_command,
                 env_vars=[
                     ("TEST_SKIP_UNSTABLE_TESTS", "1"),
                     ("ODBCINI", "./odbc.ini"),

--- a/configuration/schedulers/connectors.py
+++ b/configuration/schedulers/connectors.py
@@ -40,7 +40,7 @@ CONODBC_SCHEDULERS = [
                 for builder in builders
             )
         ]
-        + [odbc_builders.UBASAN_BUILDER.name],
+        + [odbc_builders.UBASAN_BUILDER.name, odbc_builders.VALGRIND_BUILDER.name],
     ),
 ]
 

--- a/configuration/steps/commands/scripts/valgrind.sh
+++ b/configuration/steps/commands/scripts/valgrind.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+failed=0
+success_tests=()
+failed_tests=()
+programs=()
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <program-or-glob> [program-or-glob ...]" >&2
+  exit 2
+fi
+
+for arg in "$@"; do
+  if [[ "$arg" == *'*'* || "$arg" == *'?'* || "$arg" == *'['* ]]; then
+    while IFS= read -r match; do
+      programs+=("$match")
+    done < <(compgen -G "$arg")
+  else
+    programs+=("$arg")
+  fi
+done
+
+if [ "${#programs[@]}" -eq 0 ]; then
+  echo "No programs matched." >&2
+  exit 2
+fi
+
+for prog in "${programs[@]}"; do
+  if [ ! -e "$prog" ]; then
+    echo "WARNING: not found: $prog" >&2
+    continue
+  fi
+
+  if [ ! -x "$prog" ]; then
+    echo "WARNING: not executable: $prog" >&2
+    continue
+  fi
+
+  name="$(basename "$prog")"
+  log="valgrind-${name}.log"
+
+  echo "VALGRIND_BEGIN::$prog::log=$log"
+
+  valgrind \
+    --leak-check=full \
+    --show-leak-kinds=all \
+    --error-limit=no \
+    "$prog" \
+    2> >(tee "$log" >&2) || true
+
+  definite=$(awk '/definitely lost:/ {print $4}' "$log" | tail -1 | tr -d ',')
+  indirect=$(awk '/indirectly lost:/ {print $4}' "$log" | tail -1 | tr -d ',')
+  possible=$(awk '/possibly lost:/ {print $4}' "$log" | tail -1 | tr -d ',')
+
+  definite=${definite:-0}
+  indirect=${indirect:-0}
+  possible=${possible:-0}
+
+  if [ "$definite" -ne 0 ] || [ "$indirect" -ne 0 ] || [ "$possible" -ne 0 ]; then
+    failed=1
+    failed_tests+=("$prog :: definite=$definite indirect=$indirect possible=$possible")
+    echo "VALGRIND_FAILURE::$prog::definite=$definite::indirect=$indirect::possible=$possible"
+  else
+    success_tests+=("$prog :: no definite/indirect/possible leaks")
+    echo "VALGRIND_SUCCESS::$prog"
+  fi
+done
+
+echo
+echo "================ VALGRIND FINAL SUMMARY ================"
+echo "Successful programs:"
+if [ "${#success_tests[@]}" -gt 0 ]; then
+  printf "%s\n" "${success_tests[@]}"
+else
+  echo "(none)"
+fi
+
+echo
+echo "Failed programs:"
+if [ "${#failed_tests[@]}" -gt 0 ]; then
+  printf "%s\n" "${failed_tests[@]}"
+else
+  echo "(none)"
+fi
+echo "========================================================"
+
+exit "$failed"

--- a/master-migration/master.cfg
+++ b/master-migration/master.cfg
@@ -318,6 +318,15 @@ c["builders"].append(
     )
 )
 
+# Connector/ODBC Valgrind builder
+c["builders"].append(
+    conc_odbc_builders.VALGRIND_BUILDER.get_config(
+        workers=CONNECTORS_WORKERS_BY_ARCH.get("amd64", []),
+        tags=["connector", "odbc", "valgrind"],
+        jobs=1,
+    )
+)
+
 ## ------------------------------------------------------------------- ##
 ##                             REPORTERS                               ##
 ## ------------------------------------------------------------------- ##


### PR DESCRIPTION
Since a runtime valgrind installation is not a time or configuration issue, 
i prefer to install it at runtime to avoid maintaining a separate docker image.

The script should be generic enough and work well
for a program or list of programs that should run through valgrind. 
It fails for non-zero bytes definitely/indirectly/possibly leaks.