### PR TITLE
MDBF-1199: docker library xml: curl to use --fail

### DIFF
--- a/scripts/docker-library-test.sh
+++ b/scripts/docker-library-test.sh
@@ -45,6 +45,7 @@ ret=0
 mariadb-docker/.test/run.sh --xml=doi.xml "$image" || ret=1
 
 if [ $ret ] && ! curl "$HEALTH_URL" \
+    --fail \
     --max-time 5 \
     --retry 3 \
     --retry-max-time 0 \
@@ -60,6 +61,7 @@ if [ ! -f doi.xml ]; then
 fi
 
 [ $ret ] && curl \
+    --fail \
     --max-time 120 \
     --connect-timeout 10 \
     -X POST "$UPLOAD_URL" \


### PR DESCRIPTION
b5b14072fe22631f92bc89ec2223e8a36befd11b - erronously pushed to dev, was a result of the rhel8's curl not having --fail-with-body. It was important to use --fail instead.

failing to push:
https://buildbot.mariadb.org/#/builders/311/builds/35400