### PR TITLE
Docker Library: 12.3 release based on ubuntu26.04

### DIFF
--- a/scripts/docker-library-build.sh
+++ b/scripts/docker-library-build.sh
@@ -49,11 +49,9 @@ ubi=
 arches=( linux/amd64 linux/arm64/v8 linux/ppc64le linux/s390x  )
 
 case "${buildername#*ubuntu-}" in
-  2404-deb-autobake)
-    pkgver=ubu2404
-    ;;
-  2204-deb-autobake)
-    pkgver=ubu2204
+  *-deb-autobake*)
+    pkgver=${buildername#*ubuntu-}
+    pkgver=ubu${pkgver%-deb-autobake*}
     ;;
   *-rhel-*-rpm-autobake)
     ubi=-ubi

--- a/utils.py
+++ b/utils.py
@@ -504,8 +504,10 @@ def hasDockerLibrary(step: BuildStep) -> bool:
     # from https://github.com/MariaDB/mariadb-docker/blob/next/update.sh#L7-L15
     if fnmatch.fnmatch(branch, "10.11") or fnmatch.fnmatch(branch, "10.6"):
         dockerbase = "ubuntu-2204-deb-autobake"
-    else:
+    elif fnmatch.fnmatch(branch, "11.*") or fnmatch.fnmatch(branch, "12.2"):
         dockerbase = "ubuntu-2404-deb-autobake"
+    else:
+        dockerbase = "ubuntu-2604-deb-autobake"
 
     # UBI images
     if builder_name.endswith("amd64-rhel-9-rpm-autobake"):


### PR DESCRIPTION
12.3 isn't currently GA.

Its release date is after the 12.3 release
https://jira.mariadb.org/projects/MDEV?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=unreleased

So lets use the latest LTS Ubuntu for this.

Requires Docker Library PR https://github.com/MariaDB/mariadb-docker/pull/683 to be merged soon after deployment.