### PR TITLE
MDBF-1215: Remove EOL platforms Q2->Q3

### DIFF
--- a/.github/workflows/build-debian-based.yml
+++ b/.github/workflows/build-debian-based.yml
@@ -88,17 +88,6 @@ jobs:
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
             branch: 10.11
             nogalera: false
-
-          - image: ubuntu:25.04
-            platforms: linux/amd64, linux/arm64/v8
-            branch: 11.4
-            nogalera: false
-
-          - image: ubuntu:25.10
-            platforms: linux/amd64, linux/arm64/v8
-            branch: 11.8
-            nogalera: false
-
           - image: ubuntu:26.04
             platforms: linux/amd64, linux/arm64/v8, linux/ppc64le, linux/s390x
             branch: 11.8

--- a/.github/workflows/build-fedora-based.yml
+++ b/.github/workflows/build-fedora-based.yml
@@ -26,13 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: fedora:41
-            platforms: linux/amd64, linux/arm64/v8
-            nogalera: false
-
-          - image: fedora:42
-            platforms: linux/amd64, linux/arm64/v8
-            nogalera: false
 
           - image: fedora:43
             platforms: linux/amd64, linux/arm64/v8
@@ -42,9 +35,9 @@ jobs:
             platforms: linux/amd64, linux/arm64/v8
             nogalera: True
 
-          - image: fedora:40
+          - image: fedora:44
             platforms: linux/amd64
-            tag: fedora40-valgrind
+            tag: fedora44-valgrind
             install_valgrind: "true"
             nogalera: true
 

--- a/.github/workflows/build-opensuse.pip-based.yml
+++ b/.github/workflows/build-opensuse.pip-based.yml
@@ -30,11 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: opensuse/leap:15.6
-            platforms: linux/amd64
-            tag: opensuse1506
-            nogalera: false
-
           - image: opensuse/leap:16.0
             platforms: linux/amd64
             tag: opensuse1600

--- a/.github/workflows/build-srpm.yml
+++ b/.github/workflows/build-srpm.yml
@@ -28,10 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dockerfile: srpm.Dockerfile
-            image: fedora:42
-            tag: fedora42-srpm
-            platforms: linux/amd64, linux/arm64/v8
 
           - dockerfile: srpm.Dockerfile
             image: fedora:43

