### PR TITLE
Disable the AIX builder

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -141,7 +141,6 @@ SUPPORTED_PLATFORMS["10.6"] = [
     "amd64-ubuntu-2404-clang18-asan",
     "amd64-windows",
     "amd64-windows-packages",
-    "ppc64be-aix-71",
     "ppc64le-centos-stream9",
     "ppc64le-rhel-8",
     "ppc64le-rhel-9",


### PR DESCRIPTION
Queues keep growing and on every bb release I need to clear them and shutdown the worker. When the work on the host will be resumed and it will be ready to receive builds, then just revert this commit.
