### PR TITLE
MDEV-39831 mtr: extend LSAN_OPTIONS rather than overwrite

### DIFF
--- a/configuration/builders/sequences/sanitizers.py
+++ b/configuration/builders/sequences/sanitizers.py
@@ -115,7 +115,7 @@ def asan_ubsan(
         (
             "LSAN_OPTIONS",
             "print_suppressions=0,suppressions="
-            + str(PurePath("/home", "buildbot", "src", "lsan.supp")),
+            + str(PurePath("/home", "buildbot", "src", "mysql-test", "lsan.supp")),
         ),
         (
             "ASAN_OPTIONS",


### PR DESCRIPTION
Fixing the server in 01bec43ef0d16e95eed9793284af4457041a4d79 highlighted that we've got the path wrong here. lsan.supp is in the mysql-test directory.