--- a/configuration/builders/definitions/connectors/conodbc.py
+++ b/configuration/builders/definitions/connectors/conodbc.py
@@ -228,7 +228,6 @@ def generate_deb_release_sq(ops, version):
 RELEASE_BUILDERS_BY_ARCH = {"amd64": [], "aarch64": []}
 for arch in ["amd64", "aarch64"]:
     for ops, version in [
-        ("fedora", "42"),
         ("fedora", "43"),
         ("sles", "1507"),
         ("sles", "1600"),

--- a/constants.py
+++ b/constants.py
@@ -58,7 +58,7 @@ GITHUB_STATUS_BUILDERS = [
     "amd64-debian-12-deb-autobake",
     "amd64-debian-11-debug-ps-embedded",
     "amd64-msan-clang-20",
-    "amd64-fedora-42",
+    "amd64-fedora-43",
     "amd64-ubuntu-2204-debug",
     "amd64-ubuntu-2204-debug-ps",
     "amd64-windows",
@@ -125,7 +125,7 @@ SUPPORTED_PLATFORMS["10.6"] = [
     "amd64-debian-11-debug-ps-embedded",
     "amd64-debian-12-asan-ubsan",
     "amd64-debian-12-rocksdb",
-    "amd64-fedora-40-valgrind",
+    "amd64-fedora-44-valgrind",
     "amd64-freebsd-14",
     "amd64-msan-clang-20",
     "amd64-openeuler-2403",
@@ -171,16 +171,13 @@ SUPPORTED_PLATFORMS["10.10"] += SUPPORTED_PLATFORMS["10.9"]
 SUPPORTED_PLATFORMS["10.11"] = [
     "aarch64-centos-stream10",
     "aarch64-debian-12",
-    "aarch64-fedora-42",
     "aarch64-rhel-10",
     "aarch64-ubuntu-2404",
     "amd64-centos-stream10",
     "amd64-debian-12",
     "amd64-debian-12-deb-autobake-migration",
     "amd64-debian-12-debug-embedded",
-    "amd64-fedora-42",
     "amd64-msan-clang-20-debug",
-    "amd64-opensuse-1506",
     "amd64-rhel-10",
     "amd64-ubasan-clang-20",
     "amd64-ubasan-clang-20-debug",
@@ -197,15 +194,11 @@ SUPPORTED_PLATFORMS["10.11"] += SUPPORTED_PLATFORMS["10.10"]
 
 SUPPORTED_PLATFORMS["11.0"] = SUPPORTED_PLATFORMS["10.11"].copy()
 SUPPORTED_PLATFORMS["11.0"].remove("amd64-rhel-7")
+SUPPORTED_PLATFORMS["11.0"].remove("amd64-fedora-44-valgrind")
 SUPPORTED_PLATFORMS["11.1"] = SUPPORTED_PLATFORMS["11.0"].copy()
 SUPPORTED_PLATFORMS["11.2"] = SUPPORTED_PLATFORMS["11.1"].copy()
 SUPPORTED_PLATFORMS["11.3"] = SUPPORTED_PLATFORMS["11.2"].copy()
 SUPPORTED_PLATFORMS["11.4"] = SUPPORTED_PLATFORMS["11.3"].copy()
-SUPPORTED_PLATFORMS["11.4"] += [
-    "aarch64-ubuntu-2504",
-    "amd64-ubuntu-2504",
-]
-
 SUPPORTED_PLATFORMS["11.5"] = SUPPORTED_PLATFORMS["11.4"].copy()
 SUPPORTED_PLATFORMS["11.5"].remove("amd64-centos-7-bintar")
 SUPPORTED_PLATFORMS["11.6"] = SUPPORTED_PLATFORMS["11.5"].copy()
@@ -226,8 +219,6 @@ SUPPORTED_PLATFORMS["11.8"] += [
     "s390x-sles-1507",
     "amd64-sles-1600",
     "s390x-sles-1600",
-    "aarch64-ubuntu-2510",
-    "amd64-ubuntu-2510",
     "aarch64-fedora-43",
     "amd64-fedora-43",
     "aarch64-ubuntu-2604",

--- a/master-docker-nonstandard/master.cfg
+++ b/master-docker-nonstandard/master.cfg
@@ -208,16 +208,16 @@ for w_name, w_ids in x64_bbw_docker.items():
 addWorker(
     "amd-bbw",
     1,
-    "valgrind-fedora-40",
-    os.environ["CONTAINER_REGISTRY_URL"] + "fedora40-valgrind",
+    "valgrind-fedora-44",
+    os.environ["CONTAINER_REGISTRY_URL"] + "fedora44-valgrind",
     jobs=20,
     save_packages=False,
 )
 addWorker(
     "amd-bbw",
     2,
-    "valgrind-fedora-40",
-    os.environ["CONTAINER_REGISTRY_URL"] + "fedora40-valgrind",
+    "valgrind-fedora-44",
+    os.environ["CONTAINER_REGISTRY_URL"] + "fedora44-valgrind",
     jobs=20,
     save_packages=False,
 )
@@ -526,6 +526,7 @@ f_valgrind_build.addStep(
                 -DWITH_VALGRIND=1 \\
                 -DWITH_DBUG_TRACE=OFF \\
                 -DEXTRA_DEBUG=1 \\
+                -DPLUGIN_COLUMNSTORE=NO \\
                 && make -j%(kw:jobs)s""",
                 jobs=util.Property("jobs", default="$(getconf _NPROCESSORS_ONLN)"),
             ),
@@ -1138,8 +1139,8 @@ c["builders"].append(
 
 c["builders"].append(
     util.BuilderConfig(
-        name="amd64-fedora-40-valgrind",
-        workernames=workers["x64-bbw-docker-valgrind-fedora-40"],
+        name="amd64-fedora-44-valgrind",
+        workernames=workers["x64-bbw-docker-valgrind-fedora-44"],
         tags=["Ubuntu", "quick", "gcc", "valgrind", "experimental"],
         collapseRequests=True,
         nextBuild=nextBuild,

--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -153,8 +153,8 @@ for w_name in ["hz-bbw"]:
         addWorker(
             w_name,
             i,
-            "fedora-42",
-            os.environ["CONTAINER_REGISTRY_URL"] + "fedora42",
+            "fedora-43",
+            os.environ["CONTAINER_REGISTRY_URL"] + "fedora43",
             jobs=jobs,
             save_packages=True,
         )
@@ -499,8 +499,8 @@ c["builders"].append(
 
 c["builders"].append(
     util.BuilderConfig(
-        name="amd64-fedora-42",
-        workernames=workers["x64-bbw-docker-fedora-42"],
+        name="amd64-fedora-43",
+        workernames=workers["x64-bbw-docker-fedora-43"],
         tags=["Fedora", "quick", "gcc", "protected"],
         collapseRequests=True,
         nextBuild=nextBuild,

--- a/master-web/templates/home.jade
+++ b/master-web/templates/home.jade
@@ -87,7 +87,7 @@
               li
                 | Debian 11, 12, 13 and Sid
               li
-                | Ubuntu 22.04, 24.04, 25.04, 25.10 and 26.04
+                | Ubuntu 22.04, 24.04, and 26.04
               li
                 | Fedora 42 and 43
               li
@@ -103,7 +103,7 @@
               li
                 | Rocky Linux 8, 9, and 10
               li
-                | OpenSUSE Leap 15.6 and 16.0
+                | OpenSUSE Leap 16.0
               li
                 | Windows
               li

--- a/os_info.yaml
+++ b/os_info.yaml
@@ -63,8 +63,8 @@ debian-12:
   arch:
     - amd64
     - aarch64
-    - ppc64le
     - x86
+    - ppc64le
   type: deb
 debian-13:
   image_tag: debian13
@@ -87,14 +87,6 @@ debian-sid:
     - ppc64le
     - x86
   type: deb
-fedora-42:
-  image_tag: fedora42
-  tags:
-    - release_packages
-  arch:
-    - amd64
-    - aarch64
-  type: rpm
 fedora-43:
   image_tag: fedora43
   tags:
@@ -110,13 +102,6 @@ openeuler-2403:
   arch:
     - amd64
     - aarch64
-  type: rpm
-opensuse-1506:
-  image_tag: opensuse1506
-  tags:
-    - release_packages
-  arch:
-    - amd64
   type: rpm
 opensuse-1600:
   image_tag: opensuse1600
@@ -223,22 +208,6 @@ ubuntu-2404:
     - aarch64
     - ppc64le
     - s390x
-  type: deb
-ubuntu-2504:
-  image_tag: ubuntu25.04
-  tags:
-    - release_packages
-  arch:
-    - amd64
-    - aarch64
-  type: deb
-ubuntu-2510:
-  image_tag: ubuntu25.10
-  tags:
-    - release_packages
-  arch:
-    - amd64
-    - aarch64
   type: deb
 ubuntu-2604:
   image_tag: ubuntu26.04


### PR DESCRIPTION
- Ubuntu 25.04 - already EOL
- Ubuntu 25.10 - EOL before NEXT server release
- OpenSUSE 15.06 - already EOL
- Fedora 42 - already EOL -> Fedora-43 is the next BRANCH PROTECTION builder

@fauust ^^ notes on what to be excluded from Q3 server release.

Notes on Valgrind:
- Fedora 44 server cmake fails with columnstore. Since MTR tests do not touch it, let's disable configuring columnstore.
- restricted the builds to known valgrind green branches (MDBF-406) :: can re-introduce it on higher branches if there's interest in solving the test failures.

Notes on Fedora-44:
- will add platform support in a separate PR (server + C/ODBC).

@grooverdan not clear where ppc64le support for deb12 was announced. Can't find any info on: https://wiki.debian.org/DebianReleases:
On: https://wiki.debian.org/LTS says "full architecture list still to be determined", history tells that is probably safe to remove ppc64le now.