### PR TITLE
MDBF-1223: Cancelled RelWithDebInfo builders trigger autobake builders

### DIFF
--- a/common_factories.py
+++ b/common_factories.py
@@ -119,7 +119,10 @@ def addPostTests(factory):
                 "mariadb_version": Property("mariadb_version"),
                 "master_branch": Property("master_branch"),
             },
-            doStepIf=hasAutobake,
+            doStepIf=(
+                lambda step: hasAutobake(step)
+                and step.build.results != results.CANCELLED
+            ),
         )
     )
     # create package and upload to master


### PR DESCRIPTION
This was a nice feature in the past, when playing whack-a-mole to stop
a build and immediately trigger one that will deliver packages on CI.

Now, with MDBF-1200, we may forget this childhood game, 
and allow the build canceler to stop older build requests without any side-effects (i.e. triggering other builds).

We still don't stop failed tests from triggering package builders, and it is ok; 
dev's should decide if the generated packages are worth a dime.
