### PR TITLE
Add txn-tester transaction/isolation bug-detection builders

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -74,9 +74,13 @@ BUILDERS_ECO = [
 if os.environ["ENVIRON"] == "DEV":
     BUILDERS_WORDPRESS = ["amd64-rhel9-wordpress"]
     BUILDERS_DOCKERLIBRARY = ["amd64-rhel9-dockerlibrary"]
+    BUILDERS_TXN_TESTER = ["amd64-rhel9-txntester"]
+    BUILDERS_TXN_TESTER_SOAK = ["amd64-rhel9-txntester-soak"]
 else:
     BUILDERS_WORDPRESS = ["amd64-rhel8-wordpress"]
     BUILDERS_DOCKERLIBRARY = ["amd64-rhel8-dockerlibrary"]
+    BUILDERS_TXN_TESTER = ["amd64-rhel8-txntester"]
+    BUILDERS_TXN_TESTER_SOAK = ["amd64-rhel8-txntester-soak"]
 
 BUILDERS_GALERA_MTR = [
     "aarch64-debian-12",

--- a/master-nonlatent/master.cfg
+++ b/master-nonlatent/master.cfg
@@ -16,6 +16,7 @@ from utils import (
     getHTMLLogString,
     getSourceTarball,
     hasFailed,
+    isTxnTesterBranch,
     ls2list,
     moveMTRLogs,
     mtrJobsMultiplier,
@@ -696,6 +697,167 @@ f_wordpress.addStep(
     )
 )
 
+# f_txn_tester
+#
+# txn-tester bundles three DBMS transaction/isolation bug-detection tools (TROC,
+# Fucci, APTrans) in a single image that connects to a remote MariaDB purely via
+# environment variables. Like f_wordpress, we run the freshly CI-built MariaDB
+# docker-library image (tagged "-txntester" by docker-library-build.sh) in a pod
+# and point the tools at it over the pod-local loopback.
+#
+# The image is pulled from its own GHCR repo (it is not in MariaDB's registry
+# yet); a specific version is pinned so CI runs are reproducible. --pull=always
+# still refreshes if the tag is moved.
+TXN_TESTER_IMAGE = "ghcr.io/arcivanov/txn-tester:0.0.2"
+
+
+def getTxnTesterFactory(duration, sample_num, isolation, aptrans_max_time):
+    """Build a txn-tester factory at a given intensity.
+
+    duration         -- TROC/Fucci fuzz seconds (each is bounded by `timeout`).
+    sample_num       -- APTrans cases per anomaly pattern per isolation level.
+    isolation        -- APTrans isolation(s): a level name or "all".
+    aptrans_max_time -- absolute cap (s) for the APTrans step; APTrans is
+                        work-bounded (SAMPLE_NUM x patterns x isolations), not
+                        clock-bounded, so it needs an explicit ceiling.
+    """
+    f = util.BuildFactory()
+    db_image = util.Interpolate("mariadb-%(prop:tarbuildnum)s%(prop:ubi)s-txntester")
+    pod = "txntest"
+    f.addStep(
+        steps.ShellCommand(
+            name="Create pod",
+            command=[
+                "sh",
+                "-c",
+                util.Interpolate(
+                    f"podman pod exists {pod} || podman pod create -n {pod}"
+                ),
+            ],
+        )
+    )
+    f.addStep(
+        steps.ShellCommand(
+            name="prepare output dir",
+            command=["sh", "-c", "rm -rf txn-output && mkdir -p txn-output"],
+        )
+    )
+    f.addStep(
+        steps.ShellCommand(
+            name="Start MariaDB",
+            command=[
+                "podman",
+                "run",
+                "-d",
+                "--pod",
+                pod,
+                "--name",
+                "mariadb",
+                "--env",
+                "MARIADB_ROOT_PASSWORD=txntest",
+                "--health-cmd",
+                "healthcheck.sh --connect",
+                "--health-interval=4s",
+                "--rm",
+                db_image,
+            ],
+        )
+    )
+    f.addStep(
+        steps.ShellCommand(
+            name="Wait until MariaDB started",
+            command=[
+                "sh",
+                "-c",
+                'until podman healthcheck run mariadb; do sleep 1; echo "not yet"; done; podman logs mariadb',
+            ],
+            maxTime=60,
+        )
+    )
+    # The three tools run sequentially against the same MariaDB. Each owns a
+    # distinct database by default (TROC->txntest_troc, Fucci->txntest_fucci,
+    # APTrans->test_<isolation>), so they do not collide. Each tool streams its
+    # full log to stdout and evacuates artifacts to /output (mounted here so the
+    # anomaly artifacts can be inspected and uploaded). :Z relabels the bind
+    # mount for SELinux on the RHEL worker.
+    #
+    # Bug signalling is done IN the image: the tools never exit non-zero on a
+    # finding by themselves, so the image's runners detect an inconsistency and
+    # exit with the exotic code 100 (distinct from 0=clean and from any
+    # infrastructural failure such as an image-pull/classpath/connection error,
+    # which keep their own non-zero codes). decodeRC maps 100 to FAILURE so a
+    # discovered transaction anomaly turns the build red and is greppable for
+    # triage; every other non-zero remains a (CI/infra) failure too.
+    for tool in ["troc", "fucci", "aptrans"]:
+        f.addStep(
+            steps.ShellCommand(
+                name=f"run {tool}",
+                decodeRC={0: SUCCESS, 100: FAILURE},
+                command=[
+                    "sh",
+                    "-c",
+                    f"podman run --pod {pod} --rm --pull=always "
+                    f'-v "$(pwd)/txn-output:/output:Z" '
+                    f"--env TOOL={tool} --env MODE=full "
+                    f"--env DURATION={duration} --env SAMPLE_NUM={sample_num} "
+                    f"--env ISOLATION={isolation} "
+                    f"--env DB_HOST=127.0.0.1 --env DB_USER=root "
+                    f"--env DB_PASSWORD=txntest "
+                    f"{TXN_TESTER_IMAGE}",
+                ],
+                maxTime=(aptrans_max_time if tool == "aptrans" else duration + 180),
+            )
+        )
+    # Output is written by the in-container root user; make it readable for the
+    # upload that follows.
+    f.addStep(
+        steps.ShellCommand(
+            name="permissions for upload",
+            command=["sh", "-c", "chmod -R u+rwX,go+rX txn-output || true"],
+            alwaysRun=True,
+        )
+    )
+    f.addStep(
+        steps.DirectoryUpload(
+            name="save txn-tester artifacts",
+            alwaysRun=True,
+            workersrc="txn-output",
+            masterdest=util.Interpolate(
+                "/srv/buildbot/packages/%(prop:tarbuildnum)s/logs/%(prop:buildername)s"
+            ),
+            url=util.Interpolate(
+                os.environ["ARTIFACTS_URL"]
+                + "/%(prop:tarbuildnum)s/logs/%(prop:buildername)s/"
+            ),
+        )
+    )
+    f.addStep(
+        steps.ShellCommand(
+            name="Stop MariaDB",
+            command=["podman", "kill", "mariadb"],
+            alwaysRun=True,
+        )
+    )
+    f.addStep(
+        steps.ShellCommand(
+            name="cleanup test image",
+            command=["podman", "untag", db_image],
+            alwaysRun=True,
+        )
+    )
+    return f
+
+
+# Light per-build profile (~6-7 min): fast continuous signal on every
+# saved-package build. Soak profile (~30 min): deep coverage, opt-in via a "txn"
+# branch prefix (see the triggers in f_dockerlibrary).
+f_txn_tester = getTxnTesterFactory(
+    duration=60, sample_num=2, isolation="all", aptrans_max_time=900
+)
+f_txn_tester_soak = getTxnTesterFactory(
+    duration=300, sample_num=10, isolation="all", aptrans_max_time=2700
+)
+
 # f_dockerlibrary
 DECODE_RC = {0: SUCCESS, 1: FAILURE, 2: WARNINGS}
 
@@ -779,6 +941,39 @@ f_dockerlibrary.addStep(
             "ubi": Property("ubi"),
         },
         doStepIf=lambda step: (str(step.getProperty("lasttag")) != ""),
+    )
+)
+# txn-tester runs against the same freshly-built MariaDB image. The light profile
+# fires on every saved-package build for fast signal; the soak profile fires
+# instead on opt-in "txn"-prefixed branches for deep coverage.
+f_dockerlibrary.addStep(
+    steps.Trigger(
+        name="txn-tester",
+        schedulerNames=["s_txn_tester"],
+        waitForFinish=False,
+        updateSourceStamp=False,
+        set_properties={
+            "tarbuildnum": Property("tarbuildnum"),
+            "ubi": Property("ubi"),
+        },
+        doStepIf=lambda step: (
+            str(step.getProperty("lasttag")) != "" and not isTxnTesterBranch(step)
+        ),
+    )
+)
+f_dockerlibrary.addStep(
+    steps.Trigger(
+        name="txn-tester-soak",
+        schedulerNames=["s_txn_tester_soak"],
+        waitForFinish=False,
+        updateSourceStamp=False,
+        set_properties={
+            "tarbuildnum": Property("tarbuildnum"),
+            "ubi": Property("ubi"),
+        },
+        doStepIf=lambda step: (
+            str(step.getProperty("lasttag")) != "" and isTxnTesterBranch(step)
+        ),
     )
 )
 f_dockerlibrary.addStep(
@@ -1091,6 +1286,34 @@ c["builders"].append(
         nextBuild=nextBuild,
         canStartBuild=canStartBuild,
         factory=f_wordpress,
+    )
+)
+
+c["builders"].append(
+    util.BuilderConfig(
+        name=os.environ["MASTER_NONLATENT_DOCKERLIBRARY_WORKER"]
+        .replace("bb", "amd64")
+        .replace("docker", "txntester"),
+        workernames=[os.environ["MASTER_NONLATENT_DOCKERLIBRARY_WORKER"]],
+        tags=["RHEL", "txn-tester"],
+        collapseRequests=True,
+        nextBuild=nextBuild,
+        canStartBuild=canStartBuild,
+        factory=f_txn_tester,
+    )
+)
+
+c["builders"].append(
+    util.BuilderConfig(
+        name=os.environ["MASTER_NONLATENT_DOCKERLIBRARY_WORKER"]
+        .replace("bb", "amd64")
+        .replace("docker", "txntester-soak"),
+        workernames=[os.environ["MASTER_NONLATENT_DOCKERLIBRARY_WORKER"]],
+        tags=["RHEL", "txn-tester"],
+        collapseRequests=True,
+        nextBuild=nextBuild,
+        canStartBuild=canStartBuild,
+        factory=f_txn_tester_soak,
     )
 )
 

