### PR TITLE
Deb/Ubu: libboost-system-dev presence

### DIFF
--- a/ci_build_images/debian.Dockerfile
+++ b/ci_build_images/debian.Dockerfile
@@ -23,6 +23,7 @@ RUN . /etc/os-release \
       exit 1; \
     fi
 
+ARG BASE_IMAGE
 ARG ARCH_VARIANT=
 ENV ARCH_VARIANT=$ARCH_VARIANT
 # Install updates and required packages
@@ -93,6 +94,7 @@ RUN . /etc/os-release \
     socat \
     sudo  \
     wget \
+    && if [ "$BASE_IMAGE" != "debian:sid" ]; then apt-get -y install --no-install-recommends libboost-system-dev; fi \
     && if [ "$(getconf LONG_BIT)" = 64 ]; then apt-get -y install --no-install-recommends galera-4; fi \
     && if [ "${VERSION_ID}" != 11 ]; then \
       # Bootstrap MDEV-32686 so only temporary until https://github.com/MariaDB/server/pull/3692 merged up \


### PR DESCRIPTION
Since there are no signs of 2d273018bcfcdb8db8af33536b7ed69d1fcf35fe getting cherry-picked in 10.6, I'd say it's a safer approach to assume it won't get merged before the April MariaDB Server release.

Let's include it and then revert this patch once 10.6 is EOL in July.