### PR TITLE
MDBF-1201: add --view tests to branch protection

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -1,5 +1,6 @@
 import os
 import re
+from typing import Union
 
 from twisted.internet import defer
 
@@ -572,9 +573,12 @@ def addS3Tests(factory, mtrDbPool):
     return factory
 
 
-def getQuickBuildFactory(test_type, mtrDbPool):
+def getQuickBuildFactory(test_type: Union[str, list[str]], mtrDbPool):
     f = getBuildFactoryPreTest()
-    addTests(f, test_type, mtrDbPool, util.Property("mtr_additional_args", default=""))
+    if isinstance(test_type, str):
+        test_type = [test_type]
+    for typ in test_type:
+        addTests(f, typ, mtrDbPool, util.Property("mtr_additional_args", default=""))
     addGaleraTests(f, mtrDbPool)
     addS3Tests(f, mtrDbPool)
     return addPostTests(f)

--- a/constants.py
+++ b/constants.py
@@ -267,7 +267,7 @@ TEST_TYPE_TO_MTR_ARG = {
     "debug-emb": "--embedded",
     "debug-emb-ps": "--embedded --ps-protocol",
     "debug-ps": "--ps-protocol",
-    "debug-view": "--view-protocol",
+    "debug-view": "--suite=main --view-protocol",
     "emb": "--embedded",
     "emb-ps": "--embedded --ps-protocol",
     "msan": "",

--- a/master-protected-branches/master.cfg
+++ b/master-protected-branches/master.cfg
@@ -457,7 +457,7 @@ c["builders"].append(
             "additional_args": "-DWITH_EMBEDDED_SERVER:BOOL=ON -DWITH_DBUG_TRACE=OFF",
             "mtr_additional_args": '--skip-test="main\.show_analyze_json"',
         },
-        factory=getQuickBuildFactory("debug-emb", mtrDbPool),
+        factory=getQuickBuildFactory(["debug-emb", "debug-view"], mtrDbPool),
     )
 )
 


### PR DESCRIPTION
Only known green mtr tests under --view-protocol, i.e. --suite=main.
MDEV-40142 should be fixed before adding deploying the changes to a protected branches builder.