### PR TITLE
MDBF-1197: temporary windows msi builder hotfix regarding HeidiSQL download

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -140,6 +140,16 @@ F_WINDOWS_ENV = {
 }
 F_WINDOWS_ENV.update(MTR_ENV)
 
+F_WINDOWS_ENV_WITHOUT_TEMP = {
+    "TMP": util.Interpolate(
+        "C:\\buildbot\\workers\\{0}\\%(prop:buildername)s\\build\\tmpdir".format(
+            "dev" if os.environ["ENVIRON"] == "DEV" else "prod"
+        )
+    ),
+}
+
+F_WINDOWS_ENV_WITHOUT_TEMP.update(MTR_ENV)
+
 ## f_windows
 f_windows = util.BuildFactory()
 f_windows.addStep(
@@ -374,7 +384,7 @@ f_windows_msi.addStep(
 f_windows_msi.addStep(
     steps.Compile(
         name="cmake",
-        env=F_WINDOWS_ENV,
+        env=F_WINDOWS_ENV_WITHOUT_TEMP,
         command=[
             "dojob",
             '"',
@@ -403,7 +413,7 @@ f_windows_msi.addStep(
 f_windows_msi.addStep(
     steps.Compile(
         name="compile",
-        env=F_WINDOWS_ENV,
+        env=F_WINDOWS_ENV_WITHOUT_TEMP,
         command=[
             "dojob",
             '"',
@@ -420,7 +430,7 @@ f_windows_msi.addStep(
 f_windows_msi.addStep(
     steps.Compile(
         name="package",
-        env=F_WINDOWS_ENV,
+        env=F_WINDOWS_ENV_WITHOUT_TEMP,
         command=[
             "dojob",
             '"',


### PR DESCRIPTION
windows-packages builder failing with:
```
-- Downloading https://www.heidisql.com/downloads/releases/HeidiSQL_12.14_64_Portable.zip to C:/buildbot/workers/prod/amd64-windows-packages/build/tmpdir/HeidiSQL_12.14_64_Portable/HeidiSQL_12.14_64_Portable.zip
cmake -E tar : error : ZIP decompression failed (-5) [C:\buildbot\workers\prod\amd64-windows-packages\build\win\packaging\MSI.vcxproj]
```

Because a file download 60 seconds timeout is reached in https://github.com/MariaDB/server/blob/9fc925d77163f1d63e21a65654b0f59678abf08d/win/packaging/heidisql.cmake#L9

The file download status if not checked in cmake, it will be silently ignored and cmake continues to decompression, resulting in the above error, due to an incomplete download.

CMAKE is looking in TEMP for third parties, setting: THIRD_PARTY_DOWNLOAD_LOCATION https://github.com/MariaDB/server/blob/9fc925d77163f1d63e21a65654b0f59678abf08d/win/packaging/CMakeLists.txt#L139

But currently TEMP is set to a worker path build location that is removed on every run. WVlad will permanetly fix this by making THIRD_PARTY_DOWNLOAD_LOCATION settable in 10.6 and also increasing the timeout.

Until then, I manually copied `HeidiSQL_12.14_64_Portable.zip` on the system and user TEMP location on the windows packages host, and will remove the TEMP env variable from the configuration, letting the system / user variable take precedence.
