### PR TITLE
MSAN: unwind (fixing clang 22) odbc + connect + sqlite.

### DIFF
--- a/ci_build_images/msan.fragment.Dockerfile
+++ b/ci_build_images/msan.fragment.Dockerfile
@@ -23,7 +23,7 @@ ENV CXXFLAGS="$CFLAGS"
 
 # hadolint ignore=SC2046,DL3003
 RUN . /etc/os-release \
-    && export LLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+    && export LLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
     && mkdir "$MSAN_LIBDIR" \
     && curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg \
     && if [ "$VERSION_CODENAME" = forky ]; then VERSION_CODENAME=unstable; LLVM_DEB=""; else LLVM_DEB="-$VERSION_CODENAME"; fi \
@@ -54,6 +54,7 @@ RUN . /etc/os-release \
     && cd ll-build \
     && cmake -S ../"$LLVM_DIR"*/runtimes \
         -DCMAKE_BUILD_TYPE=Release \
+        -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
         -DLLVM_ENABLE_RUNTIMES="${LLVM_ENABLE_RUNTIMES}" \
         -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_DOCS=OFF -DLLVM_ENABLE_SPHINX=OFF \
         -DLLVM_USE_SANITIZER=MemoryWithOrigins \
@@ -62,13 +63,6 @@ RUN . /etc/os-release \
     && cp -a include/c++/v1 "$MSAN_LIBDIR/include" \
     && cd .. \
     && rm -rf -- *
-
-RUN for f in "$MSAN_LIBDIR"/libunwind*; do mv "$f" "$f"-disable; done; \
-    if [ "${CLANG_VERSION}" -ge 22 ]; then \
-      apt-get -y install --no-install-recommends libunwind-19; \
-    fi
-# libunwind move/disable because of https://github.com/llvm/llvm-project/issues/128621
-# libunwind-19 meets ABI compatibility as its now linked to built executables.
 
 COPY msan.instrumentedlibs.sh /msan-build
 RUN ./msan.instrumentedlibs.sh

--- a/ci_build_images/msan.instrumentedlibs.sh
+++ b/ci_build_images/msan.instrumentedlibs.sh
@@ -94,7 +94,7 @@ make -j "$(nproc)"
 cp -aL .libs/libxml2.so* "$MSAN_LIBDIR"
 rm -rf -- *
 
-# Unixodbc used by MariaDB Connect engine.
+# Unixodbc used by MariaDB Connect engine and C/ODBC.
 if [ "${VERSION_CODENAME}" = trixie ]; then
   # additional dependency in later debian versions.
   # libltdl-dev - System independent dlopen wrapper for GNU libtool
@@ -109,7 +109,9 @@ autoconf
 automake --add-missing
 ./configure --enable-fastvalidate  --with-pth=no --with-included-ltdl=no
 make -j "$(nproc)"
-mv ./DriverManager/.libs/libodbc.so* "$MSAN_LIBDIR"
+find .
+mv ./DriverManager/.libs/libodbc.so* ./odbcinst/.libs/libodbcinst.so* "$MSAN_LIBDIR"
+rm -rf -- *
 rm -rf -- *
 
 # libfmt -  used by server for SFORMAT function

--- a/ci_build_images/msan.instrumentedlibs.sh
+++ b/ci_build_images/msan.instrumentedlibs.sh
@@ -112,6 +112,16 @@ make -j "$(nproc)"
 find .
 mv ./DriverManager/.libs/libodbc.so* ./odbcinst/.libs/libodbcinst.so* "$MSAN_LIBDIR"
 rm -rf -- *
+
+#libltdl - C/ODBC
+apt-get source libltdl-dev
+mv libtool-*/* .
+./bootstrap --force --no-git --skip-po --gnulib-srcdir=/usr/share/gnulib/ --copy
+./configure
+make -j "$(nproc)"
+mv ./libltdl/.libs/libltdl.so* "$MSAN_LIBDIR"
+rm -rf -- *
+
 rm -rf -- *
 
 # libfmt -  used by server for SFORMAT function

--- a/ci_build_images/msan.instrumentedlibs.sh
+++ b/ci_build_images/msan.instrumentedlibs.sh
@@ -107,20 +107,22 @@ aclocal
 autoheader
 autoconf
 automake --add-missing
-./configure --enable-fastvalidate  --with-pth=no --with-included-ltdl=no
+./configure --enable-fastvalidate  --with-pth=no --with-included-ltdl=yes
 make -j "$(nproc)"
 find .
 mv ./DriverManager/.libs/libodbc.so* ./odbcinst/.libs/libodbcinst.so* "$MSAN_LIBDIR"
 rm -rf -- *
 
-#libltdl - C/ODBC
-apt-get source libltdl-dev
-mv libtool-*/* .
-./bootstrap --force --no-git --skip-po --gnulib-srcdir=/usr/share/gnulib/ --copy
-./configure
-make -j "$(nproc)"
-mv ./libltdl/.libs/libltdl.so* "$MSAN_LIBDIR"
-rm -rf -- *
+##libltdl - C/ODBC
+## libodbc does a fixed path load of /lib/x86_64-linux-gnu/libltdl.so.7, which
+## isn't the instrumented version, so changed --with-included-ltdl=yes above.
+#apt-get source libltdl-dev
+#mv libtool-*/* .
+#./bootstrap --force --no-git --skip-po --gnulib-srcdir=/usr/share/gnulib/ --copy
+#./configure
+#make -j "$(nproc)"
+#mv ./libltdl/.libs/libltdl.so* "$MSAN_LIBDIR"
+#rm -rf -- *
 
 # sqlite/odbc for CONNECT engine
 apt-get source libsqliteodbc

