### PR TITLE
MDBF-1136 - vault(win) fix - no --mem on Windows - warning only

### DIFF
--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -521,7 +521,7 @@ f_windows_msi.addStep(
             '"',
             util.Interpolate(
                 (
-                    "vault status && cd mysql-test && perl mysql-test-run.pl --mem --suite=vault --big --parallel=1"
+                    "vault status && cd mysql-test && perl mysql-test-run.pl --suite=vault --big --parallel=1"
                 )
             ),
             '"',


### PR DESCRIPTION
Logging: mysql-test-run.pl  --mem --suite=vault --big --parallel=1 VS config: RelWithDebInfo
--mem not supported on Windows, ignored

Warning only. Not urgent to deploy