### PR TITLE
MDEV-39292: Columnstore upgrade test is no-op on arm 10.6,10.11

### DIFF
--- a/scripts/deb-upgrade.sh
+++ b/scripts/deb-upgrade.sh
@@ -82,6 +82,11 @@ case $test_mode in
     ;;
   columnstore)
     package_list="mariadb-server mariadb-plugin-columnstore"
+    arch=$(uname -m)
+    if [[ $arch == "aarch64" && ( $major_version == "10.6" || $major_version == "10.11" ) ]]; then
+      bb_log_warn "Columnstore is not built for aarch64 on 10.6 and 10.11, skipping the test"
+      exit 0
+    fi
     ;;
   *)
     bb_log_err "unknown test mode: $test_mode"


### PR DESCRIPTION
As per the mentioned MDEV,
the support for compiling Columnstore on aarch64 10.6, 10.11 was removed because it was not packaged.

Make this test no-op.