### PR TITLE
MDBF-1207: Build Fedora 44 container environments

### DIFF
--- a/.github/workflows/build-fedora-based.yml
+++ b/.github/workflows/build-fedora-based.yml
@@ -38,6 +38,10 @@ jobs:
             platforms: linux/amd64, linux/arm64/v8
             nogalera: false
 
+          - image: fedora:44
+            platforms: linux/amd64, linux/arm64/v8
+            nogalera: True
+
           - image: fedora:40
             platforms: linux/amd64
             tag: fedora40-valgrind

--- a/.github/workflows/build-srpm.yml
+++ b/.github/workflows/build-srpm.yml
@@ -39,6 +39,11 @@ jobs:
             platforms: linux/amd64, linux/arm64/v8
 
           - dockerfile: srpm.Dockerfile
+            image: fedora:44
+            tag: fedora44-srpm
+            platforms: linux/amd64, linux/arm64/v8
+
+          - dockerfile: srpm.Dockerfile
             image: registry.access.redhat.com/ubi7
             tag: rhel7-srpm
             platforms: linux/amd64


### PR DESCRIPTION
Official release on 28.04.2026 as per:
https://fedorapeople.org/groups/schedule/f-44/f-44-all-tasks.html