### PR TITLE
MDBF-1222: C/C++ 1.1 now tracks C/C 3.4

### DIFF
--- a/configuration/builders/sequences/connectors/concpp.py
+++ b/configuration/builders/sequences/connectors/concpp.py
@@ -694,7 +694,7 @@ def bintar(
                 ShellStep(
                     command=BashCommand(
                         name="Checkout latest C/C",
-                        cmd="git fetch origin $(([ '%(prop:cpp_version)s' = '1.0' ] || [ '%(prop:cpp_version)s' = '1.1' ]) && echo 3.3 || echo 3.4) && git reset --hard FETCH_HEAD",
+                        cmd="git fetch origin $(([ '%(prop:cpp_version)s' = '1.0' ]) && echo 3.3 || echo 3.4) && git reset --hard FETCH_HEAD",
                         workdir=PurePath(source_path) / "libmariadb",
                     ),
                     options=StepOptions(


### PR DESCRIPTION
As per CONCPP-156
https://github.com/mariadb-corporation/mariadb-connector-cpp/commit/0d773c011a10f23d45f9e3990820a9956501404f

so UBASAN builder needs to checkout latest 3.4 C/C.
