### PR TITLE
MDBF-1152: Fixup - MSI builder in Grid View

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -1123,7 +1123,7 @@ c["builders"].append(
     util.BuilderConfig(
         name="amd64-windows-packages",
         workernames=["bbw3-windows"],
-        tags=["Windows", "2022", "packages", "zip", "msi"],
+        tags=["Windows", "2022", "packages", "zip", "msi", "protected"],
         collapseRequests=True,
         nextBuild=nextBuild,
         factory=f_windows_msi,


### PR DESCRIPTION
Forgot to add the "Protected" tag to the builder,
currently is not visible under Grid View when using filter tags.