--- a/schedulers_definition.py
+++ b/schedulers_definition.py
@@ -5,6 +5,8 @@ from constants import (
     BUILDERS_DOCKERLIBRARY,
     BUILDERS_ECO,
     BUILDERS_INSTALL,
+    BUILDERS_TXN_TESTER,
+    BUILDERS_TXN_TESTER_SOAK,
     BUILDERS_UPGRADE,
     BUILDERS_WORDPRESS,
     GITHUB_STATUS_BUILDERS,
@@ -92,6 +94,16 @@ def wordpressBuilders(props: IProperties) -> list[str]:
     return BUILDERS_WORDPRESS[0]
 
 
+@util.renderer
+def txnTesterBuilders(props: IProperties) -> list[str]:
+    return BUILDERS_TXN_TESTER[0]
+
+
+@util.renderer
+def txnTesterSoakBuilders(props: IProperties) -> list[str]:
+    return BUILDERS_TXN_TESTER_SOAK[0]
+
+
 SCHEDULERS = [
     schedulers.Triggerable(name="s_upstream_all", builderNames=branchBuilders),
     schedulers.Triggerable(
@@ -105,5 +117,9 @@ SCHEDULERS = [
     schedulers.Triggerable(name="s_wordpress", builderNames=wordpressBuilders),
     schedulers.Triggerable(
         name="s_jepsen", builderNames=["amd64-ubuntu-2204-jepsen-mariadb"]
+    ),
+    schedulers.Triggerable(name="s_txn_tester", builderNames=txnTesterBuilders),
+    schedulers.Triggerable(
+        name="s_txn_tester_soak", builderNames=txnTesterSoakBuilders
     ),
 ]

--- a/scripts/docker-library-build.sh
+++ b/scripts/docker-library-build.sh
@@ -179,5 +179,6 @@ for arch in "${arches[@]}"; do
   buildah manifest add "$image" "$image-$arch"
   if [ "$arch" = linux/amd64 ]; then
     buildah tag "${image}-${arch}" "${image}-wordpress"
+    buildah tag "${image}-${arch}" "${image}-txntester"
   fi
 done

--- a/utils.py
+++ b/utils.py
@@ -657,6 +657,10 @@ def isJepsenBranch(step: BuildStep) -> bool:
     return step.getProperty("branch").startswith("jpsn")
 
 
+def isTxnTesterBranch(step: BuildStep) -> bool:
+    return step.getProperty("branch").startswith("txn")
+
+
 @util.renderer
 def mtrEnv(props: IProperties) -> dict:
     """


### PR DESCRIPTION
## What

Integrates **txn-tester** — a single image bundling three DBMS transaction /
isolation bug-detection tools, all built from source — into the non-latent
master:

| Tool | Upstream |
|------|----------|
| TROC | `tcse-iscas/Troc` |
| Fucci | `Reverie4u/Fucci` |
| APTrans | `Paper-code-sigmod/APTrans` |

It is wired exactly like the WordPress eco-test (`f_wordpress`): the freshly
CI-built MariaDB docker-library image is run in a pod and the tools are pointed at
it over the pod-local loopback. The tools connect to MariaDB purely via
environment variables; this adds no MariaDB build of its own.

## How

- **`scripts/docker-library-build.sh`** — retain a `<image>-txntester` tag on the
  amd64 image (next to the existing `-wordpress` tag) so the factory has the
  CI-built MariaDB to run against.
- **`master-nonlatent/master.cfg`** — `getTxnTesterFactory()` creates a pod, runs
  the CI-built MariaDB, then runs the three tools sequentially via `podman` and
  uploads their artifacts. Two builders:
  - **light** (`amd64-rhelN-txntester`, ~6–7 min) — fast per-build signal;
  - **soak** (`amd64-rhelN-txntester-soak`, ~30 min) — deep coverage, opt-in.
- **`f_dockerlibrary`** triggers the light builder on every saved-package build,
  and the soak builder instead on `txn`-prefixed branches (`isTxnTesterBranch`),
  mirroring the `not`/`is`-branch split used for Jepsen.
- **`constants.py` / `schedulers_definition.py`** — `BUILDERS_TXN_TESTER[_SOAK]`
  and `s_txn_tester[_soak]`.

## Bug signalling

The upstream tools never exit non-zero on a finding (TROC/Fucci loop until killed
by `timeout` and only log a `BUG REPORT`; APTrans only writes a `check/` artifact
then exits 0). The image therefore maps a discovered inconsistency to the exotic
exit code **100**, and the steps use `decodeRC={0: SUCCESS, 100: FAILURE}` so a
found transaction anomaly turns the build red and is distinguishable from an
infrastructural failure (image pull / classpath / connection), which keep their
own non-zero codes.

## Image

Pulled from `ghcr.io/arcivanov/txn-tester:0.0.2` (`--pull=always`), pinned for
reproducibility. It lives in its own repo for now; if MariaDB adopts it, only the
image reference changes (optionally adding an in-tree `eco_build_images` build).

## Notes

- Validated with `./validate_master_cfg.sh -e DEV` — all master configs check out.
- Heads-up: in local/CI testing, TROC and Fucci both report inconsistencies
  against stock MariaDB within a short run, so these builders will go red fairly
  often. That is the intended finding→red→triage behaviour; whether the reports
  are true anomalies or tool noise is worth review before treating red/green as a
  clean pass/fail signal.