--- a/ci_build_images/msan.instrumentedlibs.sh
+++ b/ci_build_images/msan.instrumentedlibs.sh
@@ -122,6 +122,14 @@ make -j "$(nproc)"
 mv ./libltdl/.libs/libltdl.so* "$MSAN_LIBDIR"
 rm -rf -- *
 
+# sqlite/odbc for CONNECT engine
+apt-get source libsqliteodbc
+mv sqliteodbc-*/* .
+mk-build-deps -it 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes'
+autoreconf --install .
+./configure
+make -j "$(nproc)"
+mv ./.libs/libsqlite3odbc.so* "$MSAN_LIBDIR"
 rm -rf -- *
 
 # libfmt -  used by server for SFORMAT function


### PR DESCRIPTION
clang Unwind fix  unblocks #912

libodbcinst is instrumented for MDBF-1196 and installed.

 connect.odbc_sqlite3 triggers:
 ```
 ==34225==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f97a01ae354 in foreach_dirinpath /msan-build/libltdl/ltdl.c:702:18
    #1 0x7f97a01ad4ca in find_handle /msan-build/libltdl/ltdl.c:805:8
    #2 0x7f97a01ad4ca in try_dlopen /msan-build/libltdl/ltdl.c:1468:10
    #3 0x7f97a01ac760 in lt_dlopenadvise /msan-build/libltdl/ltdl.c:1667:11
    #4 0x7f97a01ac760 in lt_dlopen /msan-build/libltdl/ltdl.c:1622:10
    #5 0x7f97a01310af in odbc_dlopen /msan-build/DriverManager/SQLConnect.c:842:16
    #6 0x7f97a012e355 in __connect_part_one /msan-build/DriverManager/SQLConnect.c:1182:38
    #7 0x7f97a013dff7 in SQLDriverConnect /msan-build/DriverManager/SQLDriverConnect.c:1403:11
    #8 0x7f97a07b92e1 in ODBConn::DriverConnect(unsigned int) /source/storage/connect/odbconn.cpp:1306:8
    #9 0x7f97a07b057d in ODBConn::Open(char const*, odbc_parms*, unsigned int) /source/storage/connect/odbconn.cpp:1160:11
    #10 0x7f97a07afdb7 in ODBCColumns(_global*, char const*, char const*, char const*, char const*, int, bool, odbc_parms*) /source/storage/connect/odbconn.cpp:353:14
    #11 0x7f97a058ca1e in connect_assisted_discovery(handlerton*, THD*, TABLE_SHARE*, HA_CREATE_INFO*) /source/storage/connect/ha_connect.cc:6037:14
    #12 0x5636f3ef7896 in create_table_impl(THD*, st_ddl_log_state*, st_ddl_log_state*, st_mysql_const_lex_string const&, st_mysql_const_lex_string const&, st_mysql_const_lex_string const&, st_mysql_const_lex_string const&, st_mysql_const_lex_string const&, DDL_options_st, HA_CREATE_INFO*, Alter_info*, int, bool*, st_key**, unsigned int*, st_mysql_const_unsigned_lex_string*) /source/sql/sql_table.cc:4802:13
    #13 0x5636f3ef6048 in mysql_create_table_no_lock(THD*, st_ddl_log_state*, st_ddl_log_state*, Table_specification_st*, Alter_info*, bool*, int, TABLE_LIST*) /source/sql/sql_table.cc:4955:8
    #14 0x5636f3f370ae in mysql_create_table(THD*, TABLE_LIST*, Table_specification_st*, Alter_info*) /source/sql/sql_table.cc:5202:7
    #15 0x5636f3f33879 in Sql_cmd_create_table_like::execute(THD*) /source/sql/sql_table.cc:13222:12
    #16 0x5636f3c77935 in mysql_execute_command(THD*, bool) /source/sql/sql_parse.cc:6201:26
    #17 0x5636f3c684e0 in mysql_parse(THD*, char*, unsigned int, Parser_state*) /source/sql/sql_parse.cc:8223:18
    #18 0x5636f3c618e4 in dispatch_command(enum_server_command, THD*, char*, unsigned int, bool) /source/sql/sql_parse.cc:1924:7
    #19 0x5636f3c6950b in do_command(THD*, bool) /source/sql/sql_parse.cc:1434:17
    #20 0x5636f4090b8c in do_handle_one_connection(CONNECT*, bool) /source/sql/sql_connect.cc:1475:11
    #21 0x5636f4090645 in handle_one_connection /source/sql/sql_connect.cc:1387:5
    #22 0x5636f4be0ce9 in pfs_spawn_thread /source/storage/perfschema/pfs.cc:2201:3
    #23 0x7f97a77edb7a  (/lib/x86_64-linux-gnu/libc.so.6+0x92b7a) (BuildId: 58749c528985eab03e6700ebc1469fa50aa41219)
    #24 0x7f97a786b7f7  (/lib/x86_64-linux-gnu/libc.so.6+0x1107f7) (BuildId: 58749c528985eab03e6700ebc1469fa50aa41219)
```

But as /etc/odbc* isn't copied to /usr/local/etc this test is skipped on MSAN builders stil.