### PR TITLE
Windows | check if vault is ready

### DIFF
--- a/scripts/windows/start-vault.ps1
+++ b/scripts/windows/start-vault.ps1
@@ -1,25 +1,41 @@
-# Deploy in WIN_MSI_VAULT_ROOT
 try {
-    # Kill any existing Vault processes
+    $VaultExe = "C:\vault\vault.exe"
+
     Get-Process vault -ErrorAction SilentlyContinue | ForEach-Object {
         Stop-Process -Id $_.Id -Force
         Write-Host "Killed Vault process $($_.Id)"
     }
 
-    # Set environment variables for dev mode
+    Start-Sleep -Seconds 1
+
     $env:VAULT_DEV_ROOT_TOKEN_ID = "MTR"
     $env:VAULT_ADDR = "http://127.0.0.1:8200"
+    $env:VAULT_TOKEN = "MTR"
 
+    Start-Process -FilePath $VaultExe `
+        -ArgumentList "server -dev -dev-root-token-id=MTR -dev-listen-address=127.0.0.1:8200" `
+        -WindowStyle Hidden
 
-    Start-Sleep -Seconds 1 # For old Vault process to exit
+    Write-Host "Vault process started"
 
-    # Start Vault in detached mode using Start-Process
-    Start-Process -FilePath "C:\vault\vault.exe" `
-                  -ArgumentList "server -dev" `
-                  -WindowStyle Hidden `
+    $deadline = (Get-Date).AddSeconds(30)
 
-    Write-Host "Vault started in dev mode. PID: $((Get-Process vault).Id)"
-    exit 0
+    do {
+        Start-Sleep -Milliseconds 500
+
+        & $VaultExe status *> $null
+        $statusCode = $LASTEXITCODE
+
+        if ($statusCode -eq 0 -or $statusCode -eq 2) {
+            Write-Host "Vault is ready"
+            exit 0
+        }
+
+    } while ((Get-Date) -lt $deadline)
+
+    Write-Host "Vault did not become ready"
+    Get-Process vault -ErrorAction SilentlyContinue
+    exit 1
 }
 catch {
     Write-Host "Failed to start Vault: $_"


### PR DESCRIPTION
It may be the case that MTR vault tests start
before the vault process is bootstrapped.

Now we check for vault readiness before moving
on to the next step.
