### PR TITLE
MDBF-1218 - instrumentation for curl/s3  && ODBC mem leaks

### DIFF
--- a/ci_build_images/msan.instrumentedlibs.sh
+++ b/ci_build_images/msan.instrumentedlibs.sh
@@ -218,7 +218,15 @@ rm -rf -- *
 # curl
 apt-get source curl
 mv curl*/* .
-./configure  --with-openssl --enable-ipv6 --disable-static --enable-websockets
+if [ "${VERSION_CODENAME}" = trixie ]; then
+  # extras from debian/rules
+  # ./storage/maria/ha_s3.so: /msan-libs/libcurl.so.4: no version information available (required by ./storage/maria/ha_s3.so)
+  ./configure  --with-openssl --enable-ipv6 --disable-static --enable-websockets \
+      --disable-symbol-hiding --enable-versioned-symbols --enable-threaded-resolver
+else
+  # keeping old stable - stable
+  ./configure  --with-openssl --enable-ipv6 --disable-static --enable-websockets
+fi
 make -j "$(nproc)"
 mv ./lib/.libs/*.so* "$MSAN_LIBDIR"
 rm -rf -- *

--- a/ci_build_images/msan.instrumentedlibs.sh
+++ b/ci_build_images/msan.instrumentedlibs.sh
@@ -101,10 +101,12 @@ if [ "${VERSION_CODENAME}" = trixie ]; then
   apt-get install --no-install-recommends -y libltdl-dev
 fi
 apt-get source unixodbc-dev
+mv unixodbc-*/* .
+if [ "${VERSION_CODENAME}" = trixie ]; then
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1136221
 # awaiting arrival on Debian stable.
-mv unixodbc-*/* .
-curl https://github.com/lurcher/unixODBC/commit/447ca7624394f8cc9825c6ac3ff60e3715831b87.patch | patch -p1
+  curl https://github.com/lurcher/unixODBC/commit/447ca7624394f8cc9825c6ac3ff60e3715831b87.patch | patch -p1
+fi
 libtoolize --force
 aclocal
 autoheader

--- a/ci_build_images/msan.instrumentedlibs.sh
+++ b/ci_build_images/msan.instrumentedlibs.sh
@@ -212,7 +212,7 @@ mv nghttp2-*/* .
 autoreconf --install .
 ./configure --without-libcares
 make -j "$(nproc)"
-mv ./.libs/* "$MSAN_LIBDIR"
+mv lib/.libs/*.so* "$MSAN_LIBDIR"
 rm -rf -- *
 
 # curl

--- a/ci_build_images/msan.instrumentedlibs.sh
+++ b/ci_build_images/msan.instrumentedlibs.sh
@@ -101,7 +101,10 @@ if [ "${VERSION_CODENAME}" = trixie ]; then
   apt-get install --no-install-recommends -y libltdl-dev
 fi
 apt-get source unixodbc-dev
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1136221
+# awaiting arrival on Debian stable.
 mv unixodbc-*/* .
+curl https://github.com/lurcher/unixODBC/commit/447ca7624394f8cc9825c6ac3ff60e3715831b87.patch | patch -p1
 libtoolize --force
 aclocal
 autoheader
@@ -110,7 +113,7 @@ automake --add-missing
 ./configure --enable-fastvalidate  --with-pth=no --with-included-ltdl=yes
 make -j "$(nproc)"
 find .
-mv ./DriverManager/.libs/libodbc.so* ./odbcinst/.libs/libodbcinst.so* "$MSAN_LIBDIR"
+mv ./cur/.libs/libodbccr* ./DriverManager/.libs/libodbc.so* ./odbcinst/.libs/libodbcinst.so* "$MSAN_LIBDIR"
 rm -rf -- *
 
 ##libltdl - C/ODBC

--- a/ci_build_images/msan.instrumentedlibs.sh
+++ b/ci_build_images/msan.instrumentedlibs.sh
@@ -201,6 +201,15 @@ rm -rf -- *
 # shellcheck disable=SC2094
 /usr/sbin/cracklib-packer /usr/share/dict/cracklib-small < /usr/share/dict/cracklib-small
 
+# libnghttp2, a curl dependency. Shows up in s3 tests
+apt-get source nghttp2
+mv nghttp2-*/* .
+autoreconf --install .
+./configure --without-libcares
+make -j "$(nproc)"
+mv ./.libs/* "$MSAN_LIBDIR"
+rm -rf -- *
+
 # curl
 apt-get source curl
 mv curl*/* .


### PR DESCRIPTION
instruments the curl dependency of nghttp2 that will prevent false s3 msan errors.

odbc - add leak prevention from ustream patch.

save odbc cursor msan instrumented code in case we start to use it.